### PR TITLE
fix(ui): add Compose previews for the alarm screen and NextAlarmCard sleep state

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/screens/alarm/AlarmActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/alarm/AlarmActivity.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -130,7 +131,16 @@ private fun AlarmScreen(
             delay(1_000)
         }
     }
+    AlarmScreenContent(timeText = timeText, label = label, onDismiss = onDismiss, onSnooze = onSnooze)
+}
 
+@Composable
+private fun AlarmScreenContent(
+    timeText: String,
+    label: String,
+    onDismiss: () -> Unit,
+    onSnooze: () -> Unit,
+) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -251,5 +261,38 @@ private fun SlideToActTrack(
                     },
                 ),
         )
+    }
+}
+
+@Preview(showBackground = true, name = "Alarm — light")
+@Preview(showBackground = true, name = "Alarm — dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun AlarmScreenContentPreview() {
+    CronTheme {
+        AlarmScreenContent(
+            timeText = "06:40",
+            label = "Wake up",
+            onDismiss = {},
+            onSnooze = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Slide to dismiss track")
+@Composable
+private fun SlideToActTrackPreview() {
+    CronTheme {
+        Box(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.primary)
+                .padding(Spacing.xxxl),
+        ) {
+            SlideToActTrack(
+                label = "Slide to dismiss",
+                thumbColor = MaterialTheme.colorScheme.onPrimary,
+                slideToEnd = true,
+                onSlideComplete = {},
+            )
+        }
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
@@ -1,5 +1,6 @@
 package fr.bsodium.cron.ui.screens.home.components
 
+import android.content.res.Configuration
 import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.Typeface
@@ -44,6 +45,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import fr.bsodium.cron.session.model.SleepSegment
+import fr.bsodium.cron.session.model.SleepStage
 import fr.bsodium.cron.ui.components.PillBadge
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.CronTypography
@@ -56,6 +58,7 @@ import fr.bsodium.cron.ui.theme.TightTextStyle
 import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
@@ -127,15 +130,42 @@ fun NextAlarmCard(
     }
 }
 
-@Preview(showBackground = true)
+@Preview(showBackground = true, name = "Pending — no sleep data")
 @Composable
-private fun NextAlarmCardPreview() {
+private fun NextAlarmCardPendingPreview() {
     CronTheme {
         NextAlarmCard(
             dateLabel = "Monday 1",
             alarmTime = LocalTime(6, 40),
             sleepDurationLabel = null,
             sleepSegments = emptyList(),
+            modifier = Modifier.padding(Spacing.xl),
+        )
+    }
+}
+
+/** A representative night ending at the 06:40 alarm, for previewing the sleep-duration state. */
+private val PREVIEW_SLEEP_SEGMENTS = listOf(
+    SleepStage.Awake to ("2026-06-01T23:00:00Z" to "2026-06-01T23:12:00Z"),
+    SleepStage.Light to ("2026-06-01T23:12:00Z" to "2026-06-02T00:30:00Z"),
+    SleepStage.Deep to ("2026-06-02T00:30:00Z" to "2026-06-02T02:05:00Z"),
+    SleepStage.Rem to ("2026-06-02T02:05:00Z" to "2026-06-02T02:50:00Z"),
+    SleepStage.Light to ("2026-06-02T02:50:00Z" to "2026-06-02T04:10:00Z"),
+    SleepStage.Deep to ("2026-06-02T04:10:00Z" to "2026-06-02T05:15:00Z"),
+    SleepStage.Rem to ("2026-06-02T05:15:00Z" to "2026-06-02T06:05:00Z"),
+    SleepStage.Light to ("2026-06-02T06:05:00Z" to "2026-06-02T06:40:00Z"),
+).map { (stage, span) -> SleepSegment(stage, Instant.parse(span.first), Instant.parse(span.second)) }
+
+@Preview(showBackground = true, name = "With sleep — light")
+@Preview(showBackground = true, name = "With sleep — dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun NextAlarmCardWithSleepPreview() {
+    CronTheme {
+        NextAlarmCard(
+            dateLabel = "Monday 1",
+            alarmTime = LocalTime(6, 40),
+            sleepDurationLabel = "7H 28M",
+            sleepSegments = PREVIEW_SLEEP_SEGMENTS,
             modifier = Modifier.padding(Spacing.xl),
         )
     }


### PR DESCRIPTION
## Why
Two key UI surfaces had `@Preview` coverage gaps, so their most distinctive states could only be seen with real device/session data — against AGENTS.md's mandate to preview important components with representative sample data.

- **`NextAlarmCard`**: its only preview passed `sleepDurationLabel = null` / `sleepSegments = emptyList()`, so the pane only rendered the no-sleep state. The populated state — the "Sleep" row, duration pill, and brand-coloured `SleepTimeline` (gated behind `sleepSegments.isNotEmpty()`) — had no preview.
- **The alarm ringing screen** (`AlarmScreen`): no preview at all. It's the surface shown when an alarm fires, yet could only be inspected by physically firing an alarm — and its clock was computed internally via a `LaunchedEffect`, so a naïve preview would render a non-deterministic host time.

## What
- **NextAlarmCard**: rename the empty-state preview → `NextAlarmCardPendingPreview`; add `NextAlarmCardWithSleepPreview` (**light + dark**) fed a representative night of `SleepSegment`s (Awake→Light→Deep→Rem cycles) ending at the 06:40 alarm, with a `"7H 28M"` duration label.
- **Alarm screen**: split `AlarmScreen` into a stateful wrapper (owns the ticking clock `LaunchedEffect`) delegating to a stateless `AlarmScreenContent(timeText, …)`, per AGENTS.md's "separate rendering from data-loading". Add `AlarmScreenContentPreview` (**light + dark**, fixed `06:40` clock) and a standalone `SlideToActTrackPreview`.
- **Preview-only behaviour**: rendering logic and runtime call sites are unchanged — `AlarmActivity.onCreate` still calls `AlarmScreen(label, onDismiss, onSnooze)` as before.

## Verification
`assembleDebug` + `lintDebug` pass. Both populated states now render in Android Studio's preview pane — the only way to see states not reachable without real Health Connect / a fired alarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)