### PR TITLE
feat: reactive emission of in-flight AI turns

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ai/StreamingTurnStore.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/StreamingTurnStore.kt
@@ -1,0 +1,43 @@
+package fr.bsodium.cron.ai
+
+import fr.bsodium.cron.ai.wire.ContentBlock
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** The blocks of the actively-streaming turn so far; rebuilt into the home thread for live rendering. */
+data class StreamingTurn(
+    val sessionId: String,
+    val turnIndex: Int,
+    val blocks: List<ContentBlock>,
+    val startedAtMs: Long,
+)
+
+/**
+ * Process-wide hand-off of the in-flight turn from the [TurnRunner] (running in the WorkManager
+ * worker) to the home UI. Worker and UI share the default process, so a singleton [StateFlow] is a
+ * valid channel — mirrors [fr.bsodium.cron.sensors.DebugSensorEventSink].
+ *
+ * Partials are ephemeral by design: only complete messages are persisted to Room, so process death
+ * drops the in-memory partial while the DB-backed settled state stays the source of truth.
+ */
+object StreamingTurnStore {
+    private val _active = MutableStateFlow<StreamingTurn?>(null)
+    val active: StateFlow<StreamingTurn?> = _active.asStateFlow()
+
+    fun update(turn: StreamingTurn) {
+        _active.value = turn
+    }
+
+    /**
+     * Clears the partial for [sessionId]/[turnIndex] — but only if it's still the active one, so a
+     * REPLACE-enqueued worker that already started a newer turn can't be cleared by the old one's
+     * `finally`.
+     */
+    fun clear(sessionId: String, turnIndex: Int) {
+        val current = _active.value
+        if (current?.sessionId == sessionId && current.turnIndex == turnIndex) {
+            _active.value = null
+        }
+    }
+}

