### PR TITLE
feat(home): lift the whole thinking block as it expands

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -81,6 +82,9 @@ import fr.bsodium.cron.ui.theme.Spacing
 // below), and the rubber-band floor so the reveal still creeps near full instead of fully stalling.
 private const val THINKING_EXPAND_THRESHOLD = 0.4f
 private const val THINKING_PULL_RUBBER_FLOOR = 0.15f
+// Absolute cap on the release-to-expand pull distance, so a tall timeline (where 40% of full height
+// exceeds the screen) is still openable with a short drag.
+private val THINKING_EXPAND_TRIGGER_MAX = 120.dp
 
 @Composable
 fun HomeScreen(
@@ -199,12 +203,14 @@ fun HomeScreen(
             val thinkingFullPx = remember(displayThread.turnIndex) { mutableIntStateOf(0) }
             val canPull = rememberUpdatedState(displayThread.process.isNotEmpty() && !thinkingExpanded)
             val pullHaptics = rememberCronHaptics()
-            val pullConnection = remember(listState, reveal) {
+            val expandTriggerMaxPx = with(density) { THINKING_EXPAND_TRIGGER_MAX.toPx() }
+            val pullConnection = remember(listState, reveal, expandTriggerMaxPx) {
                 object : NestedScrollConnection {
                     override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
                         if (source != NestedScrollSource.UserInput) return Offset.Zero
-                        // Dragging up while a pull is open unwinds it (1:1) before the list scrolls.
-                        if (available.y < 0f && reveal.value > 0f) {
+                        // Dragging up while a partial peek is open unwinds it (1:1) before the list scrolls.
+                        // Skip once fully expanded, or the upward scroll is eaten instead of moving the list.
+                        if (available.y < 0f && reveal.value > 0f && !thinkingExpanded) {
                             val next = (reveal.value + available.y).coerceAtLeast(0f)
                             val consumed = next - reveal.value
                             scope.launch { reveal.snapTo(next) }
@@ -229,7 +235,8 @@ fun HomeScreen(
                     override suspend fun onPreFling(available: Velocity): Velocity {
                         if (reveal.value <= 0f) return Velocity.Zero
                         val full = thinkingFullPx.intValue
-                        if (full > 0 && reveal.value >= full * THINKING_EXPAND_THRESHOLD) {
+                        val trigger = minOf(full * THINKING_EXPAND_THRESHOLD, expandTriggerMaxPx)
+                        if (full > 0 && reveal.value >= trigger) {
                             reveal.animateTo(full.toFloat())
                             thinkingExpanded = true
                         } else {

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -21,15 +21,19 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.text.style.TextOverflow
@@ -137,85 +141,92 @@ private fun ThinkingDisclosure(
     val canExpand = process.isNotEmpty()
     // Both header and timeline ride the same continuous progress so the whole disclosure lifts as one.
     val openFraction = if (expanded) 1f else expansionFraction.coerceIn(0f, 1f)
+    // The band's visible colour over the page; also handed to the timeline/avatar discs so they sit
+    // flush on it instead of reading as bright page-coloured halos. rememberUpdatedState keeps a stable
+    // State the discs read at draw time, so they don't recompose as the colour animates.
+    val bandColor = lerp(MaterialTheme.colorScheme.background, MaterialTheme.colorScheme.surfaceContainerLow, openFraction)
+    val bandColorState = rememberUpdatedState(bandColor)
     // Full-bleed band over header + timeline: transparent collapsed, fading to a quiet fill as it opens.
     // It bleeds past the side content padding (Spacing.xl) to hug both edges; the inner row/body re-inset
     // by the same amount so the summary text, chevron, and timeline stay put.
-    Column(
-        modifier = Modifier
-            .bleedHorizontally(Spacing.xl)
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = openFraction)),
-    ) {
-        Row(
+    CompositionLocalProvider(LocalTimelineSurface provides bandColorState) {
+        Column(
             modifier = Modifier
+                .bleedHorizontally(Spacing.xl)
                 .fillMaxWidth()
-                .let { if (canExpand) it.clickable { onToggle() } else it }
-                .heightIn(min = ROW_MIN_HEIGHT)
-                .padding(start = Spacing.xl, top = Spacing.sm, end = Spacing.xl, bottom = Spacing.sm),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                .background(bandColor),
         ) {
-            if (inProgress) {
-                // Live: the model's current gerund summary + a spinner.
-                Text(
-                    text = summary ?: "Thinking…",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
-                )
-                CircularProgressIndicator(
-                    modifier = Modifier.size(SPINNER_SIZE),
-                    strokeWidth = SPINNER_STROKE,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            } else {
-                // Settled: an avatar-stack of the tools that ran + how long it took.
-                val tools = process.filterIsInstance<ProcessItem.Tool>()
-                if (tools.isNotEmpty()) ToolStack(tools)
-                Text(
-                    text = thoughtForLabel(durationSeconds),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
-                )
-                if (canExpand) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
-                        contentDescription = if (expanded) "Collapse" else "Expand",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.graphicsLayer { rotationZ = openFraction * 90f },
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .let { if (canExpand) it.clickable { onToggle() } else it }
+                    .heightIn(min = ROW_MIN_HEIGHT)
+                    .padding(start = Spacing.xl, top = Spacing.sm, end = Spacing.xl, bottom = Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+            ) {
+                if (inProgress) {
+                    // Live: the model's current gerund summary + a spinner.
+                    Text(
+                        text = summary ?: "Thinking…",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
                     )
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(SPINNER_SIZE),
+                        strokeWidth = SPINNER_STROKE,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    // Settled: an avatar-stack of the tools that ran + how long it took.
+                    val tools = process.filterIsInstance<ProcessItem.Tool>()
+                    if (tools.isNotEmpty()) ToolStack(tools)
+                    Text(
+                        text = thoughtForLabel(durationSeconds),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                    if (canExpand) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+                            contentDescription = if (expanded) "Collapse" else "Expand",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.graphicsLayer { rotationZ = openFraction * 90f },
+                        )
+                    }
                 }
             }
-        }
-        // Single pixel-accurate reveal: the pull drives expandPx 1:1 with the finger; tap/release animate the
-        // same value (owned by HomeScreen), so there's no second source to dip against. Fully expanded clips to
-        // Float.MAX_VALUE → the natural height, re-measured so a still-streaming timeline isn't cut. Settled
-        // turns always compose (at h=0 when collapsed) so the measured full height is ready for tap/pull.
-        val revealing = expanded || expandPx > 0f || !inProgress
-        if (canExpand && revealing) {
-            // Re-inset by the bleed amount so the timeline aligns to the content margin, not the screen edge.
-            Box(modifier = Modifier.padding(horizontal = Spacing.xl)) {
-                ExpandReveal(
-                    targetPx = if (expanded) Float.MAX_VALUE else expandPx,
-                    peeking = !expanded,
-                    onFullHeight = onFullHeight,
-                ) {
-                    TimelineColumn {
-                        process.forEachIndexed { i, item ->
-                            val isFirst = i == 0
-                            val isLast = inProgress && i == process.lastIndex
-                            when (item) {
-                                is ProcessItem.Reasoning -> ProcessTextRow(item.text, isFirst, isLast)
-                                is ProcessItem.Narration -> ProcessTextRow(item.text, isFirst, isLast)
-                                is ProcessItem.Tool -> ToolStepRow(item, isFirst, isLast)
+            // Single pixel-accurate reveal: the pull drives expandPx 1:1 with the finger; tap/release animate
+            // the same value (owned by HomeScreen), so there's no second source to dip against. Fully expanded
+            // clips to Float.MAX_VALUE → the natural height, re-measured so a still-streaming timeline isn't
+            // cut. Settled turns always compose (at h=0 when collapsed) so the full height is ready for tap/pull.
+            val revealing = expanded || expandPx > 0f || !inProgress
+            if (canExpand && revealing) {
+                // Re-inset by the bleed amount so the timeline aligns to the content margin, not the screen edge.
+                Box(modifier = Modifier.padding(horizontal = Spacing.xl)) {
+                    ExpandReveal(
+                        targetPx = if (expanded) Float.MAX_VALUE else expandPx,
+                        peeking = !expanded,
+                        onFullHeight = onFullHeight,
+                    ) {
+                        TimelineColumn {
+                            process.forEachIndexed { i, item ->
+                                val isFirst = i == 0
+                                val isLast = inProgress && i == process.lastIndex
+                                when (item) {
+                                    is ProcessItem.Reasoning -> ProcessTextRow(item.text, isFirst, isLast)
+                                    is ProcessItem.Narration -> ProcessTextRow(item.text, isFirst, isLast)
+                                    is ProcessItem.Tool -> ToolStepRow(item, isFirst, isLast)
+                                }
                             }
+                            if (!inProgress) DoneRow(isFirst = process.isEmpty(), isLast = true)
                         }
-                        if (!inProgress) DoneRow(isFirst = process.isEmpty(), isLast = true)
                     }
                 }
             }
@@ -256,18 +267,19 @@ private val TOOL_DISC_ICON = 13.dp
 private val TOOL_STACK_OVERLAP = 8.dp
 
 /**
- * Avatar-stack of the tools that ran this turn. Each icon sits in a page-coloured ring, so where
- * the discs overlap (negative spacing) the later one occludes the earlier with a clean gap.
+ * Avatar-stack of the tools that ran this turn. Each icon sits in a ring matching the surface behind it,
+ * so where the discs overlap (negative spacing) the later one occludes the earlier with a clean gap.
  */
 @Composable
 private fun ToolStack(tools: List<ProcessItem.Tool>) {
+    val ringSurface = LocalTimelineSurface.current
+    val ringFallback = MaterialTheme.colorScheme.background
     Row(horizontalArrangement = Arrangement.spacedBy(-TOOL_STACK_OVERLAP)) {
         tools.forEach { tool ->
             Box(
                 modifier = Modifier
                     .size(TOOL_DISC_SIZE)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.background),
+                    .drawBehind { drawCircle(ringSurface?.value ?: ringFallback) },
                 contentAlignment = Alignment.Center,
             ) {
                 Box(

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.layout
@@ -136,78 +135,89 @@ private fun ThinkingDisclosure(
     expansionFraction: Float = 0f,
 ) {
     val canExpand = process.isNotEmpty()
-    // Full-bleed bar: transparent collapsed, a quiet fill when open. It bleeds past the side content
-    // padding (Spacing.xl) to hug both edges; compensating start/end padding keeps the summary text and chevron in place.
-    Row(
+    // Both header and timeline ride the same continuous progress so the whole disclosure lifts as one.
+    val openFraction = if (expanded) 1f else expansionFraction.coerceIn(0f, 1f)
+    // Full-bleed band over header + timeline: transparent collapsed, fading to a quiet fill as it opens.
+    // It bleeds past the side content padding (Spacing.xl) to hug both edges; the inner row/body re-inset
+    // by the same amount so the summary text, chevron, and timeline stay put.
+    Column(
         modifier = Modifier
             .bleedHorizontally(Spacing.xl)
             .fillMaxWidth()
-            .let { if (canExpand) it.clickable { onToggle() } else it }
-            .background(if (expanded) MaterialTheme.colorScheme.surfaceContainerLow else Color.Transparent)
-            .heightIn(min = ROW_MIN_HEIGHT)
-            .padding(start = Spacing.xl, top = Spacing.sm, end = Spacing.xl, bottom = Spacing.sm),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+            .background(MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = openFraction)),
     ) {
-        if (inProgress) {
-            // Live: the model's current gerund summary + a spinner.
-            Text(
-                text = summary ?: "Thinking…",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f),
-            )
-            CircularProgressIndicator(
-                modifier = Modifier.size(SPINNER_SIZE),
-                strokeWidth = SPINNER_STROKE,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        } else {
-            // Settled: an avatar-stack of the tools that ran + how long it took.
-            val tools = process.filterIsInstance<ProcessItem.Tool>()
-            if (tools.isNotEmpty()) ToolStack(tools)
-            Text(
-                text = thoughtForLabel(durationSeconds),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f),
-            )
-            if (canExpand) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
-                    contentDescription = if (expanded) "Collapse" else "Expand",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.graphicsLayer { rotationZ = expansionFraction * 90f },
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .let { if (canExpand) it.clickable { onToggle() } else it }
+                .heightIn(min = ROW_MIN_HEIGHT)
+                .padding(start = Spacing.xl, top = Spacing.sm, end = Spacing.xl, bottom = Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            if (inProgress) {
+                // Live: the model's current gerund summary + a spinner.
+                Text(
+                    text = summary ?: "Thinking…",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
                 )
+                CircularProgressIndicator(
+                    modifier = Modifier.size(SPINNER_SIZE),
+                    strokeWidth = SPINNER_STROKE,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                // Settled: an avatar-stack of the tools that ran + how long it took.
+                val tools = process.filterIsInstance<ProcessItem.Tool>()
+                if (tools.isNotEmpty()) ToolStack(tools)
+                Text(
+                    text = thoughtForLabel(durationSeconds),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                if (canExpand) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+                        contentDescription = if (expanded) "Collapse" else "Expand",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.graphicsLayer { rotationZ = openFraction * 90f },
+                    )
+                }
             }
         }
-    }
-    // Single pixel-accurate reveal: the pull drives expandPx 1:1 with the finger; tap/release animate the
-    // same value (owned by HomeScreen), so there's no second source to dip against. Fully expanded clips to
-    // Float.MAX_VALUE → the natural height, re-measured so a still-streaming timeline isn't cut. Settled
-    // turns always compose (at h=0 when collapsed) so the measured full height is ready for tap/pull.
-    val revealing = expanded || expandPx > 0f || !inProgress
-    if (canExpand && revealing) {
-        ExpandReveal(
-            targetPx = if (expanded) Float.MAX_VALUE else expandPx,
-            peeking = !expanded,
-            onFullHeight = onFullHeight,
-        ) {
-            TimelineColumn {
-                process.forEachIndexed { i, item ->
-                    val isFirst = i == 0
-                    val isLast = inProgress && i == process.lastIndex
-                    when (item) {
-                        is ProcessItem.Reasoning -> ProcessTextRow(item.text, isFirst, isLast)
-                        is ProcessItem.Narration -> ProcessTextRow(item.text, isFirst, isLast)
-                        is ProcessItem.Tool -> ToolStepRow(item, isFirst, isLast)
+        // Single pixel-accurate reveal: the pull drives expandPx 1:1 with the finger; tap/release animate the
+        // same value (owned by HomeScreen), so there's no second source to dip against. Fully expanded clips to
+        // Float.MAX_VALUE → the natural height, re-measured so a still-streaming timeline isn't cut. Settled
+        // turns always compose (at h=0 when collapsed) so the measured full height is ready for tap/pull.
+        val revealing = expanded || expandPx > 0f || !inProgress
+        if (canExpand && revealing) {
+            // Re-inset by the bleed amount so the timeline aligns to the content margin, not the screen edge.
+            Box(modifier = Modifier.padding(horizontal = Spacing.xl)) {
+                ExpandReveal(
+                    targetPx = if (expanded) Float.MAX_VALUE else expandPx,
+                    peeking = !expanded,
+                    onFullHeight = onFullHeight,
+                ) {
+                    TimelineColumn {
+                        process.forEachIndexed { i, item ->
+                            val isFirst = i == 0
+                            val isLast = inProgress && i == process.lastIndex
+                            when (item) {
+                                is ProcessItem.Reasoning -> ProcessTextRow(item.text, isFirst, isLast)
+                                is ProcessItem.Narration -> ProcessTextRow(item.text, isFirst, isLast)
+                                is ProcessItem.Tool -> ToolStepRow(item, isFirst, isLast)
+                            }
+                        }
+                        if (!inProgress) DoneRow(isFirst = process.isEmpty(), isLast = true)
                     }
                 }
-                if (!inProgress) DoneRow(isFirst = process.isEmpty(), isLast = true)
             }
         }
     }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ThinkingTimeline.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ThinkingTimeline.kt
@@ -1,6 +1,5 @@
 package fr.bsodium.cron.ui.screens.home.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,14 +9,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import fr.bsodium.cron.ui.theme.Spacing
@@ -27,6 +27,10 @@ private val TIMELINE_RULE_WIDTH = 2.dp
 private val ICON_MASK_SIZE = 24.dp
 /** Row content padding; doubles as the inter-step gap (sm keeps the timeline rule visible between discs). */
 private val TIMELINE_CONTENT_VPAD = Spacing.sm
+
+/** Surface colour behind the timeline icons — the elevation band when the disclosure is open. Read at
+ *  draw time (via the stable [State]) so rows don't recompose as it animates. Null → the page colour. */
+internal val LocalTimelineSurface = staticCompositionLocalOf<State<Color>?> { null }
 
 /** Stacks timeline rows so their per-row [TimelineRow] rules join into one thread. */
 @Composable
@@ -44,7 +48,9 @@ internal fun TimelineRow(
 ) {
     // Low-emphasis connector tone with enough contrast for a 2dp line against the page.
     val ruleColor = MaterialTheme.colorScheme.surfaceContainerHigh
-    val maskColor = MaterialTheme.colorScheme.background
+    // The disc matches whatever sits behind the timeline — the elevation band when open, else the page.
+    val maskSurface = LocalTimelineSurface.current
+    val maskFallback = MaterialTheme.colorScheme.background
     // Centre the disc on the content's FIRST line (not the whole multi-line row): disc centre =
     // contentTopPad + firstLine/2, so its top inset is that minus half the disc.
     val discTop = (TIMELINE_CONTENT_VPAD + (firstLineHeight - ICON_MASK_SIZE) / 2)
@@ -90,8 +96,7 @@ internal fun TimelineRow(
                             .align(Alignment.TopCenter)
                             .padding(top = discTop)
                             .size(ICON_MASK_SIZE)
-                            .clip(CircleShape)
-                            .background(maskColor),
+                            .drawBehind { drawCircle(maskSurface?.value ?: maskFallback) },
                         contentAlignment = Alignment.Center,
                     ) { icon() }
                 }


### PR DESCRIPTION
## Why
When the AI thinking thread expands, only the **header row** changed background — an instant boolean snap from transparent to `surfaceContainerLow` (`AiThinkingThread.kt`). The collapsible timeline below it stayed on the plain page, and the tint appeared in one jump rather than tracking the open motion.

We want the **entire disclosure** (header + collapsible timeline) to read as a single raised band, and for that elevation to **fade in correlated with the expansion progress** as the user pulls down or taps to open.

## What
- Wrap the header `Row` and the `ExpandReveal` body in a single full-bleed `Column` whose background is `surfaceContainerLow.copy(alpha = openFraction)`, so the whole block lifts as one unit.
- `openFraction = if (expanded) 1f else expansionFraction.coerceIn(0f, 1f)` reuses the **continuous** `expansionFraction` already plumbed in from `HomeScreen` (it drives the chevron pivot). Both the tap and pull paths animate the underlying `reveal`, so the band rises in step with the reveal — no new animation state, and `HomeScreen` is unchanged.
- Alpha-fading the shade (rather than `lerp(Color.Transparent, …)`) keeps the hue constant and avoids the black-tint artifact; the `Color.copy(alpha = …)` idiom matches `NextAlarmCard`.
- The timeline body is re-inset by `Spacing.xl` (the bleed amount) so it stays at the content margin; the header row keeps its compensating padding. The chevron now shares the same `openFraction`, which also fixes the un-rotated chevron in the "Disclosure — expanded" preview.
- Endpoint shade is `surfaceContainerLow` (faithful to today, just extended + gradual). The final serif response body stays on the plain page.

## Verification
`assembleDebug` + `lintDebug` pass. The "Disclosure — expanded" `@Preview` now renders the full opaque band with a 90°-rotated chevron.

**Still to confirm on device** (the gradual correlation is interactive and needs a settled AI turn, which I couldn't reproduce headlessly): pull-to-expand should fade the band in *with* the finger across header + revealed rows; tap should rise/reverse in step with the height animation; the collapsed state should look identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)