### PR TITLE
feat: SSE streaming in AnthropicClient

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -166,6 +166,7 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.mockk)
     testImplementation(libs.turbine)
+    testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.androidx.room.testing)
     testImplementation(libs.androidx.work.testing)

--- a/app/src/main/java/fr/bsodium/cron/ai/AnthropicClient.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/AnthropicClient.kt
@@ -1,10 +1,14 @@
 package fr.bsodium.cron.ai
 
+import android.util.Log
+import fr.bsodium.cron.ai.wire.ContentBlock
 import fr.bsodium.cron.ai.wire.ErrorEnvelope
 import fr.bsodium.cron.ai.wire.MessagesRequest
 import fr.bsodium.cron.ai.wire.MessagesResponse
+import fr.bsodium.cron.ai.wire.StreamEvent
 import fr.bsodium.cron.session.db.SessionJson
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import okhttp3.MediaType.Companion.toMediaType
@@ -12,6 +16,24 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.util.concurrent.TimeUnit
+
+/**
+ * Network seam for the Anthropic Messages API: a blocking [send] and an SSE [stream]. The
+ * [TurnRunner] depends on this interface so tests can swap in a fake without a live server.
+ */
+interface AnthropicMessages {
+    suspend fun send(request: MessagesRequest): MessagesResponse
+
+    /**
+     * Streams [request] (forcing `stream = true`), invoking [onPartial] with the blocks decoded
+     * so far as deltas arrive, and returns the fully reassembled message — identical in shape to
+     * what [send] would return for the same request.
+     */
+    suspend fun stream(
+        request: MessagesRequest,
+        onPartial: suspend (List<ContentBlock>) -> Unit,
+    ): MessagesResponse
+}
 
 /**
  * Thin client around the Anthropic Messages API.
@@ -22,36 +44,65 @@ import java.util.concurrent.TimeUnit
 class AnthropicClient(
     private val apiKeyProvider: () -> String?,
     private val client: OkHttpClient = defaultHttpClient(),
-) {
+    private val messagesUrl: String = MESSAGES_URL,
+) : AnthropicMessages {
 
-    suspend fun send(request: MessagesRequest): MessagesResponse = withContext(Dispatchers.IO) {
-        val apiKey = apiKeyProvider()
-            ?: throw MissingApiKeyException()
+    override suspend fun send(request: MessagesRequest): MessagesResponse = withContext(Dispatchers.IO) {
+        client.newCall(buildRequest(request)).execute().use { response ->
+            val raw = response.body.string()
+            if (!response.isSuccessful) throw httpException(response.code, raw)
+            SessionJson.decodeFromString(raw)
+        }
+    }
 
-        val body = SessionJson.encodeToString(request)
-            .toRequestBody(JSON_MEDIA_TYPE)
+    override suspend fun stream(
+        request: MessagesRequest,
+        onPartial: suspend (List<ContentBlock>) -> Unit,
+    ): MessagesResponse = withContext(Dispatchers.IO) {
+        client.newCall(buildRequest(request.copy(stream = true))).execute().use { response ->
+            if (!response.isSuccessful) throw httpException(response.code, response.body.string())
 
-        val httpRequest = Request.Builder()
-            .url(MESSAGES_URL)
+            val accumulator = StreamAccumulator()
+            val source = response.body.source()
+            while (true) {
+                ensureActive() // let a cancelled turn (user cancel / WorkManager stop) break the read
+                val line = source.readUtf8Line() ?: break
+                if (!line.startsWith(DATA_PREFIX)) continue // event:/id:/comment/blank lines
+                val payload = line.removePrefix(DATA_PREFIX).trim()
+                val event = runCatching { SessionJson.decodeFromString<StreamEvent>(payload) }
+                    .onFailure { Log.w(TAG, "drop unparseable stream event: ${payload.take(120)}", it) }
+                    .getOrNull() ?: continue
+                val terminal = accumulator.apply(event)
+                if (event is StreamEvent.ContentBlockStart || event is StreamEvent.ContentBlockDelta) {
+                    onPartial(accumulator.snapshotBlocks())
+                }
+                if (terminal) break
+            }
+            accumulator.toResponse(fallbackModel = request.model)
+        }
+    }
+
+    private fun buildRequest(request: MessagesRequest): Request {
+        val apiKey = apiKeyProvider() ?: throw MissingApiKeyException()
+        val body = SessionJson.encodeToString(request).toRequestBody(JSON_MEDIA_TYPE)
+        return Request.Builder()
+            .url(messagesUrl)
             .header("x-api-key", apiKey)
             .header("anthropic-version", "2023-06-01")
             .header("content-type", "application/json")
             .post(body)
             .build()
+    }
 
-        client.newCall(httpRequest).execute().use { response ->
-            val raw = response.body.string()
-            if (!response.isSuccessful) {
-                val parsed = runCatching { SessionJson.decodeFromString<ErrorEnvelope>(raw) }
-                    .getOrNull()
-                throw AnthropicHttpException(
-                    code = response.code,
-                    type = parsed?.error?.type,
-                    message = parsed?.error?.message ?: raw.take(500),
-                )
-            }
-            SessionJson.decodeFromString(raw)
-        }
+    private fun httpException(code: Int, raw: String): AnthropicHttpException {
+        val parsed = runCatching { SessionJson.decodeFromString<ErrorEnvelope>(raw) }
+            .onFailure { Log.w(TAG, "decode error envelope failed", it) }
+            .getOrNull()
+        return AnthropicHttpException(
+            code = code,
+            type = parsed?.error?.type,
+            message = parsed?.error?.message ?: raw.take(500),
+        )
     }
 
     class MissingApiKeyException : IllegalStateException("Anthropic API key is not configured")
@@ -65,12 +116,18 @@ class AnthropicClient(
     }
 
     companion object {
+        private const val TAG = "AnthropicClient"
+        private const val DATA_PREFIX = "data:"
         private const val MESSAGES_URL = "https://api.anthropic.com/v1/messages"
         private val JSON_MEDIA_TYPE = "application/json".toMediaType()
 
+        /**
+         * The 120s read timeout is per-read; on a stream it bounds the gap *between* events, not the
+         * whole response. Anthropic's `ping` events keep the socket warm during long thinking pauses.
+         */
         fun defaultHttpClient(): OkHttpClient = OkHttpClient.Builder()
             .connectTimeout(15, TimeUnit.SECONDS)
