### PR TITLE
feat: theme the onboarding illustration to Material You (+ inline-code scale)

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/components/RecoloredVector.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/RecoloredVector.kt
@@ -1,0 +1,69 @@
+package fr.bsodium.cron.ui.components
+
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.VectorGroup
+import androidx.compose.ui.graphics.vector.VectorNode
+import androidx.compose.ui.graphics.vector.VectorPath
+
+/**
+ * Rebuilds this vector with every solid fill remapped by [map]. Used to retint a multi-color asset
+ * (the onboarding illustration) onto the live Material You `colorScheme` at the Compose layer — the
+ * app's framework `Theme.Cron` can't expose the dynamic palette to the drawable via `?attr/color*`.
+ * Gradient fills and all strokes pass through unchanged; `fillAlpha`/`pathData` are preserved.
+ */
+fun ImageVector.recolored(map: (Color) -> Color): ImageVector {
+    val builder = ImageVector.Builder(
+        name = name,
+        defaultWidth = defaultWidth,
+        defaultHeight = defaultHeight,
+        viewportWidth = viewportWidth,
+        viewportHeight = viewportHeight,
+        tintColor = tintColor,
+        tintBlendMode = tintBlendMode,
+        autoMirror = autoMirror,
+    )
+    root.forEach { builder.addNode(it, map) }
+    return builder.build()
+}
+
+private fun ImageVector.Builder.addNode(node: VectorNode, map: (Color) -> Color) {
+    when (node) {
+        is VectorPath -> addPath(
+            pathData = node.pathData,
+            pathFillType = node.pathFillType,
+            name = node.name,
+            fill = node.fill.remap(map),
+            fillAlpha = node.fillAlpha,
+            stroke = node.stroke,
+            strokeAlpha = node.strokeAlpha,
+            strokeLineWidth = node.strokeLineWidth,
+            strokeLineCap = node.strokeLineCap,
+            strokeLineJoin = node.strokeLineJoin,
+            strokeLineMiter = node.strokeLineMiter,
+            trimPathStart = node.trimPathStart,
+            trimPathEnd = node.trimPathEnd,
+            trimPathOffset = node.trimPathOffset,
+        )
+        is VectorGroup -> {
+            addGroup(
+                name = node.name,
+                rotate = node.rotation,
+                pivotX = node.pivotX,
+                pivotY = node.pivotY,
+                scaleX = node.scaleX,
+                scaleY = node.scaleY,
+                translationX = node.translationX,
+                translationY = node.translationY,
+                clipPathData = node.clipPathData,
+            )
+            node.forEach { addNode(it, map) }
+            clearGroup()
+        }
+    }
+}
+
+private fun Brush?.remap(map: (Color) -> Color): Brush? =
+    if (this is SolidColor) SolidColor(map(value)) else this

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -3,6 +3,7 @@ package fr.bsodium.cron.ui.screens.home
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.provider.Settings
 import androidx.compose.animation.AnimatedVisibility
@@ -12,6 +13,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -56,10 +58,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -68,11 +73,13 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.ColorUtils
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import fr.bsodium.cron.FabRegistry
 import fr.bsodium.cron.R
+import fr.bsodium.cron.ui.components.recolored
 import fr.bsodium.cron.ui.components.FabAction
 import fr.bsodium.cron.ui.screens.home.components.AiThinkingThread
 import fr.bsodium.cron.ui.screens.home.components.GreetingHeader
