### PR TITLE
feat: configurable daily token budget + surface AI-turn failures (#52)

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/MainActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/MainActivity.kt
@@ -146,6 +146,16 @@ class MainActivity : ComponentActivity() {
                             HomeScreen(
                                 viewModel = viewModel<HomeViewModel>(),
                                 fabRegistry = fabRegistry,
+                                onNavigateToSettings = {
+                                    navController.navigate("settings") {
+                                        popUpTo("home") {
+                                            saveState = true
+                                            inclusive = false
+                                        }
+                                        launchSingleTop = true
+                                        restoreState = true
+                                    }
+                                },
                             )
                         }
                         composable(

--- a/app/src/main/java/fr/bsodium/cron/ai/CostBudget.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/CostBudget.kt
@@ -11,8 +11,9 @@ import kotlinx.datetime.toLocalDateTime
  * Per-day token budget for AI calls.
  *
  * SharedPreferences-backed counter keyed by local date. If the user's daily
- * spend exceeds [BudgetStore.maxDailyTokens], [AiTurnWorker] refuses to
- * start a new turn until the next day.
+ * spend reaches the configured cap, [AiTurnWorker] refuses to start a new turn
+ * until the next day. The cap is a user setting (see SettingsRepository); this
+ * store just accounts usage and answers [hasHeadroom] for whatever cap it's given.
  *
  * Counts both input + output tokens. Doesn't distinguish cached / uncached
  * input tokens — for a single-user app the precision isn't worth the
@@ -43,9 +44,10 @@ class BudgetStore(context: Context) {
             .apply()
     }
 
-    /** True when the daily limit hasn't been hit. Default 75k tokens/day. */
+    /** True when the daily cap hasn't been reached. A [maxDailyTokens] of 0 or less means
+     *  unlimited (the user disabled the cap), so headroom is always available. */
     fun hasHeadroom(maxDailyTokens: Int = DEFAULT_DAILY_TOKEN_LIMIT): Boolean =
-        usedToday() < maxDailyTokens
+        maxDailyTokens <= 0 || usedToday() < maxDailyTokens
 
     private fun currentLocalDate(): LocalDate =
         Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
@@ -56,10 +58,11 @@ class BudgetStore(context: Context) {
         private const val KEY_USED = "tokens_used"
 
         /**
-         * Default daily cap. With Haiku 4.5 input ~ $1/MTok, output ~ $5/MTok,
-         * 75k mixed tokens is roughly $0.20/day worst-case. The evening Sonnet
-         * call is the biggest single hit; overnight Haiku replans are cheap.
+         * Default daily cap, used until the user picks one. Sized to comfortably cover a normal
+         * day — the evening Sonnet plan plus its tool calls, a handful of overnight Haiku replans,
+         * and a few manual retries — so a single busy day never trips it. The user can raise it
+         * further, or disable the cap entirely, in Settings.
          */
-        const val DEFAULT_DAILY_TOKEN_LIMIT = 75_000
+        const val DEFAULT_DAILY_TOKEN_LIMIT = 250_000
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/settings/SettingsRepository.kt
+++ b/app/src/main/java/fr/bsodium/cron/settings/SettingsRepository.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import fr.bsodium.cron.ai.BudgetStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -70,6 +71,11 @@ class SettingsRepository(private val context: Context) {
         prefs[USER_INSTRUCTIONS]?.takeIf { it.isNotBlank() }
     }
 
+    /** Daily AI token cap. Unset → the default cap; 0 (or less) means the user disabled it (unlimited). */
+    val dailyTokenLimit: Flow<Int> = context.dataStore.data.map { prefs ->
+        prefs[DAILY_TOKEN_LIMIT] ?: BudgetStore.DEFAULT_DAILY_TOKEN_LIMIT
+    }
+
     /** Epoch-ms of the last change to a plan-affecting setting; 0 if never changed. The home
      *  screen compares this against the active session's last AI call to offer a re-plan. */
     val settingsUpdatedAt: Flow<Long> = context.dataStore.data.map { prefs ->
@@ -118,7 +124,12 @@ class SettingsRepository(private val context: Context) {
     suspend fun setUserInstructions(text: String) =
         context.dataStore.edit { it[USER_INSTRUCTIONS] = text.trim() }
 
+    /** Plain edit (not plan-affecting): the cap governs spend, not the plan, so it mustn't raise the pill. */
+    suspend fun setDailyTokenLimit(tokens: Int) =
+        context.dataStore.edit { it[DAILY_TOKEN_LIMIT] = tokens }
+
     suspend fun currentUserInstructions(): String? = userInstructions.first()
+    suspend fun currentDailyTokenLimit(): Int = dailyTokenLimit.first()
 
     /** One-shot read for use from broadcast receivers and one-shot workers. */
     suspend fun currentEveningTriggerLocalTime(): LocalTime = eveningTriggerLocalTime.first()
@@ -141,6 +152,7 @@ class SettingsRepository(private val context: Context) {
         val ONBOARDING_COMPLETE = booleanPreferencesKey("onboarding_complete")
         val DISPLAY_NAME = stringPreferencesKey("display_name")
         val USER_INSTRUCTIONS = stringPreferencesKey("user_instructions")
+        val DAILY_TOKEN_LIMIT = intPreferencesKey("daily_token_limit")
         val SETTINGS_UPDATED_AT = longPreferencesKey("settings_updated_at")
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -76,12 +77,18 @@ import fr.bsodium.cron.ui.components.FabAction
 import fr.bsodium.cron.ui.screens.home.components.AiThinkingThread
 import fr.bsodium.cron.ui.screens.home.components.GreetingHeader
 import fr.bsodium.cron.ui.screens.home.components.NextAlarmCard
+import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.CronTypography
 import fr.bsodium.cron.ui.theme.Radius
 import fr.bsodium.cron.ui.theme.Spacing
+import java.util.Locale
 
 @Composable
-fun HomeScreen(viewModel: HomeViewModel, fabRegistry: FabRegistry) {
+fun HomeScreen(
+    viewModel: HomeViewModel,
+    fabRegistry: FabRegistry,
+    onNavigateToSettings: () -> Unit,
+) {
     val uiState by viewModel.uiState.collectAsState()
     DisposableEffect(viewModel, fabRegistry) {
         fabRegistry.set(FabAction(onClick = viewModel::retryAiPlan, onCancel = viewModel::cancelAiPlan))
@@ -217,11 +224,9 @@ fun HomeScreen(viewModel: HomeViewModel, fabRegistry: FabRegistry) {
             )
         }
 
-        // Floats just above the nav when a plan-affecting setting changed since the last plan.
-        AnimatedVisibility(
-            visible = uiState.settingsChangedSincePlan,
-            enter = fadeIn() + slideInVertically { it / 2 },
-            exit = fadeOut() + slideOutVertically { it / 2 },
+        // Floating callouts stack just above the nav: a turn-failure banner on top of the
+        // "settings changed" pill, so the two never overlap when both are visible.
+        Column(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .padding(
@@ -230,13 +235,36 @@ fun HomeScreen(viewModel: HomeViewModel, fabRegistry: FabRegistry) {
                     bottom = navInsetBottom + Spacing.navBarClearance,
                 ),
         ) {
-            SettingsChangedPill(
-                onRewrite = {
-                    viewModel.retryAiPlan()
-                    viewModel.dismissSettingsReminder()
-                },
-                onDismiss = viewModel::dismissSettingsReminder,
-            )
+            // Hold the last failure so it animates out cleanly after aiFailure clears on dismiss.
+            var lastFailure by remember { mutableStateOf<AiTurnFailure?>(null) }
+            LaunchedEffect(uiState.aiFailure) { uiState.aiFailure?.let { lastFailure = it } }
+            AnimatedVisibility(
+                visible = uiState.aiFailure != null,
+                enter = fadeIn() + slideInVertically { it / 2 },
+                exit = fadeOut() + slideOutVertically { it / 2 },
+            ) {
+                lastFailure?.let { failure ->
+                    AiFailureBanner(
+                        failure = failure,
+                        onOpenSettings = onNavigateToSettings,
+                        onDismiss = viewModel::dismissAiFailure,
+                        modifier = Modifier.padding(bottom = Spacing.sm),
+                    )
+                }
+            }
+            AnimatedVisibility(
+                visible = uiState.settingsChangedSincePlan,
+                enter = fadeIn() + slideInVertically { it / 2 },
+                exit = fadeOut() + slideOutVertically { it / 2 },
+            ) {
+                SettingsChangedPill(
+                    onRewrite = {
+                        viewModel.retryAiPlan()
+                        viewModel.dismissSettingsReminder()
+                    },
+                    onDismiss = viewModel::dismissSettingsReminder,
+                )
+            }
         }
     }
 }
@@ -400,5 +428,66 @@ private fun NotificationPermissionRow(onEnable: () -> Unit, modifier: Modifier =
             )
             TextButton(onClick = onEnable) { Text("Enable") }
         }
+    }
+}
+
+@Composable
+private fun AiFailureBanner(
+    failure: AiTurnFailure,
+    onOpenSettings: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.errorContainer,
+        shape = RoundedCornerShape(Radius.lg),
+        tonalElevation = 0.dp,
+    ) {
+        Column(modifier = Modifier.padding(start = Spacing.lg, top = Spacing.md, end = Spacing.xs)) {
+            Text(
+                text = failure.bannerMessage(),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = { onOpenSettings(); onDismiss() }) { Text("Open settings") }
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Rounded.Close,
+                        contentDescription = "Dismiss",
+                        tint = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun AiTurnFailure.bannerMessage(): String = when (this) {
+    is AiTurnFailure.BudgetExhausted -> String.format(
+        Locale.US,
+        "Daily AI budget reached (%,d / %,d tokens). Resets at midnight, or raise it in Settings.",
+        used,
+        limit,
+    )
+    AiTurnFailure.MissingApiKey -> "AI planning needs an Anthropic API key. Add one in Settings."
+    is AiTurnFailure.Generic ->
+        "Couldn't update your plan${reason?.let { " ($it)" }.orEmpty()}. Try again, or check Settings."
+}
+
+@Preview
+@Composable
+private fun AiFailureBannerPreview() {
+    CronTheme {
+        AiFailureBanner(
+            failure = AiTurnFailure.BudgetExhausted(used = 80_802, limit = 250_000),
+            onOpenSettings = {},
+            onDismiss = {},
+        )
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.Data
 import androidx.work.WorkInfo
 import fr.bsodium.cron.ai.wire.ContentBlock
 import fr.bsodium.cron.calendar.requestCalendarSync
@@ -22,6 +23,7 @@ import fr.bsodium.cron.session.model.SessionStatus
 import fr.bsodium.cron.session.model.SleepSegment
 import fr.bsodium.cron.session.model.TriggerType
 import fr.bsodium.cron.settings.SettingsRepository
+import fr.bsodium.cron.worker.AiTurnWorker
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -61,7 +63,16 @@ data class HomeUiState(
     val initialized: Boolean = false,
     /** A plan-affecting setting changed since the last plan was written — offers a re-run. */
     val settingsChangedSincePlan: Boolean = false,
+    /** The latest AI turn failed (and hasn't been dismissed) — surfaces a dismissible banner. */
+    val aiFailure: AiTurnFailure? = null,
 )
+
+/** Why the most recent AI turn ended without updating the plan, for the home failure banner. */
+sealed interface AiTurnFailure {
+    data class BudgetExhausted(val used: Int, val limit: Int) : AiTurnFailure
+    data object MissingApiKey : AiTurnFailure
+    data class Generic(val reason: String?) : AiTurnFailure
+}
 
 data class SleepStatsUi(
     val durationLabel: String,
@@ -101,6 +112,15 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _isRetrying = MutableStateFlow(false)
 
+    /** Failure parsed from the latest FAILED turn; null while idle, running, or once dismissed. */
+    private val _aiFailure = MutableStateFlow<AiTurnFailure?>(null)
+
+    /** id of the most-recent FAILED turn surfaced, and the one the user dismissed — WorkManager keeps
+     *  re-emitting a terminal FAILED WorkInfo, so dismissal keys on its id to avoid resurrection. A new
+     *  enqueue (REPLACE) gets a fresh id, so a genuinely new failure still shows. */
+    private val _lastFailedId = MutableStateFlow<String?>(null)
+    private val _dismissedFailureId = MutableStateFlow<String?>(null)
+
     /** Latest session entity; many derived streams hang off this. */
     private val sessionFlow = db.sessionDao().observeLatest()
 
@@ -135,8 +155,12 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         settingsAt > lastAiCallAt && settingsAt > dismissedAt
     }
 
-    private val statusFlow = combine(_isRetrying, settingsChangedFlow) { retrying, settingsChanged ->
-        retrying to settingsChanged
+    private val statusFlow = combine(
+        _isRetrying,
+        settingsChangedFlow,
+        _aiFailure,
+    ) { retrying, settingsChanged, failure ->
+        HomeStatus(isRetrying = retrying, settingsChanged = settingsChanged, failure = failure)
     }
 
     val uiState: StateFlow<HomeUiState> = combine(
@@ -146,7 +170,6 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         settings.displayName,
         statusFlow,
     ) { session, sleepStats, thread, displayName, status ->
-        val (retrying, settingsChanged) = status
         HomeUiState(
             sessionDisplay = session,
             greetingPrefix = greetingPrefix(),
@@ -154,11 +177,12 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             dateLabel = formatDateLabel(session),
             sleepStats = sleepStats,
             aiThread = thread,
-            isRetrying = retrying,
+            isRetrying = status.isRetrying,
             // combine() only emits once every source has produced a value, so reaching here means
             // the backing flows have loaded — distinguishes "no plan" from "not loaded yet".
             initialized = true,
-            settingsChangedSincePlan = settingsChanged && thread != null,
+            settingsChangedSincePlan = status.settingsChanged && thread != null,
+            aiFailure = status.failure,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), HomeUiState())
 
@@ -177,8 +201,9 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
      * scheduling concerns owned by the receiver, not a manual user trigger.)
      */
     init {
-        // Drive the "working" flag off the real WorkManager turn, not a fixed delay: a tap sets it
-        // true optimistically; this clears it when the turn reaches a terminal state.
+        // Drive the "working" flag and the failure banner off the real WorkManager turn, not a fixed
+        // delay: a tap sets isRetrying true optimistically; this clears it when the turn reaches a
+        // terminal state, and surfaces the failure reason a FAILED turn carries in its output data.
         viewModelScope.launch {
             sessionFlow.map { it?.id }.distinctUntilChanged()
                 .flatMapLatest { id ->
@@ -189,8 +214,26 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                         infos.any { !it.state.isFinished } -> _isRetrying.value = true
                         infos.isNotEmpty() -> _isRetrying.value = false
                     }
+
+                    val failed = infos.firstOrNull { it.state == WorkInfo.State.FAILED }
+                    _aiFailure.value = when {
+                        // A turn is running/queued — hide any stale failure from the previous attempt.
+                        infos.any { !it.state.isFinished } -> null
+                        failed == null -> null
+                        failed.id.toString() == _dismissedFailureId.value -> null
+                        else -> {
+                            _lastFailedId.value = failed.id.toString()
+                            failed.outputData.toAiTurnFailure()
+                        }
+                    }
                 }
         }
+    }
+
+    /** Hide the AI failure banner until the next distinct turn fails (keyed on the failed work's id). */
+    fun dismissAiFailure() {
+        _dismissedFailureId.value = _lastFailedId.value
+        _aiFailure.value = null
     }
 
     fun retryAiPlan() {
@@ -393,6 +436,17 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         )
     }
 
+    /** Maps an [AiTurnWorker] failure's output data to a UI failure. Unknown/absent reasons (open input
+     *  — future worker reasons) fall through to [AiTurnFailure.Generic]. */
+    private fun Data.toAiTurnFailure(): AiTurnFailure = when (getString(AiTurnWorker.KEY_REASON)) {
+        AiTurnWorker.REASON_BUDGET -> AiTurnFailure.BudgetExhausted(
+            used = getInt(AiTurnWorker.KEY_USED, 0),
+            limit = getInt(AiTurnWorker.KEY_LIMIT, 0),
+        )
+        AiTurnWorker.REASON_NO_API_KEY -> AiTurnFailure.MissingApiKey
+        else -> AiTurnFailure.Generic(getString(AiTurnWorker.KEY_REASON))
+    }
+
     private fun decodeBlocks(json: String): List<ContentBlock> = runCatching {
         SessionJson.decodeFromString<List<ContentBlock>>(json)
     }
@@ -449,6 +503,13 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         const val TAG = "HomeViewModel"
     }
 }
+
+/** The three transient status signals folded into one combine source to keep uiState's arity at 5. */
+private data class HomeStatus(
+    val isRetrying: Boolean,
+    val settingsChanged: Boolean,
+    val failure: AiTurnFailure?,
+)
 
 // Hoisted so they compile once, not on every buildAiThread call.
 private val LEADING_RULE = Regex("([-*_])\\1{2,}")

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -23,12 +24,14 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -37,26 +40,48 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.health.connect.client.PermissionController
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import fr.bsodium.cron.permissions.SystemPermissions
 import fr.bsodium.cron.sensors.healthconnect.SleepStageReader
 import fr.bsodium.cron.ui.components.ScreenTitle
 import fr.bsodium.cron.ui.components.SectionLabel
+import fr.bsodium.cron.ui.theme.CronTheme
+import fr.bsodium.cron.ui.theme.Radius
 import fr.bsodium.cron.ui.theme.Spacing
 import java.util.Locale
 import kotlinx.datetime.LocalTime
 
 private val DIALOG_FIELD_MIN_HEIGHT = 120.dp
+private val BUDGET_ROW_MIN_HEIGHT = 48.dp
+
+/** Daily AI token-cap presets shown in the budget dialog; 0 means unlimited (cap disabled). */
+private val BUDGET_PRESETS = listOf(100_000, 250_000, 500_000, 0)
 
 @Composable
 fun SettingsScreen(viewModel: SettingsViewModel) {
     val state by viewModel.uiState.collectAsState()
     val navBottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val statusInsetTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+
+    // Token spend is read from SharedPreferences, not observed — refresh it whenever the screen resumes
+    // (e.g. after a turn ran while the app was backgrounded) so the "used today" figure stays current.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) viewModel.refreshUsage()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     Column(
         modifier = Modifier
@@ -115,6 +140,11 @@ fun SettingsScreen(viewModel: SettingsViewModel) {
                 CustomInstructionsRow(
                     instructions = state.userInstructions,
                     onSave = viewModel::setUserInstructions,
+                )
+                DailyBudgetRow(
+                    limit = state.dailyTokenLimit,
+                    usedToday = state.tokensUsedToday,
+                    onSelect = viewModel::setDailyTokenLimit,
                 )
             }
 
@@ -525,6 +555,93 @@ private fun CustomInstructionsRow(
                 TextButton(onClick = { showDialog = false }) { Text("Cancel") }
             },
         )
+    }
+}
+
+@Composable
+private fun DailyBudgetRow(
+    limit: Int,
+    usedToday: Int,
+    onSelect: (Int) -> Unit,
+) {
+    var showDialog by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { showDialog = true },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Daily AI budget",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Text(
+                text = String.format(Locale.US, "%,d used today", usedToday),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Text(
+            text = formatTokenLimit(limit),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm),
+        )
+    }
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Daily AI budget") },
+            text = {
+                Column {
+                    BUDGET_PRESETS.forEach { preset ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(Radius.sm))
+                                .clickable {
+                                    onSelect(preset)
+                                    showDialog = false
+                                }
+                                .heightIn(min = BUDGET_ROW_MIN_HEIGHT),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
+                                selected = preset == limit,
+                                onClick = {
+                                    onSelect(preset)
+                                    showDialog = false
+                                },
+                            )
+                            Text(
+                                text = formatTokenLimit(preset),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showDialog = false }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+/** "250,000 tokens" for a finite cap, "Unlimited" when disabled (0 or less). */
+private fun formatTokenLimit(tokens: Int): String =
+    if (tokens <= 0) "Unlimited" else String.format(Locale.US, "%,d tokens", tokens)
+
+@Preview
+@Composable
+private fun DailyBudgetRowPreview() {
+    CronTheme {
+        DailyBudgetRow(limit = 250_000, usedToday = 12_480, onSelect = {})
     }
 }
 

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsViewModel.kt
@@ -3,9 +3,11 @@ package fr.bsodium.cron.ui.screens.settings
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import fr.bsodium.cron.ai.BudgetStore
 import fr.bsodium.cron.alarm.EveningPlanScheduler
 import fr.bsodium.cron.settings.SecureKeyStore
 import fr.bsodium.cron.settings.SettingsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -23,12 +25,22 @@ data class SettingsUiState(
     val hasApiKey: Boolean = false,
     val displayName: String? = null,
     val userInstructions: String? = null,
+    val dailyTokenLimit: Int = BudgetStore.DEFAULT_DAILY_TOKEN_LIMIT,
+    val tokensUsedToday: Int = 0,
 )
 
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
 
     private val repo = SettingsRepository(application)
     private val secureStore = SecureKeyStore(application)
+    private val budget = BudgetStore(application)
+
+    /** Today's token spend. SharedPreferences-backed (not a Flow); refreshed on screen resume. */
+    private val _tokensUsedToday = MutableStateFlow(0)
+
+    init {
+        refreshUsage()
+    }
 
     val uiState: StateFlow<SettingsUiState> = combine(
         repo.eveningTriggerLocalTime,
@@ -51,6 +63,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         state.copy(displayName = name)
     }.combine(repo.userInstructions) { state, instructions ->
         state.copy(userInstructions = instructions)
+    }.combine(repo.dailyTokenLimit) { state, limit ->
+        state.copy(dailyTokenLimit = limit)
+    }.combine(_tokensUsedToday) { state, used ->
+        state.copy(tokensUsedToday = used)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState())
 
     fun setEveningTrigger(time: LocalTime) {
@@ -86,5 +102,14 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun setUserInstructions(text: String) {
         viewModelScope.launch { repo.setUserInstructions(text) }
+    }
+
+    fun setDailyTokenLimit(tokens: Int) {
+        viewModelScope.launch { repo.setDailyTokenLimit(tokens) }
+    }
+
+    /** Re-reads today's token spend; called when the Settings screen resumes. */
+    fun refreshUsage() {
+        _tokensUsedToday.value = budget.usedToday()
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
@@ -8,6 +8,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import androidx.work.workDataOf
 import fr.bsodium.cron.BuildConfig
 import fr.bsodium.cron.CronApplication
 import fr.bsodium.cron.MainActivity
@@ -80,13 +81,15 @@ class AiTurnWorker(
         val apiKey = SecureKeyStore(applicationContext).anthropicApiKey
         if (apiKey.isNullOrBlank()) {
             Log.w(TAG, "Anthropic API key not set — skipping AI turn for $sessionId")
-            return Result.failure()
+            return Result.failure(workDataOf(KEY_REASON to REASON_NO_API_KEY))
         }
 
         val budget = BudgetStore(applicationContext)
-        if (!budget.hasHeadroom()) {
-            Log.w(TAG, "Daily token budget exhausted (${budget.usedToday()} used); skipping turn for $sessionId")
-            return Result.failure()
+        val limit = settingsRepository.currentDailyTokenLimit()
+        if (!budget.hasHeadroom(limit)) {
+            val used = budget.usedToday()
+            Log.w(TAG, "Daily token budget exhausted ($used / $limit); skipping turn for $sessionId")
+            return Result.failure(workDataOf(KEY_REASON to REASON_BUDGET, KEY_USED to used, KEY_LIMIT to limit))
         }
 
         val turnIndex = (db.aiMessageDao().maxTurnIndex(sessionId) ?: -1) + 1
@@ -129,10 +132,10 @@ class AiTurnWorker(
             Result.success()
         } catch (e: AnthropicClient.MissingApiKeyException) {
             Log.e(TAG, "Missing API key during turn", e)
-            Result.failure()
+            Result.failure(workDataOf(KEY_REASON to REASON_NO_API_KEY))
         } catch (e: AnthropicClient.AnthropicHttpException) {
             Log.e(TAG, "Anthropic HTTP ${e.code} during turn for $sessionId", e)
-            if (e.isRetryable) Result.retry() else Result.failure()
+            if (e.isRetryable) Result.retry() else Result.failure(workDataOf(KEY_REASON to REASON_HTTP))
         } catch (e: Exception) {
             Log.e(TAG, "Unexpected error during AI turn for $sessionId", e)
             Result.retry()
@@ -325,6 +328,15 @@ class AiTurnWorker(
     companion object {
         const val KEY_SESSION_ID = "session_id"
         const val WORK_PREFIX = "ai_turn_"
+
+        /** Failure output: why the turn was skipped, plus budget figures when relevant. Read by HomeViewModel. */
+        const val KEY_REASON = "reason"
+        const val KEY_USED = "used"
+        const val KEY_LIMIT = "limit"
+        const val REASON_BUDGET = "budget_exhausted"
+        const val REASON_NO_API_KEY = "no_api_key"
+        const val REASON_HTTP = "http_error"
+
         private const val TAG = "AiTurnWorker"
         private val PHONE_ONLY_THRESHOLD = 90.minutes
         private const val THINKING_BUDGET = 2_000


### PR DESCRIPTION
## Why

The app-internal daily token cap was hardcoded at 75k — too low for a normal day — and hitting it returned a bare `Result.failure()`, so the "Thinking…" thread just cleared with no explanation. It looked broken.

## What

**#53 — make the cap configurable**
- `CostBudget`: default `75k → 250k`; `hasHeadroom()` treats `≤ 0` as unlimited (cap disabled).
- `SettingsRepository`: `dailyTokenLimit` DataStore Int (plain edit, not plan-affecting) + `currentDailyTokenLimit()` one-shot for the worker.
- `AiTurnWorker`: reads the configured limit and passes it to `hasHeadroom()`.
- Settings → Assistant: a **Daily AI budget** row with a preset radio dialog (100k / 250k / 500k / Unlimited) and a "used today" subtitle refreshed on resume.

**#54 — never fail silently**
- `AiTurnWorker`: `Result.failure(workDataOf(reason, used, limit))` for budget exhaustion, missing API key, and non-retryable HTTP.
- `HomeViewModel`: sealed `AiTurnFailure` parsed from `WorkInfo.outputData`; dismissal keyed on the failed work's id so WorkManager's terminal re-emission can't resurrect a dismissed banner (a fresh REPLACE enqueue gets a new id, so a genuinely new failure still shows).
- `HomeScreen`: flat, dismissible failure banner stacked above the "Settings updated" pill, with an "Open settings" action.

## Verification
`:app:assembleDebug`, `:app:lintDebug` (no errors), and `:app:testDebugUnitTest` all pass. New composables carry `@Preview`s.

Closes #53
Closes #54
Part of #52