-            .readTimeout(120, TimeUnit.SECONDS) // Anthropic responses can be slow
+            .readTimeout(120, TimeUnit.SECONDS)
             .writeTimeout(15, TimeUnit.SECONDS)
             .build()
     }

--- a/app/src/main/java/fr/bsodium/cron/ai/StreamAccumulator.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/StreamAccumulator.kt
@@ -1,0 +1,154 @@
+package fr.bsodium.cron.ai
+
+import fr.bsodium.cron.ai.wire.ContentBlock
+import fr.bsodium.cron.ai.wire.Delta
+import fr.bsodium.cron.ai.wire.MessagesResponse
+import fr.bsodium.cron.ai.wire.StreamEvent
+import fr.bsodium.cron.ai.wire.Usage
+import fr.bsodium.cron.session.db.SessionJson
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Reassembles a streamed Anthropic message from [StreamEvent]s into a [MessagesResponse],
+ * so a streaming turn hands the [TurnRunner] the same shape a blocking `send()` would.
+ *
+ * Pure and non-suspending — no OkHttp, so it's unit-testable in isolation. One instance per
+ * round-trip (a retry constructs a fresh accumulator, never replaying prior deltas).
+ */
+class StreamAccumulator {
+
+    private val builders = mutableListOf<BlockBuilder>()
+    private var messageId: String? = null
+    private var role: String? = null
+    private var streamModel: String? = null
+    private var stopReason: String? = null
+    private var usage = Usage()
+
+    /** Feeds one event into the running state; returns true once the stream is terminal. */
+    fun apply(event: StreamEvent): Boolean = when (event) {
+        is StreamEvent.MessageStart -> {
+            messageId = event.message.id
+            role = event.message.role
+            streamModel = event.message.model
+            event.message.usage?.let { usage = it }
+            builders.clear()
+            false
+        }
+        is StreamEvent.ContentBlockStart -> {
+            setBuilder(event.index, BlockBuilder.from(event.content_block))
+            false
+        }
+        is StreamEvent.ContentBlockDelta -> {
+            builders.getOrNull(event.index)?.apply(event.delta)
+            false
+        }
+        is StreamEvent.ContentBlockStop -> false
+        is StreamEvent.MessageDelta -> {
+            event.delta.stop_reason?.let { stopReason = it }
+            event.usage?.let { usage = usage.copy(output_tokens = it.output_tokens) }
+            false
+        }
+        is StreamEvent.MessageStop -> true
+        is StreamEvent.Ping -> false
+        // Mid-stream errors (e.g. overloaded_error) arrive after a 200; map to 529 so the
+        // runner's retry wrapper treats them as retryable, just like a pre-stream 529.
+        is StreamEvent.Error -> throw AnthropicClient.AnthropicHttpException(
+            code = 529,
+            type = event.error.type,
+            message = event.error.message,
+        )
+    }
+
+    /** Blocks accumulated so far, for live UI rendering. Tool input is parsed leniently. */
+    fun snapshotBlocks(): List<ContentBlock> = builders.mapNotNull { it.toContentBlock(strict = false) }
+
+    /**
+     * The finished message. Throws a retryable [AnthropicClient.AnthropicHttpException] if the
+     * stream ended before a `stop_reason` (truncated socket) — the round-trip is then retried.
+     */
+    fun toResponse(fallbackModel: String): MessagesResponse {
+        val reason = stopReason ?: throw AnthropicClient.AnthropicHttpException(
+            code = 503,
+            type = "incomplete_stream",
+            message = "stream ended before stop_reason",
+        )
+        return MessagesResponse(
+            id = messageId.orEmpty(),
+            model = streamModel ?: fallbackModel,
+            role = role ?: "assistant",
+            content = builders.mapNotNull { it.toContentBlock(strict = true) },
+            stop_reason = reason,
+            usage = usage,
+        )
+    }
+
+    private fun setBuilder(index: Int, builder: BlockBuilder) {
+        while (builders.size <= index) builders.add(BlockBuilder("text"))
+        builders[index] = builder
+    }
+}
+
+/** Mutable per-index scratch for one content block as its deltas arrive. */
+private class BlockBuilder(private val type: String) {
+    private val text = StringBuilder()
+    private val partialJson = StringBuilder()
+    private var toolId: String? = null
+    private var toolName: String? = null
+    private var initialInput: JsonElement? = null
+    private var signature: String? = null
+
+    fun apply(delta: Delta) {
+        when (delta) {
+            is Delta.TextDelta -> text.append(delta.text)
+            is Delta.ThinkingDelta -> text.append(delta.thinking)
+            is Delta.InputJsonDelta -> partialJson.append(delta.partial_json)
+            is Delta.SignatureDelta -> signature = delta.signature
+        }
+    }
+
+    /** [strict] = the final pass: a tool_use whose accumulated input won't parse is a corrupt stream. */
+    fun toContentBlock(strict: Boolean): ContentBlock? = when (type) {
+        "text" -> ContentBlock.Text(text.toString())
+        "thinking" -> ContentBlock.Thinking(thinking = text.toString(), signature = signature)
+        "tool_use" -> buildToolUse(strict)
+        else -> null // tool_result is never model-emitted; unknown future types are skipped.
+    }
+
+    private fun buildToolUse(strict: Boolean): ContentBlock.ToolUse? {
+        val id = toolId
+        val name = toolName
+        if (id == null || name == null) {
+            if (strict) throw AnthropicClient.AnthropicHttpException(503, "incomplete_stream", "tool_use missing id/name")
+            return null
+        }
+        return ContentBlock.ToolUse(id = id, name = name, input = resolveInput(strict))
+    }
+
+    private fun resolveInput(strict: Boolean): JsonElement {
+        val raw = partialJson.toString()
+        if (raw.isBlank()) return initialInput ?: EMPTY_OBJECT
+        return runCatching { SessionJson.parseToJsonElement(raw) }.getOrElse {
+            if (strict) throw AnthropicClient.AnthropicHttpException(503, "incomplete_stream", "tool_use input not valid JSON")
+            initialInput ?: EMPTY_OBJECT
+        }
+    }
+
+    companion object {
+        private val EMPTY_OBJECT = JsonObject(emptyMap())
+
+        fun from(block: ContentBlock): BlockBuilder = when (block) {
+            is ContentBlock.Text -> BlockBuilder("text").also { it.text.append(block.text) }
+            is ContentBlock.Thinking -> BlockBuilder("thinking").also {
+                it.text.append(block.thinking)
+                it.signature = block.signature
+            }
+            is ContentBlock.ToolUse -> BlockBuilder("tool_use").also {
+                it.toolId = block.id
+                it.toolName = block.name
+                it.initialInput = block.input
+            }
+            is ContentBlock.ToolResult -> BlockBuilder("tool_result")
+        }
+    }
+}