@@ -379,8 +386,39 @@ private fun OnboardingHint(modifier: Modifier = Modifier) {
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        val scheme = MaterialTheme.colorScheme
+        val source = ImageVector.vectorResource(R.drawable.ic_onboarding_illustration)
+        // Tonal ramp around the dynamic accent: highlights blend toward white, shadows toward black so
+        // they stay lighter/darker than the body in both themes (Material role pairs would invert).
+        // Dark mode flips `primary` to a light pastel, and the fallback accent is itself low-chroma. Build the
+        // dark body in HSL — keep the accent hue, floor its saturation so the layers read as *tinted* (not grey),
+        // and set a deep lightness so they stay darker than the near-white frosting. Light mode is untouched.
+        val dark = isSystemInDarkTheme()
+        val body = if (dark) {
+            val hsl = FloatArray(3)
+            ColorUtils.colorToHSL(scheme.primary.toArgb(), hsl)
+            Color.hsl(hsl[0], hsl[1].coerceAtLeast(CAKE_DARK_SAT_FLOOR), CAKE_DARK_BODY_LIGHTNESS)
+        } else {
+            scheme.primary
+        }
+        val highlight = lerp(scheme.primary, Color.White, CAKE_HIGHLIGHT_TINT)
+        val accent = lerp(scheme.primary, Color.Black, CAKE_ACCENT_TINT)
+        val shadow = lerp(scheme.primary, Color.Black, CAKE_SHADOW_TINT)
+        val ground = scheme.surfaceVariant
+        val themedCake = remember(source, body, highlight, accent, shadow, ground) {
+            source.recolored { original ->
+                when (original) {
+                    CAKE_BODY -> body
+                    CAKE_HIGHLIGHT -> highlight
+                    CAKE_GROUND -> ground
+                    CAKE_ACCENT -> accent
+                    CAKE_SHADOW -> shadow
+                    else -> original
+                }
+            }
+        }
         Image(
-            painter = painterResource(R.drawable.ic_onboarding_illustration),
+            imageVector = themedCake,
             contentDescription = null,
             modifier = Modifier.size(200.dp),
         )
@@ -403,6 +441,34 @@ private fun OnboardingHint(modifier: Modifier = Modifier) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )
+    }
+}
+
+/** Source fills of `ic_onboarding_illustration`, remapped onto `colorScheme` so the cake tracks Material You. */
+private val CAKE_BODY = Color(0xFF407BFF)
+private val CAKE_HIGHLIGHT = Color(0xFFFFFFFF)
+private val CAKE_GROUND = Color(0xFFF5F5F5)
+private val CAKE_ACCENT = Color(0xFF263238)
+private val CAKE_SHADOW = Color(0xFF000000)
+
+/** Blend fractions for the cake's tonal ramp: highlight toward white, accent/shadow toward black. */
+private const val CAKE_HIGHLIGHT_TINT = 0.82f
+private const val CAKE_ACCENT_TINT = 0.50f
+private const val CAKE_SHADOW_TINT = 0.60f
+
+/** Dark-theme only: the cake body uses the accent hue at this saturation floor + lightness, so the layers read
+ *  as a deep *tinted* accent (not grey) while staying darker than the near-white frosting. */
+private const val CAKE_DARK_SAT_FLOOR = 0.45f
+private const val CAKE_DARK_BODY_LIGHTNESS = 0.35f
+
+@Preview(name = "Onboarding hint — light", showBackground = true)
+@Preview(name = "Onboarding hint — dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun OnboardingHintPreview() {
+    CronTheme {
+        Surface(color = MaterialTheme.colorScheme.background) {
+            OnboardingHint(Modifier.padding(Spacing.xxl))
+        }
     }
 }
 

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -87,9 +88,11 @@ import com.mikepenz.markdown.compose.elements.MarkdownHeader
 import com.mikepenz.markdown.compose.elements.MarkdownOrderedList
 import com.mikepenz.markdown.compose.elements.MarkdownParagraph
 import com.mikepenz.markdown.compose.elements.listDepth
+import com.mikepenz.markdown.compose.extendedspans.ExtendedSpans
 import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
+import com.mikepenz.markdown.model.markdownExtendedSpans
 import com.mikepenz.markdown.model.markdownPadding
 import fr.bsodium.cron.R
 import fr.bsodium.cron.ui.screens.home.AiThreadUi