--- a/app/src/main/java/fr/bsodium/cron/ai/TurnRunner.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/TurnRunner.kt
@@ -30,7 +30,7 @@ import kotlin.math.min
  * Retries on 429 / 5xx with exponential backoff, capped at [maxRetries].
  */
 class TurnRunner(
-    private val client: AnthropicClient,
+    private val client: AnthropicMessages,
     private val aiMessageDao: AiMessageDao,
     private val model: String,
     private val systemPrompt: String,
@@ -62,43 +62,66 @@ class TurnRunner(
         turnIndex: Int,
         initialUserMessage: String,
     ): Outcome {
+        val startedAtMs = Clock.System.now().toEpochMilliseconds()
         val messages = loadOrSeed(sessionId, turnIndex, initialUserMessage).toMutableList()
+        // The turn's renderable blocks so far (assistant content + tool_result, never the user prompt),
+        // seeded from any already-persisted messages on resume. Streamed deltas append onto this.
+        var committedBlocks = renderableBlocks(messages)
         var aggregateUsage = Usage()
 
-        repeat(maxRoundTrips) { round ->
-            val request = MessagesRequest(
-                model = model,
-                max_tokens = maxTokens,
-                system = systemPrompt,
-                messages = messages.toList(),
-                tools = tools.definitions,
-                tool_choice = toolChoice,
-                thinking = thinking,
-            )
+        return try {
+            repeat(maxRoundTrips) { round ->
+                val request = MessagesRequest(
+                    model = model,
+                    max_tokens = maxTokens,
+                    system = systemPrompt,
+                    messages = messages.toList(),
+                    tools = tools.definitions,
+                    tool_choice = toolChoice,
+                    thinking = thinking,
+                )
 
-            val response = sendWithRetries(request)
-            aggregateUsage = aggregateUsage.plus(response.usage)
+                val response = streamWithRetries(sessionId, turnIndex, request, committedBlocks, startedAtMs)
+                aggregateUsage = aggregateUsage.plus(response.usage)
 
-            // Persist assistant message.
-            val assistantBlocks = response.content
-            persistMessage(sessionId, turnIndex, role = "assistant", blocks = assistantBlocks)
-            messages.add(MessageInput(role = "assistant", content = assistantBlocks))
+                // Persist assistant message (complete — keeps resume safe), then settle the partial.
+                val assistantBlocks = response.content
+                persistMessage(sessionId, turnIndex, role = "assistant", blocks = assistantBlocks)
+                messages.add(MessageInput(role = "assistant", content = assistantBlocks))
+                committedBlocks = committedBlocks + assistantBlocks
+                publish(sessionId, turnIndex, committedBlocks, startedAtMs)
 
-            val toolUses = assistantBlocks.filterIsInstance<ContentBlock.ToolUse>()
-            if (toolUses.isEmpty() || response.stop_reason == "end_turn") {
-                return Outcome.Completed(response, aggregateUsage)
+                val toolUses = assistantBlocks.filterIsInstance<ContentBlock.ToolUse>()
+                if (toolUses.isEmpty() || response.stop_reason == "end_turn") {
+                    return Outcome.Completed(response, aggregateUsage)
+                }
+
+                // Execute every tool_use block emitted in this assistant message.
+                val toolResults: List<ContentBlock> = toolUses.map { call ->
+                    executeToolCall(call)
+                }
+
+                persistMessage(sessionId, turnIndex, role = "user", blocks = toolResults)
+                messages.add(MessageInput(role = "user", content = toolResults))
+                committedBlocks = committedBlocks + toolResults
+                publish(sessionId, turnIndex, committedBlocks, startedAtMs)
             }
 
-            // Execute every tool_use block emitted in this assistant message.
-            val toolResults: List<ContentBlock> = toolUses.map { call ->
-                executeToolCall(call)
-            }
-
-            persistMessage(sessionId, turnIndex, role = "user", blocks = toolResults)
-            messages.add(MessageInput(role = "user", content = toolResults))
+            Outcome.BudgetExhausted(maxRoundTrips, aggregateUsage)
+        } finally {
+            StreamingTurnStore.clear(sessionId, turnIndex)
         }
+    }
 
-        return Outcome.BudgetExhausted(maxRoundTrips, aggregateUsage)
+    private fun publish(sessionId: String, turnIndex: Int, blocks: List<ContentBlock>, startedAtMs: Long) =
+        StreamingTurnStore.update(StreamingTurn(sessionId, turnIndex, blocks, startedAtMs))
+
+    /** Blocks the home thread renders: assistant content plus tool_result, excluding the user prompt. */
+    private fun renderableBlocks(messages: List<MessageInput>): List<ContentBlock> = buildList {
+        messages.forEach { message ->
+            if (message.role == "assistant") addAll(message.content)
+            else addAll(message.content.filterIsInstance<ContentBlock.ToolResult>())
+        }
     }
 
     private fun Usage.plus(other: Usage?): Usage {
@@ -133,13 +156,24 @@ class TurnRunner(
         )
     }
 
-    private suspend fun sendWithRetries(request: MessagesRequest): MessagesResponse {
+    private suspend fun streamWithRetries(
+        sessionId: String,
+        turnIndex: Int,
+        request: MessagesRequest,
+        committedBlocks: List<ContentBlock>,
+        startedAtMs: Long,
+    ): MessagesResponse {
         var attempt = 0
         while (true) {
             try {
-                return client.send(request)
+                return client.stream(request) { streamingBlocks ->
+                    publish(sessionId, turnIndex, committedBlocks + streamingBlocks, startedAtMs)
+                }
             } catch (e: AnthropicClient.AnthropicHttpException) {
                 if (!e.isRetryable || attempt >= maxRetries) throw e
+                // A fresh attempt re-streams from scratch — drop the half-streamed tail so the UI
+                // doesn't briefly show doubled text.
+                publish(sessionId, turnIndex, committedBlocks, startedAtMs)
                 val backoffMs = min(BASE_BACKOFF_MS shl attempt, MAX_BACKOFF_MS)
                 delay(backoffMs)
                 attempt++

--- a/app/src/test/java/fr/bsodium/cron/ai/StreamingTurnStoreTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ai/StreamingTurnStoreTest.kt
@@ -1,0 +1,51 @@
+package fr.bsodium.cron.ai
+
+import app.cash.turbine.test
+import fr.bsodium.cron.ai.wire.ContentBlock
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class StreamingTurnStoreTest {
+
+    /** The store is a process-wide singleton — reset it around each test. */
+    @Before
+    @After
+    fun reset() {
+        StreamingTurnStore.active.value?.let { StreamingTurnStore.clear(it.sessionId, it.turnIndex) }
+    }
+
+    private fun turn(sessionId: String, index: Int, text: String) =
+        StreamingTurn(sessionId, index, listOf(ContentBlock.Text(text)), startedAtMs = 0L)
+
+    @Test
+    fun active_emits_latest_update() = runTest {
+        StreamingTurnStore.active.test {
+            assertNull(awaitItem())
+            StreamingTurnStore.update(turn("s1", 0, "hi"))
+            assertEquals("hi", (awaitItem()?.blocks?.single() as ContentBlock.Text).text)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun clear_nulls_the_matching_turn() {
+        StreamingTurnStore.update(turn("s1", 0, "hi"))
+        StreamingTurnStore.clear("s1", 0)
+        assertNull(StreamingTurnStore.active.value)
+    }
+
+    @Test
+    fun clear_ignores_a_stale_turn_or_session() {
+        StreamingTurnStore.update(turn("s1", 1, "hi"))
+        // An older turn's finally must not wipe the newer active turn (REPLACE overlap).
+        StreamingTurnStore.clear("s1", 0)
+        assertEquals(1, StreamingTurnStore.active.value?.turnIndex)
+        // A different session's clear must not touch this one either.
+        StreamingTurnStore.clear("s2", 1)
+        assertEquals("s1", StreamingTurnStore.active.value?.sessionId)
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/ai/TurnRunnerStreamingTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ai/TurnRunnerStreamingTest.kt
@@ -1,0 +1,171 @@
+package fr.bsodium.cron.ai
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import fr.bsodium.cron.ai.wire.ContentBlock
+import fr.bsodium.cron.ai.wire.MessagesRequest
+import fr.bsodium.cron.ai.wire.MessagesResponse
+import fr.bsodium.cron.ai.wire.ToolDefinition
+import fr.bsodium.cron.ai.wire.Usage
+import fr.bsodium.cron.session.db.AiMessageDao
+import fr.bsodium.cron.session.db.CronDatabase
+import fr.bsodium.cron.session.db.SessionJson
+import fr.bsodium.cron.session.db.toEntity
+import fr.bsodium.cron.testutil.Fixtures
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class TurnRunnerStreamingTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var db: CronDatabase
+    private lateinit var dao: AiMessageDao
+
+    @Before
+    fun setUp() = runTest(dispatcher) {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext<Context>(),
+            CronDatabase::class.java,
+        ).setQueryExecutor(dispatcher.asExecutor())
+            .setTransactionExecutor(dispatcher.asExecutor())
+            .allowMainThreadQueries()
+            .build()
+        dao = db.aiMessageDao()
+        db.sessionDao().insert(Fixtures.session(id = "s1", date = LocalDate.parse("2026-05-22")).toEntity())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+        StreamingTurnStore.active.value?.let { StreamingTurnStore.clear(it.sessionId, it.turnIndex) }
+    }
+
+    @Test
+    fun single_round_trip_streams_growing_partials_then_persists_complete() = runTest(dispatcher) {
+        val fake = FakeAnthropic(
+            listOf(
+                Scripted(
+                    partials = listOf(listOf(ContentBlock.Text("Hel")), listOf(ContentBlock.Text("Hello"))),
+                    response = response(listOf(ContentBlock.Text("Hello")), stop = "end_turn"),
+                ),
+            ),
+        )
+
+        val outcome = runner(fake).run("s1", turnIndex = 0, initialUserMessage = "good evening")
+
+        assertTrue(outcome is TurnRunner.Outcome.Completed)
+        assertEquals(
+            listOf("Hel", "Hello"),
+            fake.published.map { (it.blocks.single() as ContentBlock.Text).text },
+        )
+        val rows = dao.findBySession("s1")
+        assertEquals(listOf("user", "assistant"), rows.map { it.role })
+        assertEquals(listOf(ContentBlock.Text("Hello")), decode(rows[1].contentJson))
+        assertNull(StreamingTurnStore.active.value)
+    }
+
+    @Test
+    fun tool_round_trip_accumulates_prior_blocks_and_round_trips_signature() = runTest(dispatcher) {
+        val thinking = ContentBlock.Thinking(thinking = "let me check", signature = "sig-xyz")
+        val toolUse = ContentBlock.ToolUse(id = "t1", name = "echo", input = JsonObject(emptyMap()))
+        val fake = FakeAnthropic(
+            listOf(
+                Scripted(
+                    partials = listOf(listOf(thinking)),
+                    response = response(listOf(thinking, toolUse), stop = "tool_use"),
+                ),
+                Scripted(
+                    partials = listOf(listOf(ContentBlock.Text("Do")), listOf(ContentBlock.Text("Done"))),
+                    response = response(listOf(ContentBlock.Text("Done")), stop = "end_turn"),
+                ),
+            ),
+        )
+
+        val outcome = runner(fake).run("s1", turnIndex = 0, initialUserMessage = "good evening")
+
+        assertTrue(outcome is TurnRunner.Outcome.Completed)
+        // The 2nd round-trip's partial carries the prior round-trip's blocks ahead of new text.
+        val lastPartial = fake.published.last().blocks
+        assertTrue(lastPartial.any { it is ContentBlock.ToolUse })
+        assertTrue(lastPartial.any { it is ContentBlock.ToolResult })
+        assertEquals("Done", (lastPartial.last() as ContentBlock.Text).text)
+
+        // DB holds complete messages only, in order.
+        val rows = dao.findBySession("s1")
+        assertEquals(listOf("user", "assistant", "user", "assistant"), rows.map { it.role })
+        rows.forEach { decode(it.contentJson) } // decoding without throwing proves each row is complete JSON
+
+        // The thinking signature is echoed back verbatim on the follow-up request.
+        val echoed = fake.requests[1].messages
+            .flatMap { it.content }
+            .filterIsInstance<ContentBlock.Thinking>()
+            .single()
+        assertEquals("sig-xyz", echoed.signature)
+        assertNull(StreamingTurnStore.active.value)
+    }
+
+    private fun runner(client: AnthropicMessages) = TurnRunner(
+        client = client,
+        aiMessageDao = dao,
+        model = "claude-haiku-4-5",
+        systemPrompt = "system",
+        tools = ToolRegistry(listOf(EchoTool())),
+        maxTokens = 1024,
+    )
+
+    private fun response(blocks: List<ContentBlock>, stop: String) = MessagesResponse(
+        id = "msg",
+        model = "claude-haiku-4-5",
+        role = "assistant",
+        content = blocks,
+        stop_reason = stop,
+        usage = Usage(output_tokens = 3),
+    )
+
+    private fun decode(json: String): List<ContentBlock> = SessionJson.decodeFromString(json)
+
+    private data class Scripted(val partials: List<List<ContentBlock>>, val response: MessagesResponse)
+
+    /** Plays a scripted stream per call; records the partial the runner published after each onPartial. */
+    private class FakeAnthropic(private val script: List<Scripted>) : AnthropicMessages {
+        val requests = mutableListOf<MessagesRequest>()
+        val published = mutableListOf<StreamingTurn>()
+        private var call = 0
+
+        override suspend fun send(request: MessagesRequest): MessagesResponse =
+            throw UnsupportedOperationException("streaming path only")
+
+        override suspend fun stream(
+            request: MessagesRequest,
+            onPartial: suspend (List<ContentBlock>) -> Unit,
+        ): MessagesResponse {
+            requests += request
+            val scripted = script[call++]
+            scripted.partials.forEach { partial ->
+                onPartial(partial)
+                StreamingTurnStore.active.value?.let { published += it }
+            }
+            return scripted.response
+        }
+    }
+
+    private class EchoTool : Tool {
+        override val definition = ToolDefinition(name = "echo", description = "echoes", input_schema = JsonObject(emptyMap()))
+        override suspend fun execute(input: JsonElement): ToolResult = ToolResult(payload = """{"ok":true}""")
+    }
+}


### PR DESCRIPTION
## What

Stacked on #62. Makes the turn runner stream and surfaces the in-flight turn through a process-wide reactive store — still not user-visible (the home UI doesn't read the store until the next PR).

- **`StreamingTurnStore`** — `object` singleton (mirrors `DebugSensorEventSink`) holding the actively-streaming turn's blocks as a `StateFlow<StreamingTurn?>`. `clear()` is **guarded** (only nulls if it's still the active turn) so a `REPLACE`-enqueued worker can't wipe a newer turn's partial.
- **`TurnRunner`** — `streamWithRetries()` calls `AnthropicClient.stream()`, publishing `committedBlocks + streaming deltas` as they arrive. Complete messages are persisted to Room exactly as before, so **resume stays safe and there's no schema change**. `committedBlocks` accumulates across round-trips (round 2's partial carries round 1's tool blocks), and the store is cleared in a `finally`. A retry drops the half-streamed tail so the UI never shows doubled text. Depends on the `AnthropicMessages` interface for testability.
- **`AiTurnWorker`** — unchanged (`AnthropicClient` *is* an `AnthropicMessages`).

## Tests

- `StreamingTurnStoreTest` (Turbine) — latest-wins emission; guarded clear ignores stale turn/session.
- `TurnRunnerStreamingTest` (fake `AnthropicMessages` + in-memory Room) — growing partials; round 2's partial carries round 1's `tool_use` + `tool_result`; DB holds complete messages only, in order; store cleared in `finally`; **thinking `signature` round-trips** onto the follow-up request.

Green locally: `:app:testDebugUnitTest :app:checkFileLength :app:lintDebug :app:assembleDebug`.

> Review/merge after #62. Part of #15. Closes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)