--- a/app/src/main/java/fr/bsodium/cron/ai/wire/AnthropicStream.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/wire/AnthropicStream.kt
@@ -1,0 +1,85 @@
+package fr.bsodium.cron.ai.wire
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Server-sent events emitted by the Anthropic Messages API when `stream = true`.
+ * https://docs.anthropic.com/en/api/messages-streaming
+ *
+ * Modelled as its own sealed root on kotlinx's default `"type"` discriminator — wire-faithful
+ * and independent of [ContentBlock], which shares the same discriminator without colliding
+ * (each sealed root resolves its discriminator from its own declaration). Field names mirror the
+ * snake_case wire shape, matching [MessagesRequest]/[MessagesResponse]. Unknown keys (and event
+ * types we don't model) are tolerated by [fr.bsodium.cron.session.db.SessionJson].
+ */
+@Serializable
+sealed class StreamEvent {
+
+    @Serializable
+    @SerialName("message_start")
+    data class MessageStart(val message: MessageStartInfo) : StreamEvent()
+
+    @Serializable
+    @SerialName("content_block_start")
+    data class ContentBlockStart(val index: Int, val content_block: ContentBlock) : StreamEvent()
+
+    @Serializable
+    @SerialName("content_block_delta")
+    data class ContentBlockDelta(val index: Int, val delta: Delta) : StreamEvent()
+
+    @Serializable
+    @SerialName("content_block_stop")
+    data class ContentBlockStop(val index: Int) : StreamEvent()
+
+    @Serializable
+    @SerialName("message_delta")
+    data class MessageDelta(val delta: MessageDeltaInfo, val usage: Usage? = null) : StreamEvent()
+
+    @Serializable
+    @SerialName("message_stop")
+    data object MessageStop : StreamEvent()
+
+    @Serializable
+    @SerialName("ping")
+    data object Ping : StreamEvent()
+
+    @Serializable
+    @SerialName("error")
+    data class Error(val error: ApiError) : StreamEvent()
+}
+
+@Serializable
+data class MessageStartInfo(
+    val id: String,
+    val model: String,
+    val role: String,
+    val usage: Usage? = null,
+)
+
+@Serializable
+data class MessageDeltaInfo(
+    val stop_reason: String? = null,
+    val stop_sequence: String? = null,
+)
+
+/** Incremental update to the content block at a given index. */
+@Serializable
+sealed class Delta {
+
+    @Serializable
+    @SerialName("text_delta")
+    data class TextDelta(val text: String) : Delta()
+
+    @Serializable
+    @SerialName("thinking_delta")
+    data class ThinkingDelta(val thinking: String) : Delta()
+
+    @Serializable
+    @SerialName("input_json_delta")
+    data class InputJsonDelta(val partial_json: String) : Delta()
+
+    @Serializable
+    @SerialName("signature_delta")
+    data class SignatureDelta(val signature: String) : Delta()
+}

--- a/app/src/main/java/fr/bsodium/cron/ai/wire/AnthropicWire.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/wire/AnthropicWire.kt
@@ -23,6 +23,8 @@ data class MessagesRequest(
     val tool_choice: ToolChoice? = null,
     val temperature: Double? = null,
     val thinking: ThinkingConfig? = null,
+    /** Opt into SSE streaming. Omitted from the wire when null (explicitNulls = false). */
+    val stream: Boolean? = null,
 )
 
 @Serializable

--- a/app/src/test/java/fr/bsodium/cron/ai/AnthropicClientStreamTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ai/AnthropicClientStreamTest.kt
@@ -1,0 +1,126 @@
+package fr.bsodium.cron.ai
+
+import fr.bsodium.cron.ai.wire.ContentBlock
+import fr.bsodium.cron.ai.wire.MessageInput
+import fr.bsodium.cron.ai.wire.MessagesRequest
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AnthropicClientStreamTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() = server.shutdown()
+
+    private fun client() = AnthropicClient(
+        apiKeyProvider = { "key" },
+        client = AnthropicClient.defaultHttpClient(),
+        messagesUrl = server.url("/v1/messages").toString(),
+    )
+
+    private val request = MessagesRequest(
+        model = "claude-haiku-4-5",
+        max_tokens = 64,
+        messages = listOf(MessageInput(role = "user", content = listOf(ContentBlock.Text("hi")))),
+    )
+
+    @Test
+    fun stream_emits_growing_partials_and_returns_full_message() = runTest {
+        server.enqueue(MockResponse().setHeader("Content-Type", "text/event-stream").setBody(TEXT_STREAM))
+
+        val partials = mutableListOf<List<ContentBlock>>()
+        val response = client().stream(request) { partials.add(it) }
+
+        assertEquals("end_turn", response.stop_reason)
+        assertEquals(listOf(ContentBlock.Text("Hello world")), response.content)
+        assertEquals(5, response.usage?.output_tokens)
+
+        // Partials accumulate: text length is monotonic and the last one holds the full answer.
+        val lengths = partials.map { (it.firstOrNull() as? ContentBlock.Text)?.text?.length ?: 0 }
+        assertTrue(lengths.isNotEmpty())
+        assertEquals(lengths.sorted(), lengths)
+        assertEquals("Hello world", (partials.last().single() as ContentBlock.Text).text)
+
+        assertTrue(server.takeRequest().body.readUtf8().contains("\"stream\":true"))
+    }
+
+    @Test
+    fun http_429_maps_to_retryable_exception() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(429)
+                .setBody("""{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}"""),
+        )
+        val error = runCatching { client().stream(request) {} }.exceptionOrNull()
+        assertTrue(error is AnthropicClient.AnthropicHttpException)
+        error as AnthropicClient.AnthropicHttpException
+        assertEquals(429, error.code)
+        assertEquals("rate_limit_error", error.type)
+        assertTrue(error.isRetryable)
+    }
+
+    @Test
+    fun mid_stream_error_event_throws_retryable() = runTest {
+        server.enqueue(MockResponse().setHeader("Content-Type", "text/event-stream").setBody(ERROR_STREAM))
+        val error = runCatching { client().stream(request) {} }.exceptionOrNull()
+        assertTrue(error is AnthropicClient.AnthropicHttpException)
+        assertEquals(529, (error as AnthropicClient.AnthropicHttpException).code)
+        assertTrue(error.isRetryable)
+    }
+
+    private companion object {
+        val TEXT_STREAM = """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_1","model":"claude-haiku-4-5","role":"assistant","usage":{"input_tokens":10,"output_tokens":1}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello "}}
+
+            event: ping
+            data: {"type":"ping"}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+        """.trimIndent()
+
+        val ERROR_STREAM = """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_2","model":"claude-haiku-4-5","role":"assistant"}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+            event: error
+            data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
+
+        """.trimIndent()
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/ai/StreamAccumulatorTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ai/StreamAccumulatorTest.kt
@@ -1,0 +1,109 @@
+package fr.bsodium.cron.ai
+
+import fr.bsodium.cron.ai.wire.ContentBlock
+import fr.bsodium.cron.ai.wire.Delta
+import fr.bsodium.cron.ai.wire.MessageDeltaInfo
+import fr.bsodium.cron.ai.wire.MessageStartInfo
+import fr.bsodium.cron.ai.wire.StreamEvent
+import fr.bsodium.cron.ai.wire.Usage
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StreamAccumulatorTest {
+
+    private fun start(usageInput: Int = 7) = StreamEvent.MessageStart(
+        MessageStartInfo(id = "msg_1", model = "claude-haiku-4-5", role = "assistant", usage = Usage(input_tokens = usageInput, output_tokens = 1)),
+    )
+
+    private fun blockStart(index: Int, block: ContentBlock) = StreamEvent.ContentBlockStart(index, block)
+    private fun delta(index: Int, d: Delta) = StreamEvent.ContentBlockDelta(index, d)
+    private fun stopMessage(reason: String = "end_turn", out: Int = 5) =
+        StreamEvent.MessageDelta(MessageDeltaInfo(stop_reason = reason), Usage(output_tokens = out))
+
+    @Test
+    fun text_turn_reassembles_into_one_text_block() {
+        val acc = StreamAccumulator()
+        acc.apply(start())
+        acc.apply(blockStart(0, ContentBlock.Text("")))
+        acc.apply(delta(0, Delta.TextDelta("Hel")))
+        acc.apply(delta(0, Delta.TextDelta("lo")))
+        acc.apply(StreamEvent.ContentBlockStop(0))
+        acc.apply(stopMessage(out = 12))
+        assertTrue(acc.apply(StreamEvent.MessageStop))
+
+        val response = acc.toResponse(fallbackModel = "fallback")
+        assertEquals("msg_1", response.id)
+        assertEquals("assistant", response.role)
+        assertEquals("claude-haiku-4-5", response.model)
+        assertEquals("end_turn", response.stop_reason)
+        assertEquals(listOf(ContentBlock.Text("Hello")), response.content)
+        assertEquals(7, response.usage?.input_tokens)
+        assertEquals(12, response.usage?.output_tokens)
+    }
+
+    @Test
+    fun thinking_signature_is_preserved() {
+        val acc = StreamAccumulator()
+        acc.apply(start())
+        acc.apply(blockStart(0, ContentBlock.Thinking(thinking = "")))
+        acc.apply(delta(0, Delta.ThinkingDelta("rea")))
+        acc.apply(delta(0, Delta.ThinkingDelta("soning")))
+        acc.apply(delta(0, Delta.SignatureDelta("sig-abc")))
+        acc.apply(stopMessage())
+        acc.apply(StreamEvent.MessageStop)
+
+        val thinking = acc.toResponse("m").content.single() as ContentBlock.Thinking
+        assertEquals("reasoning", thinking.thinking)
+        assertEquals("sig-abc", thinking.signature)
+    }
+
+    @Test
+    fun tool_use_input_accumulates_across_fragments() {
+        val acc = StreamAccumulator()
+        acc.apply(start())
+        acc.apply(blockStart(0, ContentBlock.ToolUse(id = "toolu_1", name = "set_alarm", input = JsonObject(emptyMap()))))
+        acc.apply(delta(0, Delta.InputJsonDelta("""{"time""")))
+
+        // Mid-stream the input is not yet valid JSON → lenient snapshot yields an empty object, never a throw.
+        val partial = acc.snapshotBlocks().single() as ContentBlock.ToolUse
+        assertEquals("toolu_1", partial.id)
+        assertTrue((partial.input as JsonObject).isEmpty())
+
+        acc.apply(delta(0, Delta.InputJsonDelta("""":"06:40"}""")))
+        acc.apply(stopMessage())
+        acc.apply(StreamEvent.MessageStop)
+
+        val tool = acc.toResponse("m").content.single() as ContentBlock.ToolUse
+        assertEquals("set_alarm", tool.name)
+        assertEquals("06:40", (tool.input as JsonObject)["time"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun mid_stream_error_throws_retryable() {
+        val acc = StreamAccumulator()
+        acc.apply(start())
+        val ex = assertThrows(AnthropicClient.AnthropicHttpException::class.java) {
+            acc.apply(StreamEvent.Error(fr.bsodium.cron.ai.wire.ApiError(type = "overloaded_error", message = "Overloaded")))
+        }
+        assertEquals(529, ex.code)
+        assertTrue(ex.isRetryable)
+    }
+
+    @Test
+    fun truncated_stream_without_stop_reason_throws_retryable() {
+        val acc = StreamAccumulator()
+        acc.apply(start())
+        acc.apply(blockStart(0, ContentBlock.Text("")))
+        acc.apply(delta(0, Delta.TextDelta("partial")))
+        // socket closed: no message_delta / message_stop
+        val ex = assertThrows(AnthropicClient.AnthropicHttpException::class.java) {
+            acc.toResponse(fallbackModel = "m")
+        }
+        assertEquals(503, ex.code)
+        assertTrue(ex.isRetryable)
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/ai/wire/AnthropicStreamTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ai/wire/AnthropicStreamTest.kt
@@ -1,0 +1,93 @@
+package fr.bsodium.cron.ai.wire
+
+import fr.bsodium.cron.session.db.SessionJson
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Decodes representative `data:` payloads to prove the `"type"` discriminators resolve and the
+ *  load-bearing fields (tool id/name, partial_json, signature, stop_reason) survive. */
+class AnthropicStreamTest {
+
+    private inline fun <reified T> decode(json: String): T = SessionJson.decodeFromString<T>(json)
+
+    @Test
+    fun message_start_carries_id_role_usage() {
+        val event = decode<StreamEvent>(
+            """{"type":"message_start","message":{"id":"msg_1","model":"claude-haiku-4-5","role":"assistant","usage":{"input_tokens":10,"output_tokens":1}}}""",
+        )
+        event as StreamEvent.MessageStart
+        assertEquals("msg_1", event.message.id)
+        assertEquals("assistant", event.message.role)
+        assertEquals(10, event.message.usage?.input_tokens)
+    }
+
+    @Test
+    fun content_block_start_decodes_tool_use_id_and_name() {
+        val event = decode<StreamEvent>(
+            """{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"set_alarm","input":{}}}""",
+        )
+        event as StreamEvent.ContentBlockStart
+        assertEquals(1, event.index)
+        val block = event.content_block as ContentBlock.ToolUse
+        assertEquals("toolu_1", block.id)
+        assertEquals("set_alarm", block.name)
+    }
+
+    @Test
+    fun every_delta_variant_resolves() {
+        assertEquals("Hi", (delta("""{"type":"text_delta","text":"Hi"}""") as Delta.TextDelta).text)
+        assertEquals("hmm", (delta("""{"type":"thinking_delta","thinking":"hmm"}""") as Delta.ThinkingDelta).thinking)
+        assertEquals("""{"x":1}""", (delta("""{"type":"input_json_delta","partial_json":"{\"x\":1}"}""") as Delta.InputJsonDelta).partial_json)
+        assertEquals("sig==", (delta("""{"type":"signature_delta","signature":"sig=="}""") as Delta.SignatureDelta).signature)
+    }
+
+    private fun delta(json: String): Delta =
+        (decode<StreamEvent>("""{"type":"content_block_delta","index":0,"delta":$json}""") as StreamEvent.ContentBlockDelta).delta
+
+    @Test
+    fun message_delta_carries_stop_reason_and_output_tokens() {
+        val event = decode<StreamEvent>(
+            """{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":42}}""",
+        )
+        event as StreamEvent.MessageDelta
+        assertEquals("end_turn", event.delta.stop_reason)
+        assertEquals(42, event.usage?.output_tokens)
+    }
+
+    @Test
+    fun terminal_and_control_events_decode_as_objects() {
+        assertTrue(decode<StreamEvent>("""{"type":"message_stop"}""") is StreamEvent.MessageStop)
+        assertTrue(decode<StreamEvent>("""{"type":"ping"}""") is StreamEvent.Ping)
+    }
+
+    @Test
+    fun error_event_carries_type_and_message() {
+        val event = decode<StreamEvent>(
+            """{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}""",
+        )
+        event as StreamEvent.Error
+        assertEquals("overloaded_error", event.error.type)
+        assertEquals("Overloaded", event.error.message)
+    }
+
+    @Test
+    fun unknown_keys_in_content_block_start_are_tolerated() {
+        // message_start sends a full message object with extra fields (content, stop_reason …).
+        val event = decode<StreamEvent>(
+            """{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""},"extra":"ignored"}""",
+        )
+        assertTrue(event is StreamEvent.ContentBlockStart)
+    }
+
+    @Test
+    fun input_json_partial_is_raw_string_not_reparsed() {
+        // The fragment is an incomplete JSON string; it must round-trip verbatim, not as an object.
+        val d = delta("""{"type":"input_json_delta","partial_json":"{\"address\":\"1 Infi"}""") as Delta.InputJsonDelta
+        assertEquals("""{"address":"1 Infi""", d.partial_json)
+        // sanity: it is genuinely not yet valid JSON
+        assertTrue(runCatching { SessionJson.parseToJsonElement(d.partial_json).jsonObject["address"]?.jsonPrimitive }.isFailure)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx"
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
## What

Adds SSE streaming to the network layer (the foundation for streaming assistant responses end-to-end). Not yet user-visible — `TurnRunner` still calls `send()`; this PR only lands the `stream()` seam and its tests.

- **`MessagesRequest.stream`** — opt-in `stream: Boolean? = null` (omitted on the wire when null).
- **`AnthropicStream.kt`** — `StreamEvent` / `Delta` SSE DTOs on kotlinx's default `"type"` discriminator, wire-faithful and independent of `ContentBlock` (no collision).
- **`StreamAccumulator.kt`** — pure, non-suspending reassembly of `data:` events into a `MessagesResponse`. Per-index block builders concat text/thinking, accumulate `tool_use` `partial_json` (lenient mid-stream, strict at the end), and **preserve thinking `signature`s** (load-bearing for tool-use-after-thinking follow-ups). Mid-stream `error` events → `529`; truncated streams (no `stop_reason`) → `503` — both retryable.
- **`AnthropicClient.stream(request, onPartial)`** — posts with `stream=true`, reads `body.source()` line-by-line with `ensureActive()` (so a cancelled turn breaks the read), and returns the same `MessagesResponse` shape `send()` would. `onPartial` reports blocks-so-far for live rendering. The 120s read timeout is now *inter-event* (Anthropic `ping`s keep the socket warm).
- **`AnthropicMessages`** interface seam so `TurnRunner` (next PR) can be unit-tested with a fake.

## Tests

- `AnthropicStreamTest` — every `StreamEvent` / `Delta` variant decodes; tool id/name, `partial_json`, `signature`, `stop_reason` survive.
- `StreamAccumulatorTest` — text turn; thinking + signature preserved; multi-fragment tool input; mid-stream error → retryable 529; truncation → retryable 503.
- `AnthropicClientStreamTest` (**MockWebServer**) — growing partials + full message; `stream=true` on the wire; 429 and mid-stream error map to retryable exceptions.

Green locally: `:app:testDebugUnitTest :app:checkFileLength :app:lintDebug :app:assembleDebug`.

Part of #15. Closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)