@@ -327,6 +330,8 @@ private fun ProcessTextRow(text: String, isFirst: Boolean, isLast: Boolean) {
                 // the touch target at 48dp while the visible pill stays compact.
                 Box(
                     modifier = Modifier
+                        // Tuck the toggle up under the fade so the soft dissolve leads straight into it.
+                        .offset(y = -Spacing.md)
                         // No start padding so the label aligns with the reasoning-text column; the
                         // 48dp touch target is preserved by minimumInteractiveComponentSize.
                         .minimumInteractiveComponentSize()
@@ -361,11 +366,12 @@ private fun ProcessTextRow(text: String, isFirst: Boolean, isLast: Boolean) {
 
 private const val REASONING_COLLAPSE_CHARS = 280
 private const val REASONING_COLLAPSED_LINES = 6
-/** Martian Mono's x-height + stroke read much larger than EB Garamond's delicate body, so inline/block
- *  code is scaled well below the serif point size to sit flush with the surrounding prose. */
+/** Martian Mono's x-height + stroke read much larger than the body face's, so inline/block code is scaled
+ *  below the body point size — but never below [CODE_MIN_SP], so the smaller sans/thinking code stays legible. */
 private const val CODE_FONT_SCALE = 0.68f
-// Taller fade band → a softer, more gradual dissolve into "See more" (was Spacing.xl, too abrupt).
-private val REASONING_FADE_HEIGHT = 48.dp
+private const val CODE_MIN_SP = 11f
+// Soft dissolve into "See more"; the band's height sets how gradual the fade reads.
+private val REASONING_FADE_HEIGHT = 56.dp
 private val REASONING_HEIGHT_SPEC = tween<Int>(durationMillis = 200, easing = FastOutSlowInEasing)
 
 /** Collapsed clamp height for a long reasoning block — about [REASONING_COLLAPSED_LINES] lines. */
@@ -390,7 +396,9 @@ private fun ClippedReveal(
 ) {
     val collapsedPx = with(LocalDensity.current) { collapsedHeight.roundToPx() }
     var fullPx by remember { mutableIntStateOf(0) }
-    val target = if (expanded) fullPx else minOf(collapsedPx, fullPx)
+    // Collapsed target is the constant collapsedPx (never `minOf(..., fullPx)` which is 0 before the first
+    // measure) — so animateIntAsState starts at the resting height and a static preview never catches it at 0.
+    val target = if (expanded) (if (fullPx > 0) fullPx else collapsedPx) else collapsedPx
     val animatedPx by animateIntAsState(target, REASONING_HEIGHT_SPEC, label = "reasoning-reveal")
     val fading = fullPx > 0 && animatedPx < fullPx
     SubcomposeLayout(
@@ -644,7 +652,7 @@ private fun MarkdownBlock(
     val codeStyle = bodyStyle.copy(
         fontFamily = CodeFontFamily,
         color = onSurface,
-        fontSize = (bodyStyle.fontSize.value * CODE_FONT_SCALE).sp,
+        fontSize = (bodyStyle.fontSize.value * CODE_FONT_SCALE).coerceAtLeast(CODE_MIN_SP).sp,
     )
     val typography = markdownTypography(
         h1 = serifize(MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.SemiBold, color = onSurface)),
@@ -677,6 +685,20 @@ private fun MarkdownBlock(
             listItemBottom = Spacing.xs,
             listIndent = Spacing.lg,
         ),
+        // Draw the inline-code background as a rounded chip echoing the "Calling …" tool pill. The
+        // band is anchored to each line's baseline and sized from the code font, so it hugs the
+        // glyphs in both the serif response and the smaller sans thinking text.
+        extendedSpans = markdownExtendedSpans {
+            ExtendedSpans(
+                InlineCodeChipPainter(
+                    chipColor = surfaceHigh,
+                    cornerRadius = INLINE_CODE_CORNER,
+                    horizontalPadding = INLINE_CODE_PAD_H,
+                    aboveBaseline = (codeStyle.fontSize.value * INLINE_CODE_ASCENT_RATIO).sp,
+                    belowBaseline = (codeStyle.fontSize.value * INLINE_CODE_DESCENT_RATIO).sp,
+                ),
+            )
+        },
         components = markdownComponents(
             paragraph = { model ->
                 MarkdownParagraph(model.content, model.node, Modifier.padding(bottom = MD_PARA_BELOW), bodyStyle)
@@ -726,6 +748,15 @@ private val HEADING_GAP = listOf(
     HeadingGap(Spacing.xs, 0.dp),                                // h6 — 4 / 0
 )
 private val MD_BLOCK_GAP = Spacing.xxs
+// Inline-code chip, tuned to echo the "Calling …" tool pill (rounded). InlineCodeChipPainter trims
+// the renderer's injected CODE_SPAN spaces out of the drawn range, so we add our own horizontal gap.
+private val INLINE_CODE_CORNER = 6.sp
+private val INLINE_CODE_PAD_H = 4.sp
+// Band extents above/below the baseline, as a fraction of the code font size — so the chip hugs the
+// glyphs proportionally in both the serif and sans contexts. Descent runs deliberately past Martian
+// Mono's natural descender (~0.25em) for a little breathing room beneath the baseline.
+private const val INLINE_CODE_ASCENT_RATIO = 1.2f
+private const val INLINE_CODE_DESCENT_RATIO = 0.42f
 private val MD_PARA_BELOW = Spacing.xxs
 private val LIST_MARKER_GAP = Spacing.sm
 // Bounds for content-proportional table columns, so no column dominates or collapses.

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -361,8 +361,9 @@ private fun ProcessTextRow(text: String, isFirst: Boolean, isLast: Boolean) {
 
 private const val REASONING_COLLAPSE_CHARS = 280
 private const val REASONING_COLLAPSED_LINES = 6
-/** Martian Mono reads larger than the sans/serif at the same size, so code renders below body size. */
-private const val CODE_FONT_SCALE = 0.78f
+/** Martian Mono's x-height + stroke read much larger than EB Garamond's delicate body, so inline/block
+ *  code is scaled well below the serif point size to sit flush with the surrounding prose. */
+private const val CODE_FONT_SCALE = 0.68f
 // Taller fade band → a softer, more gradual dissolve into "See more" (was Spacing.xl, too abrupt).
 private val REASONING_FADE_HEIGHT = 48.dp
 private val REASONING_HEIGHT_SPEC = tween<Int>(durationMillis = 200, easing = FastOutSlowInEasing)

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/InlineCodeChipPainter.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/InlineCodeChipPainter.kt
@@ -1,0 +1,106 @@
+package fr.bsodium.cron.ui.screens.home.components
+
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.isUnspecified
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastForEachIndexed
+import com.mikepenz.markdown.compose.extendedspans.ExtendedSpanPainter
+import com.mikepenz.markdown.compose.extendedspans.SpanDrawInstructions
+
+/**
+ * Draws the rounded "chip" behind inline code, tuned to echo the `Calling …` tool pill.
+ *
+ * Two reasons this exists instead of the library's `RoundedCornerSpanPainter`:
+ *  - The renderer brackets inline code with an injected space glyph on each side, *inside* the
+ *    background span (CODE_SPAN in the library's AnnotatedStringKtx). We trim those spaces out of
+ *    the drawn range so a wrapped span can't strand a rounded sliver (the lone leading space) at
+ *    the end of the previous line.
+ *  - The band is anchored to the text [TextLayoutResult.getLineBaseline] with extents scaled from
+ *    the code font size, so it hugs the glyphs in both the serif response and the smaller sans
+ *    thinking text — and we control the gap below the baseline independently.
+ */
+class InlineCodeChipPainter(
+    private val chipColor: Color,
+    private val cornerRadius: TextUnit,
+    private val horizontalPadding: TextUnit,
+    private val aboveBaseline: TextUnit,
+    private val belowBaseline: TextUnit,
+) : ExtendedSpanPainter() {
+    private val path = Path()
+
+    override fun decorate(
+        span: SpanStyle,
+        start: Int,
+        end: Int,
+        text: AnnotatedString,
+        builder: AnnotatedString.Builder,
+    ): SpanStyle {
+        if (span.background.isUnspecified) return span
+        // Exclude the injected leading/trailing space from the drawn range, but still strip the
+        // background off the whole span so the text layer paints no rectangle behind it.
+        val drawStart = (start + 1).coerceAtMost(end)
+        val drawEnd = (end - 1).coerceAtLeast(drawStart)
+        if (drawStart < drawEnd) builder.addStringAnnotation(TAG, annotation = "", start = drawStart, end = drawEnd)
+        return span.copy(background = Color.Unspecified)
+    }
+
+    // Inline code carries no link; leave link styling untouched.
+    override fun decorate(
+        linkAnnotation: LinkAnnotation,
+        start: Int,
+        end: Int,
+        text: AnnotatedString,
+        builder: AnnotatedString.Builder,
+    ): LinkAnnotation = linkAnnotation
+
+    override fun drawInstructionsFor(layoutResult: TextLayoutResult, color: Color?): SpanDrawInstructions {
+        val text = layoutResult.layoutInput.text
+        val annotations = text.getStringAnnotations(TAG, start = 0, end = text.length)
+
+        return SpanDrawInstructions {
+            val radius = CornerRadius(cornerRadius.toPx())
+            val hPad = horizontalPadding.toPx()
+            val above = aboveBaseline.toPx()
+            val below = belowBaseline.toPx()
+
+            annotations.fastForEach { annotation ->
+                val boxes = layoutResult.getBoundingBoxes(annotation.start, annotation.end)
+                boxes.fastForEachIndexed { index, box ->
+                    val line = layoutResult.getLineForVerticalPosition((box.top + box.bottom) / 2f)
+                    val baseline = layoutResult.getLineBaseline(line)
+                    path.rewind()
+                    path.addRoundRect(
+                        RoundRect(
+                            rect = Rect(
+                                left = box.left - hPad,
+                                top = baseline - above,
+                                right = box.right + hPad,
+                                bottom = baseline + below,
+                            ),
+                            // Round only the outer corners so a wrapped chip reads as one shape.
+                            topLeft = if (index == 0) radius else CornerRadius.Zero,
+                            bottomLeft = if (index == 0) radius else CornerRadius.Zero,
+                            topRight = if (index == boxes.lastIndex) radius else CornerRadius.Zero,
+                            bottomRight = if (index == boxes.lastIndex) radius else CornerRadius.Zero,
+                        ),
+                    )
+                    drawPath(path = path, color = chipColor, style = Fill)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "inline_code_chip"
+    }
+}


### PR DESCRIPTION
Two bits of UI polish. No behavior changes; `:app:assembleDebug` + `:app:lintDebug` + `:app:testDebugUnitTest` (42 tests) green.

## Theme the onboarding illustration — Closes #31
The first-run cake illustration rendered with its hardcoded Storyset palette, clashing with the dynamic Material You colors used everywhere else. Recolored at the **Compose layer** (framework `Theme.Cron` can't expose the dynamic palette to a `?attr/` drawable):

- **`ImageVector.recolored { }`** (`ui/components/RecoloredVector.kt`) — rebuilds a vector, remapping `SolidColor` fills onto new colors while preserving `pathData`/`fillAlpha`/strokes.
- **`OnboardingHint`** maps the cake's five source fills onto `colorScheme` as a tonal ramp: body → `primary`, frosting → blend toward white, shadows/accents → blend toward black, ground → `surfaceVariant`. Tracks the palette in light **and** dark with no role inversion.
- **Dark mode** builds the body in HSL (accent hue, saturation floor, deep lightness) so the cake layers read as a *tinted* accent distinct from the near-white frosting, instead of greying out (dark `primary` is a light, low-chroma pastel).
- Adds a **light + dark `@Preview`** for `OnboardingHint` — verifiable with no emulator.

> The preview shows the muted fallback accent (a warm amber once saturated); on a Material You device the cake tracks the wallpaper accent. `CAKE_DARK_SAT_FLOOR` / `CAKE_DARK_BODY_LIGHTNESS` are the tuning dials.

## Scale inline code to the serif body
Martian Mono reads larger than EB Garamond at the same point size, so inline `code` spans towered over the AI response prose. `CODE_FONT_SCALE 0.78 → 0.68` brings inline/block code flush with the surrounding serif.