### PR TITLE
chore: enforce CLAUDE.md conventions (#20–#23) — dp→tokens, Locale, comments, audit

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/MainActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/MainActivity.kt
@@ -70,8 +70,10 @@ class FabRegistry {
 
 class MainActivity : ComponentActivity() {
 
-    // The Scaffold padding is intentionally unused: content draws edge-to-edge and
-    // each screen folds the status-bar / nav insets into its own content padding.
+    /**
+     * The Scaffold padding is intentionally unused: content draws edge-to-edge and each screen
+     * folds the status-bar / nav insets into its own content padding.
+     */
     @Suppress("UnusedMaterial3ScaffoldPaddingParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -115,12 +117,8 @@ class MainActivity : ComponentActivity() {
                         }
                     },
                 ) { _ ->
-                    // Content draws edge-to-edge, under the status bar and the
-                    // transparent area around the floating nav pill. Each screen
-                    // folds the status-bar inset into its own top content padding
-                    // and carries bottom contentPadding for the nav pill. EdgeFades
-                    // overlays soft top/bottom scrims so content dissolves into the
-                    // background under the status bar and behind the nav pill.
+                    // Edge-to-edge: each screen folds the status-bar inset into its own top padding and
+                    // carries bottom padding for the nav pill; EdgeFades overlays soft top/bottom scrims.
                     Box(modifier = Modifier.fillMaxSize()) {
                     NavHost(
                         navController = navController,

--- a/app/src/main/java/fr/bsodium/cron/ai/tools/DoNothingTool.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/tools/DoNothingTool.kt
@@ -42,8 +42,7 @@ class DoNothingTool(
         val reason = input.jsonObject["reason"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
             ?: return ToolResult("""{"error":"reason is required"}""", isError = true)
 
-        // "No change" means keep the armed alarm. The alarm time lives only in currentInstruction,
-        // so carry it (and the wake window) forward — otherwise the home card blanks out.
+        // Keep the armed alarm: its time + window live only in currentInstruction, so carry them forward.
         val prior = repository.findById(sessionId)?.currentInstruction
         repository.updateInstruction(
             sessionId,

--- a/app/src/main/java/fr/bsodium/cron/receiver/EveningPlanReceiver.kt
+++ b/app/src/main/java/fr/bsodium/cron/receiver/EveningPlanReceiver.kt
@@ -31,8 +31,7 @@ class EveningPlanReceiver : BroadcastReceiver() {
             try {
                 // Re-arm for tomorrow before doing anything else.
                 EveningPlanScheduler(context).armNext()
-                // The exact-alarm broadcast is allowed to start a foreground service from the
-                // background; the service does the location capture + event itself.
+                // An exact-alarm broadcast may start a foreground service from the background.
                 val tz = TimeZone.currentSystemDefault().id
                 context.startForegroundService(SleepSessionService.eveningPlanIntent(context, tz))
                 Log.i(TAG, "Evening plan service started")

--- a/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
+++ b/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
@@ -62,8 +62,7 @@ class SleepSessionService : Service() {
             } catch (t: Throwable) {
                 Log.e(TAG, "FSM error on sensor event ${event.trigger}", t)
             }
-            // Keep ActivityRecognitionMonitor in sync with sleep state so it only
-            // emits MidSleepActivity events while the user is actually asleep.
+            // Keep ActivityRecognitionMonitor in sync with sleep state (emit only while asleep).
             when (event.trigger) {
                 TriggerType.SleepOnset        -> activityRecognitionMonitor?.onSleepOnset()
                 TriggerType.OutOfBedConfirmed -> activityRecognitionMonitor?.onWake()
@@ -87,9 +86,8 @@ class SleepSessionService : Service() {
         }
         val eveningPlan = intent?.action == ACTION_EVENING_PLAN
         ensureNotificationChannel()
-        // Run as a location-typed FGS for the evening plan so the in-service location fetch is
-        // "in use" (fresh + unthrottled) with only foreground permission. A sticky restart (null
-        // intent) resumes monitoring only — it must NOT re-fire the plan.
+        // Location-typed FGS so the in-service fetch counts as "in use" (fresh, unthrottled) on
+        // foreground permission alone. A sticky restart (null intent) resumes monitoring only — never re-fires the plan.
         startForegroundService(includeLocation = eveningPlan)
 
         if (screenStateMonitor == null) {

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -163,13 +163,13 @@ class SessionFsm(
             TriggerType.SleepOnset -> when (session.status) {
                 SessionStatus.Planning, SessionStatus.Monitoring -> SessionStatus.Monitoring
                 SessionStatus.Awake -> SessionStatus.ReMonitoring
-                else -> session.status
+                else -> session.status // already past monitoring: no change
             }
             TriggerType.OutOfBedConfirmed -> when (session.status) {
                 SessionStatus.Monitoring, SessionStatus.ReMonitoring -> SessionStatus.Awake
-                else -> session.status
+                else -> session.status // only Monitoring/ReMonitoring wake to Awake
             }
-            else -> session.status
+            else -> session.status // other triggers don't change status
         }
 
     private fun onStatusChange(session: SleepSession, newStatus: SessionStatus) {
@@ -184,7 +184,7 @@ class SessionFsm(
                 context.startService(SleepSessionService.stopIntent(context))
                 Log.i(TAG, "Session ${session.id} complete — alarms cleared, service stopped")
             }
-            else -> {}
+            else -> {} // Planning/Monitoring/ReMonitoring: no status-change side effect
         }
     }
 

--- a/app/src/main/java/fr/bsodium/cron/session/db/Json.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/db/Json.kt
@@ -11,7 +11,6 @@ val SessionJson: Json = Json {
     ignoreUnknownKeys = true
     encodeDefaults = true
     explicitNulls = false
-    // No global classDiscriminator — kotlinx default is "type", which matches the
-    // Anthropic wire format for ContentBlock. EventData overrides via
-    // @JsonClassDiscriminator("kind").
+    // No global classDiscriminator: kotlinx's default "type" matches the Anthropic ContentBlock
+    // wire format; EventData overrides it via @JsonClassDiscriminator("kind").
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/components/Atoms.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/Atoms.kt
@@ -17,7 +17,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import fr.bsodium.cron.ui.theme.Radius
+import fr.bsodium.cron.ui.theme.Spacing
 import java.util.Locale
+
+private val PILL_VPAD = 5.dp
+private val DOT_SIZE = 7.dp
 
 /**
  * Uppercase, tracked-out, muted label used as the only "header"
@@ -55,14 +59,14 @@ fun PillBadge(
         modifier = modifier,
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 5.dp),
+            modifier = Modifier.padding(horizontal = Spacing.md, vertical = PILL_VPAD),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xs + Spacing.xxs),
         ) {
             if (leadingDot != null) {
                 Box(
                     modifier = Modifier
-                        .size(7.dp)
+                        .size(DOT_SIZE)
                         .background(leadingDot, CircleShape),
                 )
             }

--- a/app/src/main/java/fr/bsodium/cron/ui/components/CronBottomBar.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/CronBottomBar.kt
@@ -106,7 +106,7 @@ private fun FabSlot(fabAction: FabAction?) {
     Box(
         modifier = Modifier
             .width(width)
-            .height(56.dp),
+            .height(FAB_SLOT_HEIGHT),
         contentAlignment = Alignment.CenterEnd,
     ) {
         AnimatedVisibility(
@@ -120,6 +120,8 @@ private fun FabSlot(fabAction: FabAction?) {
 }
 
 private val FAB_SLOT_WIDTH = 68.dp // 56dp FAB + 12dp leading gap
+private val FAB_SLOT_HEIGHT = 56.dp
+private val NAV_SLOT_SIZE = 48.dp
 private val FAB_SLOT_SPEC = tween<Dp>(durationMillis = 200, easing = FastOutSlowInEasing)
 // A pronounced grow-from-centre + fade so the FAB pops rather than slides in.
 private val FAB_ENTER =
@@ -147,7 +149,7 @@ private fun NavPill(
         shadowElevation = 0.dp,
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 6.dp, vertical = 6.dp),
+            modifier = Modifier.padding(horizontal = Spacing.xs + Spacing.xxs, vertical = Spacing.xs + Spacing.xxs),
             horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -168,8 +170,7 @@ private fun RowScope.NavSlot(
     onNavigate: (String) -> Unit,
 ) {
     val selected = currentRoute == route
-    // Selected tab: a filled circular indicator in the dynamic accent (primary) with an onPrimary
-    // icon, matching the FAB. Unselected tabs are low-emphasis outlined icons directly on the pill.
+    // Selected: filled accent indicator (matches the FAB); unselected: outlined icon on the pill.
     val targetContainer = if (selected) MaterialTheme.colorScheme.primary else Color.Transparent
     val targetTint = if (selected) MaterialTheme.colorScheme.onPrimary
         else MaterialTheme.colorScheme.onSurfaceVariant
@@ -180,7 +181,7 @@ private fun RowScope.NavSlot(
         modifier = Modifier
             // Square slot so the circular indicator nests with an equal margin on every side
             // (x and y) inside the pill, rather than wider side gaps.
-            .size(48.dp)
+            .size(NAV_SLOT_SIZE)
             // Clip BEFORE clickable so the ripple respects the slot shape.
             .clip(Radius.full)
             .clickable(enabled = !selected) {
@@ -243,6 +244,8 @@ private fun PrimaryActionFab(action: FabAction?) {
 // The play FAB's horizontal distance right of screen centre, derived from the centred nav row
 // (pill 164dp + 68dp FAB slot, FAB at the slot's far end). Device-width independent.
 private val FAB_CENTER_OFFSET = 88.dp
+private val POINTER_WIDTH = 16.dp
+private val POINTER_HEIGHT = 8.dp
 
 // Downward-pointing triangle for the onboarding callout's tail.
 private val PointerDown = GenericShape { size, _ ->
@@ -279,7 +282,7 @@ fun BoxScope.OnboardingTooltip(navBottom: Dp, text: String, modifier: Modifier =
         }
         Box(
             modifier = Modifier
-                .size(width = 16.dp, height = 8.dp)
+                .size(width = POINTER_WIDTH, height = POINTER_HEIGHT)
                 .background(MaterialTheme.colorScheme.primary, PointerDown),
         )
     }

--- a/app/src/main/java/fr/bsodium/cron/ui/components/PermissionGate.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/PermissionGate.kt
@@ -33,6 +33,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import fr.bsodium.cron.ui.theme.Spacing
+
+private val GATE_ICON_SIZE = 64.dp
 
 /**
  * Gates the main content behind required permissions.
@@ -81,18 +84,18 @@ fun PermissionGate(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(32.dp),
+            .padding(Spacing.xxxl),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Icon(
             imageVector = Icons.Outlined.CalendarMonth,
             contentDescription = null,
-            modifier = Modifier.size(64.dp),
+            modifier = Modifier.size(GATE_ICON_SIZE),
             tint = MaterialTheme.colorScheme.primary
         )
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(Spacing.xxl))
 
         Text(
             text = "Calendar access needed",
@@ -100,7 +103,7 @@ fun PermissionGate(
             textAlign = TextAlign.Center
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(Spacing.md))
 
         Text(
             text = "Cron needs to read your calendar to automatically schedule wake-up alarms before your first event each day.",
@@ -109,17 +112,17 @@ fun PermissionGate(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
 
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(Spacing.xxxl))
 
         if (!hasRequestedOnce) {
             Button(
                 onClick = {
-                    val permissions = mutableListOf(
-                        Manifest.permission.READ_CALENDAR,
-                        Manifest.permission.ACCESS_COARSE_LOCATION
-                    )
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        permissions.add(Manifest.permission.POST_NOTIFICATIONS)
+                    val permissions = buildList {
+                        add(Manifest.permission.READ_CALENDAR)
+                        add(Manifest.permission.ACCESS_COARSE_LOCATION)
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            add(Manifest.permission.POST_NOTIFICATIONS)
+                        }
                     }
                     permissionLauncher.launch(permissions.toTypedArray())
                 }
@@ -135,7 +138,7 @@ fun PermissionGate(
                 color = MaterialTheme.colorScheme.error
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(Spacing.lg))
 
             OutlinedButton(
                 onClick = {

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/alarm/AlarmActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/alarm/AlarmActivity.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -50,10 +49,17 @@ import androidx.compose.ui.unit.sp
 import fr.bsodium.cron.receiver.AlarmReceiver
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.ExpressiveFontFamily
+import fr.bsodium.cron.ui.theme.Radius
+import fr.bsodium.cron.ui.theme.Spacing
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.time.LocalTime
+import java.util.Locale
 import kotlin.math.roundToInt
+
+private val THUMB_SIZE = 52.dp
+private val THUMB_INSET = 6.dp
+private val TRACK_HEIGHT = 64.dp
 
 class AlarmActivity : ComponentActivity() {
 
@@ -120,7 +126,7 @@ private fun AlarmScreen(
     LaunchedEffect(Unit) {
         while (true) {
             val t = LocalTime.now()
-            timeText = "%02d:%02d".format(t.hour, t.minute)
+            timeText = String.format(Locale.US, "%02d:%02d", t.hour, t.minute)
             delay(1_000)
         }
     }
@@ -133,7 +139,7 @@ private fun AlarmScreen(
         Column(
             modifier = Modifier.align(Alignment.Center),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(Spacing.sm),
         ) {
             Text(
                 text = timeText,
@@ -145,7 +151,7 @@ private fun AlarmScreen(
                     fontFeatureSettings = "tnum",
                 ),
             )
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(Spacing.xs))
             Text(
                 text = label,
                 style = MaterialTheme.typography.titleMedium,
@@ -156,8 +162,8 @@ private fun AlarmScreen(
         Column(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .padding(horizontal = 32.dp, vertical = 48.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+                .padding(horizontal = Spacing.xxxl, vertical = Spacing.xxxl + Spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(Spacing.lg),
         ) {
             SlideToActTrack(
                 label = "Slide to snooze",
@@ -184,8 +190,8 @@ private fun SlideToActTrack(
     modifier: Modifier = Modifier,
 ) {
     val density = LocalDensity.current
-    val thumbSizePx = with(density) { 52.dp.toPx() }
-    val insetPx = with(density) { 6.dp.toPx() }
+    val thumbSizePx = with(density) { THUMB_SIZE.toPx() }
+    val insetPx = with(density) { THUMB_INSET.toPx() }
 
     var trackWidthPx by remember { mutableStateOf(0f) }
     val maxOffset = (trackWidthPx - thumbSizePx - 2 * insetPx).coerceAtLeast(0f)
@@ -202,8 +208,8 @@ private fun SlideToActTrack(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(64.dp)
-            .background(onPrimary.copy(alpha = 0.15f), RoundedCornerShape(50))
+            .height(TRACK_HEIGHT)
+            .background(onPrimary.copy(alpha = 0.15f), Radius.full)
             .onSizeChanged { trackWidthPx = it.width.toFloat() },
     ) {
         Text(
@@ -217,7 +223,7 @@ private fun SlideToActTrack(
             modifier = Modifier
                 .align(Alignment.CenterStart)
                 .offset { IntOffset((insetPx + thumbAnim.value).roundToInt(), 0) }
-                .size(52.dp)
+                .size(THUMB_SIZE)
                 .background(thumbColor, CircleShape)
                 .draggable(
                     orientation = Orientation.Horizontal,

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -86,8 +87,7 @@ fun HomeScreen(viewModel: HomeViewModel, fabRegistry: FabRegistry) {
         fabRegistry.set(FabAction(onClick = viewModel::retryAiPlan, onCancel = viewModel::cancelAiPlan))
         onDispose { fabRegistry.clear() }
     }
-    // Show the onboarding callout (rendered above EdgeFades in MainActivity) only in the loaded,
-    // no-plan, idle state — it hides the moment the user taps the FAB.
+    // Onboarding callout (rendered above EdgeFades in MainActivity): only in the loaded, no-plan, idle state.
     val showOnboardingHint = uiState.initialized && uiState.aiThread == null && !uiState.isRetrying
     LaunchedEffect(uiState.isRetrying, showOnboardingHint, fabRegistry) {
         fabRegistry.set(
@@ -141,10 +141,8 @@ fun HomeScreen(viewModel: HomeViewModel, fabRegistry: FabRegistry) {
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (uiState.aiThread == null) {
-            // First-run / no-plan OR still loading: a simple Column so the onboarding centres in
-            // the empty space between the alarm card and the nav bar. The hint + arrow only render
-            // once `initialized` is true, so they never flash over an existing plan on cold start.
-            // The play FAB is the call to action.
+            // First-run / no-plan / loading: a simple centred Column. The hint + arrow render only
+            // once `initialized`, so they never flash over an existing plan on cold start.
             val showOnboarding = uiState.initialized
             Column(
                 modifier = Modifier
@@ -175,13 +173,12 @@ fun HomeScreen(viewModel: HomeViewModel, fabRegistry: FabRegistry) {
             // The onboarding callout that points at the play FAB is rendered in MainActivity,
             // layered above EdgeFades (via FabAction.hint) so the bottom scrim doesn't fade it.
         } else {
-            // The alarm card behaves like CSS `position: sticky; top: statusBar + gap`: the list
-            // scrolls edge-to-edge under the status bar while the card flows then sticks just below
-            // it. It's an overlay, not a stickyHeader (which pins at y=0 and can't take a top
-            // offset without a rest gap or pin jump); an "alarm-spacer" holds its place in flow.
+            // The alarm card acts like CSS `position: sticky` (top = statusBar + gap): the list scrolls
+            // under the status bar while the card sticks just below it. It's an overlay, not a
+            // stickyHeader (which pins at y=0 and can't take a top offset); an "alarm-spacer" holds its flow slot.
             val listState = rememberLazyListState()
             val density = LocalDensity.current
-            var cardHeightPx by remember { mutableStateOf(0) }
+            var cardHeightPx by remember { mutableIntStateOf(0) }
             LazyColumn(
                 state = listState,
                 modifier = Modifier.fillMaxSize(),
@@ -302,9 +299,8 @@ private fun BoxScope.StickyAlarm(
     val state by remember(safeTopPx, fadePx) {
         derivedStateOf {
             val info = listState.layoutInfo
-            // Item offsets are content-relative; the on-screen top = offset - viewportStartOffset
-            // (viewportStartOffset is -beforeContentPadding). Null when the spacer has scrolled
-            // off the top → fully stuck (handled explicitly to avoid sentinel-int overflow).
+            // On-screen top = item offset − viewportStartOffset (= −beforeContentPadding). Null once
+            // the spacer scrolls off the top → fully stuck (handled explicitly to avoid int overflow).
             val screenTop = info.visibleItemsInfo.firstOrNull { it.key == "alarm-spacer" }
                 ?.let { it.offset - info.viewportStartOffset }
             if (screenTop == null) {
@@ -318,9 +314,7 @@ private fun BoxScope.StickyAlarm(
         }
     }
     val background = MaterialTheme.colorScheme.background
-    // Solid background-colour from the top all the way down to the card's bottom, then a soft
-    // fade to transparent just below it — so nothing is visible above/behind the pinned card and
-    // content dissolves as it slides out the bottom.
+    // Solid bg down to the card bottom, then a short fade below so content dissolves as it scrolls under.
     val cardBottomPx = safeTopPx + cardHeightPx
     val belowFadePx = with(density) { Spacing.xxxl.toPx() }
     val totalPx = cardBottomPx + belowFadePx

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
@@ -177,9 +177,8 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
      * scheduling concerns owned by the receiver, not a manual user trigger.)
      */
     init {
-        // Drive the "working" flag off the real WorkManager turn rather than a fixed delay:
-        // a tap optimistically sets it true; this clears it once the turn reaches a terminal
-        // state (succeeded / failed / cancelled).
+        // Drive the "working" flag off the real WorkManager turn, not a fixed delay: a tap sets it
+        // true optimistically; this clears it when the turn reaches a terminal state.
         viewModelScope.launch {
             sessionFlow.map { it?.id }.distinctUntilChanged()
                 .flatMapLatest { id ->
@@ -197,11 +196,9 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     fun retryAiPlan() {
         _isRetrying.value = true
         viewModelScope.launch(Dispatchers.IO) {
-            // Nudge a calendar sync up front so a freshly-added event reaches the provider by read
-            // time; the location fetch + AI round-trip below give it time to land.
+            // Nudge a calendar sync up front; the location fetch + AI round-trip below give it time to land.
             requestCalendarSync()
-            // A manual replan always captures a FRESH foreground fix — the user may have moved since
-            // the session was created, and reusing the stored origin would replan from the wrong place.
+            // Manual replan captures a FRESH foreground fix — the user may have moved since the session began.
             val tz = TimeZone.currentSystemDefault()
             val location = locationProvider.acquireForEveningPlan()
             val event = SessionEvent(
@@ -303,9 +300,8 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             .filterIsInstance<ContentBlock.ToolResult>()
             .associateBy { it.tool_use_id }
 
-        // Model-authored pill labels: the prompt asks for "STATUS: <gerund>" lines while
-        // working and a leading "SUMMARY: <past tense>" on the answer. Pull them out of the
-        // text in order and strip them so they never render in the timeline or response.
+        // Model-authored pill labels: "STATUS: <gerund>" while working, leading "SUMMARY: <past>" on
+        // the answer. Pull them out in order and strip them so they never render.
         val statuses = mutableListOf<String>()
         var summaryLine: String? = null
         fun stripDirectives(text: String): String {
@@ -323,10 +319,8 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             return kept.toString().trim()
         }
 
-        // The final answer is the trailing run of Text blocks — those after the
-        // last non-text block (a tool call or reasoning). Text emitted before or
-        // between tool calls is narration that belongs to the thinking process,
-        // not the output, so collapsing the disclosure hides it.
+        // The answer is the trailing run of Text blocks (after the last tool/reasoning block); text
+        // emitted earlier is thinking-process narration, not output.
         val answerStart = blocks.indexOfLast { it !is ContentBlock.Text } + 1
 
         val process = blocks.take(answerStart).mapNotNull { block ->
@@ -357,9 +351,8 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             .let(::stripLeadingRule)
             .takeIf { it.isNotBlank() }
 
-        // A no-op turn (do_nothing) ends with no trailing text, so the answer would be blank.
-        // Fall back to the model's SUMMARY line, then the do_nothing reason, so the card still
-        // explains the decision instead of sitting empty.
+        // A do_nothing turn ends with no trailing text; fall back to the SUMMARY line, then the
+        // do_nothing reason, so the card still explains the decision.
         val doNothingReason = blocks
             .filterIsInstance<ContentBlock.ToolUse>()
             .firstOrNull { it.name == "do_nothing" }
@@ -371,8 +364,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             ?.takeIf { it.isNotBlank() }
         val answer = response ?: summaryLine ?: doNothingReason
 
-        // Wall-clock span of the latest turn; shown once the turn settles (driven by the
-        // WorkManager signal in the UI, not by whether an answer exists).
+        // Wall-clock span of the latest turn; shown once the turn settles (UI drives this off WorkManager).
         val turnRows = rows.filter { it.turnIndex == latestTurn }
         val durationSeconds = if (turnRows.isNotEmpty()) {
             ((turnRows.maxOf { it.createdAt } - turnRows.minOf { it.createdAt }) / 1000).toInt()
@@ -380,8 +372,8 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             null
         }
 
-        // Pill preview: the model's gerund while working, its past-tense summary once an answer
-        // exists. Fall back to the first line of reasoning if the model skipped the directives.
+        // Pill preview: gerund while working, past-tense summary once answered; falls back to the
+        // first reasoning line if the model skipped the directives.
         val fallback = process
             .firstNotNullOfOrNull { (it as? ProcessItem.Reasoning)?.text ?: (it as? ProcessItem.Narration)?.text }
             ?.lineSequence()

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -113,8 +114,7 @@ import fr.bsodium.cron.ui.theme.Spacing
 @Composable
 fun AiThinkingThread(thread: AiThreadUi, isRunning: Boolean, modifier: Modifier = Modifier) {
     Column(modifier = modifier.fillMaxWidth()) {
-        // The turn's settled/running state is the real WorkManager signal, not whether a text
-        // response exists — a do_nothing turn finishes with no response and must still settle.
+        // Settled/running is the WorkManager signal, not response presence — a do_nothing turn settles with none.
         val inProgress = isRunning
         if (thread.process.isNotEmpty() || inProgress) {
             ThinkingDisclosure(
@@ -135,13 +135,13 @@ private val GUTTER_WIDTH = 28.dp
 private val TIMELINE_RULE_WIDTH = 2.dp
 private val STEP_ICON_SIZE = 16.dp
 private val ICON_MASK_SIZE = 24.dp
-// Vertical padding around each row's content. Doubles as the gap between steps —
-// kept at sm so a clear segment of the timeline rule shows between icon discs.
+private val SPINNER_SIZE = 14.dp
+private val SPINNER_STROKE = 1.5.dp
+private val ROW_MIN_HEIGHT = 48.dp
+/** Row content padding; doubles as the inter-step gap (sm keeps the timeline rule visible between discs). */
 private val TIMELINE_CONTENT_VPAD = Spacing.sm
 
-// Centre the glyph within its line box (the default trims the first line's top leading and
-// seats the glyph high), so the first line's optical centre lands at lineHeight/2 — where the
-// gutter icon disc is positioned.
+/** Centre the glyph in its line box so the first line's optical centre lands at lineHeight/2 (where the gutter disc sits). */
 private val STEP_LINE_HEIGHT = LineHeightStyle(
     alignment = LineHeightStyle.Alignment.Center,
     trim = LineHeightStyle.Trim.None,
@@ -174,18 +174,15 @@ private fun ThinkingDisclosure(
 ) {
     var expanded by rememberSaveable { mutableStateOf(initiallyExpanded) }
     val canExpand = process.isNotEmpty()
-    // Full-bleed square bar: transparent when collapsed, a quiet fill when open (a step below
-    // the alarm card so it stays secondary to it). It bleeds past the screen-side content
-    // padding (Spacing.xl) to hug both edges; the compensating start/end padding keeps the
-    // summary text on the content edge (flush with the response) and the chevron in place.
-    // Only the timeline stays indented.
+    // Full-bleed bar: transparent collapsed, a quiet fill when open. It bleeds past the side content
+    // padding (Spacing.xl) to hug both edges; compensating start/end padding keeps the summary text and chevron in place.
     Row(
         modifier = Modifier
             .bleedHorizontally(Spacing.xl)
             .fillMaxWidth()
             .let { if (canExpand) it.clickable { expanded = !expanded } else it }
             .background(if (expanded) MaterialTheme.colorScheme.surfaceContainerLow else Color.Transparent)
-            .heightIn(min = 48.dp)
+            .heightIn(min = ROW_MIN_HEIGHT)
             .padding(start = Spacing.xl, top = Spacing.sm, end = Spacing.md + Spacing.xl, bottom = Spacing.sm),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
@@ -201,8 +198,8 @@ private fun ThinkingDisclosure(
                 modifier = Modifier.weight(1f),
             )
             CircularProgressIndicator(
-                modifier = Modifier.size(14.dp),
-                strokeWidth = 1.5.dp,
+                modifier = Modifier.size(SPINNER_SIZE),
+                strokeWidth = SPINNER_STROKE,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         } else {
@@ -330,9 +327,8 @@ private fun ProcessTextRow(text: String, isFirst: Boolean, isLast: Boolean) {
                 // the touch target at 48dp while the visible pill stays compact.
                 Box(
                     modifier = Modifier
-                        // No start padding so the label's left edge sits on the reasoning-text
-                        // column; end padding keeps the ripple a pill. The 48dp touch target is
-                        // preserved by minimumInteractiveComponentSize.
+                        // No start padding so the label aligns with the reasoning-text column; the
+                        // 48dp touch target is preserved by minimumInteractiveComponentSize.
                         .minimumInteractiveComponentSize()
                         .clip(Radius.full)
                         .clickable { expanded = !expanded }
@@ -392,7 +388,7 @@ private fun ClippedReveal(
     content: @Composable () -> Unit,
 ) {
     val collapsedPx = with(LocalDensity.current) { collapsedHeight.roundToPx() }
-    var fullPx by remember { mutableStateOf(0) }
+    var fullPx by remember { mutableIntStateOf(0) }
     val target = if (expanded) fullPx else minOf(collapsedPx, fullPx)
     val animatedPx by animateIntAsState(target, REASONING_HEIGHT_SPEC, label = "reasoning-reveal")
     val fading = fullPx > 0 && animatedPx < fullPx
@@ -444,8 +440,7 @@ private fun TimelineRow(
     // Low-emphasis connector tone with enough contrast for a 2dp line against the page.
     val ruleColor = MaterialTheme.colorScheme.surfaceContainerHigh
     val maskColor = MaterialTheme.colorScheme.background
-    // Centre the icon disc on the content's FIRST line (not the whole row, which
-    // drifts to the middle of multi-line reasoning): disc centre =
+    // Centre the disc on the content's FIRST line (not the whole multi-line row): disc centre =
     // contentTopPad + firstLine/2, so its top inset is that minus half the disc.
     val discTop = (TIMELINE_CONTENT_VPAD + (firstLineHeight - ICON_MASK_SIZE) / 2)
         .coerceAtLeast(0.dp)
@@ -557,8 +552,8 @@ private fun ToolStepRow(step: ProcessItem.Tool, isFirst: Boolean, isLast: Boolea
             Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.CenterEnd) {
                 when {
                     !step.isComplete -> CircularProgressIndicator(
-                        modifier = Modifier.size(14.dp),
-                        strokeWidth = 1.5.dp,
+                        modifier = Modifier.size(SPINNER_SIZE),
+                        strokeWidth = SPINNER_STROKE,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     step.isError -> Icon(
@@ -673,10 +668,8 @@ private fun MarkdownBlock(
         content = text,
         colors = colors,
         typography = typography,
-        // The library drops a uniform `block` spacer after every block, so keep it
-        // at the tight floor gap and let paragraphs/headers own their own rhythm:
-        // paragraphs add a bottom gap; headers add a roomy break above and a
-        // below-gap that shrinks with level so deep headers hug the text they head.
+        // The library adds a uniform `block` spacer after every block; keep it at the tight floor
+        // and let paragraphs/headers own their rhythm (headers get a roomy break above).
         padding = markdownPadding(
             block = MD_BLOCK_GAP,
             listItemTop = Spacing.xs,
@@ -764,9 +757,8 @@ private fun CronMarkdownTable(model: MarkdownComponentModel, cellStyle: TextStyl
     val measurer = rememberTextMeasurer()
     val density = LocalDensity.current
     val numCols = rows.maxOf { it.size }
-    // Weight columns by measured content width, but clamp into a band so a long-sentence
-    // column can't dominate (squeezing its neighbours to per-character wrapping) and a short
-    // one can't collapse.
+    // Weight columns by measured width, clamped into a band so a long column can't dominate
+    // (squeezing neighbours to per-character wrapping) and a short one can't collapse.
     val minColPx = with(density) { TABLE_COL_MIN.toPx() }
     val maxColPx = with(density) { TABLE_COL_MAX.toPx() }
     val colWeights = remember(rows, headerStyle, minColPx, maxColPx) {

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
@@ -151,9 +151,8 @@ private fun LcdTimeDisplay(alarmTime: LocalTime?, modifier: Modifier = Modifier)
         }
     }
     val pending = alarmTime == null
-    // Roll the digits up from 0 with an easeOut only when the alarm VALUE changes (incl. the first
-    // time it appears). The animated value is rememberSaveable (minutes-of-day), so re-opening the app
-    // or switching tabs with an unchanged value shows the digits at rest instead of re-rolling.
+    // Roll digits up from 0 (easeOut) only when the alarm VALUE changes. The animated key is
+    // rememberSaveable, so reopening or switching tabs with an unchanged value shows digits at rest.
     val valueKey = alarmTime?.let { it.hour * 60 + it.minute }
     var animatedKey by rememberSaveable { mutableStateOf<Int?>(null) }
     val progressAnim = remember { Animatable(if (valueKey == null || valueKey == animatedKey) 1f else 0f) }
@@ -175,8 +174,7 @@ private fun LcdTimeDisplay(alarmTime: LocalTime?, modifier: Modifier = Modifier)
         else String.format(Locale.US, "%02d", (alarmTime.minute * progress).roundToInt())
     val base = MaterialTheme.colorScheme.onSurface
     val digitColor = if (pending) base.copy(alpha = 0.22f) else base
-    // Match the dimmed-digit alpha when pending so the "00H/00M" placeholder reads as a deliberate
-    // grayed twin of the "00:00" digits; a touch brighter than the digits once a real time shows.
+    // Pending: match the dimmed-digit alpha so "00H/00M" reads as a deliberate grayed twin; brighter once a real time shows.
     val countdownColor = if (pending) base.copy(alpha = 0.22f) else base.copy(alpha = 0.6f)
 
     val lcdStyle = TightTextStyle.copy(
@@ -201,7 +199,7 @@ private fun LcdTimeDisplay(alarmTime: LocalTime?, modifier: Modifier = Modifier)
             countdown = countdown,
             progress = progress,
             color = countdownColor,
-            modifier = Modifier.padding(start = 6.dp, top = 6.dp),
+            modifier = Modifier.padding(start = Spacing.xs + Spacing.xxs, top = Spacing.xs + Spacing.xxs),
         )
     }
 }
@@ -221,8 +219,7 @@ private fun CountdownStack(
     color: Color,
     modifier: Modifier = Modifier,
 ) {
-    // Space Grotesk (the date-label face) — geometric and legible, pairs with the LCD digits
-    // without Major Mono Display's hard-to-read art-deco H/M.
+    // Space Grotesk pairs with the LCD digits — legible, unlike Major Mono Display's art-deco H/M.
     val smallLcd = TightTextStyle.copy(
         fontFamily = DisplayFontFamily,
         fontSize = 24.sp,
@@ -253,10 +250,15 @@ private fun computeCountdown(alarmTime: LocalTime?): HoursMinutes? {
     return HoursMinutes(hours = totalMinutes / 60, minutes = totalMinutes % 60)
 }
 
+private val COLON_WIDTH = 8.dp
+private val COLON_HEIGHT = 56.dp
+private val TIMELINE_HEIGHT = 82.dp
+private val TICK_BAR_HEIGHT = 20.dp
+
 /** Two small filled dots stacked vertically — replaces the chunky Major Mono colon. */
 @Composable
 private fun ColonSeparator(color: Color, modifier: Modifier = Modifier) {
-    Canvas(modifier = modifier.size(width = 8.dp, height = 56.dp)) {
+    Canvas(modifier = modifier.size(width = COLON_WIDTH, height = COLON_HEIGHT)) {
         drawColonDot(color, yFraction = 0.35f)
         drawColonDot(color, yFraction = 0.65f)
     }
@@ -339,22 +341,21 @@ private fun SleepTimeline(
         shape = RoundedCornerShape(Radius.lg),
         modifier = modifier
             .fillMaxWidth()
-            .height(82.dp),
+            .height(TIMELINE_HEIGHT),
     ) {
         val tStart = segments.first().start
         val tEnd = segments.last().end
         val totalSpanMs = (tEnd - tStart).inWholeMilliseconds.coerceAtLeast(1)
         val tz = TimeZone.currentSystemDefault()
 
-        // Pick two anchor segments for the labels — longest two by duration,
-        // sorted chronologically so the left label is earlier than the right.
+        // Two anchor segments for labels: the longest two by duration, sorted chronologically (left earlier).
         val labelled = segments
             .sortedByDescending { (it.end - it.start).inWholeMilliseconds }
             .take(2)
             .sortedBy { it.start }
             .ifEmpty { listOf(segments.first()) }
 
-        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)) {
+        Column(modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm + Spacing.xxs)) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = if (labelled.size == 1) Arrangement.Start else Arrangement.SpaceBetween,
@@ -373,7 +374,7 @@ private fun SleepTimeline(
             Canvas(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(20.dp),
+                    .height(TICK_BAR_HEIGHT),
             ) {
                 val w = size.width
                 val h = size.height

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/onboarding/OnboardingScreen.kt
@@ -39,6 +39,10 @@ import androidx.compose.ui.unit.dp
 import androidx.health.connect.client.PermissionController
 import fr.bsodium.cron.permissions.SystemPermissions
 import fr.bsodium.cron.sensors.healthconnect.SleepStageReader
+import fr.bsodium.cron.ui.theme.Spacing
+
+private val WELCOME_ICON_SIZE = 72.dp
+private val DONE_ICON_SIZE = 64.dp
 
 @Composable
 fun OnboardingScreen(
@@ -55,16 +59,16 @@ fun OnboardingScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .padding(horizontal = 32.dp),
+                .padding(horizontal = Spacing.xxxl),
         ) {
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(Spacing.lg))
 
             if (state.step != OnboardingStep.Done) {
                 LinearProgressIndicator(
                     progress = { stepIndex.toFloat() / totalSteps },
                     modifier = Modifier.fillMaxWidth(),
                 )
-                Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = Modifier.height(Spacing.xxxl))
             }
 
             when (state.step) {
@@ -101,23 +105,23 @@ private fun WelcomeStep(onNext: () -> Unit) {
         Icon(
             imageVector = Icons.Outlined.Alarm,
             contentDescription = null,
-            modifier = Modifier.size(72.dp),
+            modifier = Modifier.size(WELCOME_ICON_SIZE),
             tint = MaterialTheme.colorScheme.primary,
         )
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(Spacing.xxl))
         Text(
             text = "Meet Cron",
             style = MaterialTheme.typography.headlineLarge,
             textAlign = TextAlign.Center,
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(Spacing.lg))
         Text(
             text = "Cron watches your calendar and sleep patterns overnight, then wakes you at the ideal moment before your first appointment — automatically planned by Claude.",
             style = MaterialTheme.typography.bodyLarge,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Spacer(modifier = Modifier.height(40.dp))
+        Spacer(modifier = Modifier.height(Spacing.xxxl + Spacing.sm))
         Button(onClick = onNext, modifier = Modifier.fillMaxWidth()) {
             Text("Get started")
         }
@@ -134,13 +138,13 @@ private fun NameStep(
         verticalArrangement = Arrangement.Center,
     ) {
         Text("What should Cron call you?", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(Spacing.md))
         Text(
             text = "Your name appears in the morning greeting. Stored on this device only.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(Spacing.xxl))
 
         OutlinedTextField(
             value = state.displayNameInput,
@@ -151,7 +155,7 @@ private fun NameStep(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(Spacing.lg))
         Button(
             onClick = viewModel::saveDisplayName,
             enabled = state.displayNameInput.isNotBlank(),
@@ -172,13 +176,13 @@ private fun ApiKeyStep(
         verticalArrangement = Arrangement.Center,
     ) {
         Text("Anthropic API key", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(Spacing.md))
         Text(
             text = "Cron uses Claude to plan your alarm. Paste your API key below — it's stored encrypted on this device and never leaves it.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(Spacing.xxl))
 
         OutlinedTextField(
             value = state.apiKeyInput,
@@ -192,7 +196,7 @@ private fun ApiKeyStep(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(Spacing.lg))
         Button(
             onClick = viewModel::saveApiKey,
             enabled = state.apiKeyInput.isNotBlank(),
@@ -230,7 +234,7 @@ private fun PermissionsStep(
         verticalArrangement = Arrangement.Center,
     ) {
         Text("Permissions", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(Spacing.md))
         Text(
             text = "Cron needs the following to work:\n\n" +
                 "• Calendar — to read tomorrow's appointments\n" +
@@ -240,14 +244,14 @@ private fun PermissionsStep(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(Spacing.xxl))
         Button(
             onClick = { launcher.launch(permissions.toTypedArray()) },
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Grant permissions")
         }
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(Spacing.sm))
         TextButton(onClick = onSkip, modifier = Modifier.fillMaxWidth()) {
             Text("Skip for now")
         }
@@ -278,14 +282,14 @@ private fun ReliabilityStep(onContinue: () -> Unit) {
         verticalArrangement = Arrangement.Center,
     ) {
         Text("Reliable overnight", style = MaterialTheme.typography.headlineSmall)
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(Spacing.md))
         Text(
             text = "These let Cron refresh your location and run the plan while you sleep — without " +
                 "opening the app. All optional, and you can change them later in Settings.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(Spacing.xxl))
 
         ReliabilityButton(
             title = if (bgLocationGranted) "Background location enabled" else "Allow location all the time",
@@ -294,7 +298,7 @@ private fun ReliabilityStep(onContinue: () -> Unit) {
             enabled = SystemPermissions.hasForegroundLocation(context),
             onClick = { bgLocationLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION) },
         )
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(Spacing.md))
         ReliabilityButton(
             title = if (batteryExempt) "Battery optimization off" else "Ignore battery optimization",
             subtitle = "Stops the system from killing the overnight tracker.",
@@ -302,7 +306,7 @@ private fun ReliabilityStep(onContinue: () -> Unit) {
             enabled = true,
             onClick = { batteryLauncher.launch(SystemPermissions.batteryOptimizationIntent(context)) },
         )
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(Spacing.md))
         ReliabilityButton(
             title = if (hcConnected) "Sleep data connected" else "Connect sleep data",
             subtitle = "Use wearable sleep stages (Health Connect) for smarter wake timing.",
@@ -311,7 +315,7 @@ private fun ReliabilityStep(onContinue: () -> Unit) {
             onClick = { hcLauncher.launch(reader.requiredPermissions) },
         )
 
-        Spacer(modifier = Modifier.height(28.dp))
+        Spacer(modifier = Modifier.height(Spacing.xxl + Spacing.xs))
         Button(onClick = onContinue, modifier = Modifier.fillMaxWidth()) {
             Text("Continue")
         }
@@ -340,7 +344,7 @@ private fun ReliabilityButton(
             )
         }
         if (done) {
-            Spacer(modifier = Modifier.size(8.dp))
+            Spacer(modifier = Modifier.size(Spacing.sm))
             Icon(
                 imageVector = Icons.Outlined.Check,
                 contentDescription = null,
@@ -360,23 +364,23 @@ private fun DoneStep(onFinish: () -> Unit) {
         Icon(
             imageVector = Icons.Outlined.Alarm,
             contentDescription = null,
-            modifier = Modifier.size(64.dp),
+            modifier = Modifier.size(DONE_ICON_SIZE),
             tint = MaterialTheme.colorScheme.primary,
         )
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(Spacing.xxl))
         Text(
             text = "You're all set",
             style = MaterialTheme.typography.headlineMedium,
             textAlign = TextAlign.Center,
         )
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(Spacing.md))
         Text(
             text = "Cron will plan your first alarm tonight. You'll see the session status on the home screen.",
             style = MaterialTheme.typography.bodyLarge,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Spacer(modifier = Modifier.height(40.dp))
+        Spacer(modifier = Modifier.height(Spacing.xxxl + Spacing.sm))
         Button(onClick = onFinish, modifier = Modifier.fillMaxWidth()) {
             Text("Go to home")
         }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsScreen.kt
@@ -47,7 +47,10 @@ import fr.bsodium.cron.sensors.healthconnect.SleepStageReader
 import fr.bsodium.cron.ui.components.ScreenTitle
 import fr.bsodium.cron.ui.components.SectionLabel
 import fr.bsodium.cron.ui.theme.Spacing
+import java.util.Locale
 import kotlinx.datetime.LocalTime
+
+private val DIALOG_FIELD_MIN_HEIGHT = 120.dp
 
 @Composable
 fun SettingsScreen(viewModel: SettingsViewModel) {
@@ -188,7 +191,7 @@ fun SettingsScreen(viewModel: SettingsViewModel) {
                 }
             }
 
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(Spacing.xxxl + Spacing.sm))
         }
 }
 
@@ -297,10 +300,10 @@ private fun Section(
     label: String,
     content: @Composable () -> Unit,
 ) {
-    Spacer(modifier = Modifier.height(28.dp))
+    Spacer(modifier = Modifier.height(Spacing.xxl + Spacing.xs))
     SectionLabel(text = label)
-    Spacer(modifier = Modifier.height(14.dp))
-    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+    Spacer(modifier = Modifier.height(Spacing.md + Spacing.xxs))
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.xl)) {
         content()
     }
 }
@@ -333,7 +336,7 @@ private fun TimePickerRow(
             )
         }
         Text(
-            text = "%02d:%02d".format(time.hour, time.minute),
+            text = String.format(Locale.US, "%02d:%02d", time.hour, time.minute),
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.primary,
             fontWeight = FontWeight.SemiBold,
@@ -383,7 +386,7 @@ private fun BufferSlider(
                 fontWeight = FontWeight.SemiBold,
             )
         }
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(Spacing.sm))
         Slider(
             value = value.toFloat(),
             onValueChange = { onChange(it.toInt()) },
@@ -507,7 +510,7 @@ private fun CustomInstructionsRow(
                     label = { Text("Tell Cron how to plan your wake-ups") },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(min = 120.dp),
+                        .heightIn(min = DIALOG_FIELD_MIN_HEIGHT),
                 )
             },
             confirmButton = {

--- a/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
@@ -90,9 +90,8 @@ class AiTurnWorker(
         }
 
         val turnIndex = (db.aiMessageDao().maxTurnIndex(sessionId) ?: -1) + 1
-        // A manual replan appends a fresh EveningPlan event on purpose, so it runs the full
-        // EVENING_PLAN + Sonnet pass. Automatic overnight replans append *sensor* events, so the
-        // latest trigger is not EveningPlan and they stay on OVERNIGHT_REPLAN + Haiku.
+        // A manual replan re-appends an EveningPlan event (→ Sonnet); sensor-driven overnight
+        // replans leave the latest trigger ≠ EveningPlan, so they stay on Haiku.
         val isEveningPlan = session.events.lastOrNull()?.trigger == TriggerType.EveningPlan
 
         val model = if (isEveningPlan) TurnRunner.MODEL_SONNET else TurnRunner.MODEL_HAIKU
@@ -100,8 +99,7 @@ class AiTurnWorker(
 
         val tools = buildToolRegistry(session, apiKey)
         val client = AnthropicClient(apiKeyProvider = { apiKey })
-        // Anthropic requires max_tokens > thinking.budget_tokens, so widen the
-        // ceiling on evening_plan turns to leave room for the visible response.
+        // Anthropic requires max_tokens > thinking budget, so widen the ceiling on evening_plan turns.
         val thinking = if (isEveningPlan) ThinkingConfig(budgetTokens = THINKING_BUDGET) else null
         val maxTokens = if (isEveningPlan) THINKING_BUDGET + 2048 else 2048
         val runner = TurnRunner(


### PR DESCRIPTION
Completes epic #8 — a deliberate sweep of the four cleanup sub-issues in one pass. No behavior changes; `:app:assembleDebug` + `:app:lintDebug` + `:app:testDebugUnitTest` all green.

> Based on top of #7 (merged). Off-grid spacing uses **additive token composition** (no new tokens added to the scale), and #22 follows the maintainer's steer to *minimize* comment volume rather than mechanically KDoc every block.

## #20 — dp literals → Spacing/Radius tokens — Closes #20
- `OnboardingScreen`, `SettingsScreen`, `AlarmActivity`, `PermissionGate`, plus the post-#7 remainders in `CronBottomBar` / `NextAlarmCard` / `Atoms` / `AiThinkingThread`.
- Direct mappings (`8→sm`, `12→md`, `16→lg`, `20→xl`, `24→xxl`, `32→xxxl`, `4→xs`); off-grid values via additive composition: `40 = xxxl+sm`, `28 = xxl+xs`, `14 = md+xxs`, `10 = sm+xxs`, `6 = xs+xxs`.
- Genuine component dimensions (icon/canvas/track/disc/dialog sizes, the `5.dp` pill inset) hoisted to named `private val`s — not tokenized. `AlarmActivity` `RoundedCornerShape(50)` → `Radius.full`.

## #21 — Locale.US on numeric/clock formats — Closes #21
- `AlarmActivity:123` and `SettingsScreen:336` `"%02d:%02d"` now go through `String.format(Locale.US, …)`. Other numeric formats already passed `Locale.US`; `formatDateLabel` (human-language) left locale-default.

## #22 — comment hygiene — Closes #22
- Declaration-level stacked `//` → KDoc (`MainActivity.onCreate`, `AiThinkingThread`'s `TIMELINE_CONTENT_VPAD` / `STEP_LINE_HEIGHT`).
- Trimmed verbose in-body comment paragraphs to the load-bearing minimum across `HomeViewModel`, `HomeScreen`, `AiThinkingThread`, `NextAlarmCard`, `LocationProvider`, `AiTurnWorker`, `SleepSessionService`, `DoNothingTool`, `EveningPlanReceiver`, `Json.kt` — preferring clear names over prose. (Most audit "hits" were comments above *local vals*, which KDoc can't attach to.)

## #23 — Kotlin-style audit — Closes #23
- Documented the bare `else` on closed-enum `when`s in `SessionFsm` as intentional "ignore the rest" defaults (kept per existing design, not expanded into exhaustive `when`s).
- `mutableStateOf(0)` → `mutableIntStateOf(0)` for `Int` state (`AiThinkingThread`, `HomeScreen`); `PermissionGate` `mutableListOf` builder → `buildList`.
- **Clean:** no public `Mutable*` returns / public `var`, no positional-boolean call sites, no block-body one-liners, no `java.time` in domain logic.
- **Intentionally left:** `TAG` in companion objects (consistent repo-wide idiom — `AlarmReceiver`, the sensor monitors, `CronApplication`, `LocationProvider`); the `isLast` param flagged "always true" (per-call-site inference on a shared `TimelineRow` API — not worth churning here).

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)