### PR TITLE
Flatten thinking-block background, full-width header, threshold haptic

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -204,8 +204,16 @@ fun HomeScreen(
             val canPull = rememberUpdatedState(displayThread.process.isNotEmpty() && !thinkingExpanded)
             val pullHaptics = rememberCronHaptics()
             val expandTriggerMaxPx = with(density) { THINKING_EXPAND_TRIGGER_MAX.toPx() }
-            val pullConnection = remember(listState, reveal, expandTriggerMaxPx) {
+            // Tracks whether the pull is past the release-to-open threshold, so a click fires once per crossing.
+            val pastThreshold = remember(displayThread.turnIndex) { mutableStateOf(false) }
+            val pullConnection = remember(listState, reveal, expandTriggerMaxPx, pastThreshold) {
                 object : NestedScrollConnection {
+                    // Pixels of pull past which releasing snaps the block open — the same point onPreFling tests.
+                    fun triggerPx(): Float {
+                        val full = thinkingFullPx.intValue
+                        return if (full > 0) minOf(full * THINKING_EXPAND_THRESHOLD, expandTriggerMaxPx) else Float.MAX_VALUE
+                    }
+
                     override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
                         if (source != NestedScrollSource.UserInput) return Offset.Zero
                         // Dragging up while a partial peek is open unwinds it (1:1) before the list scrolls.
@@ -213,20 +221,24 @@ fun HomeScreen(
                         if (available.y < 0f && reveal.value > 0f && !thinkingExpanded) {
                             val next = (reveal.value + available.y).coerceAtLeast(0f)
                             val consumed = next - reveal.value
+                            pastThreshold.value = next >= triggerPx()
                             scope.launch { reveal.snapTo(next) }
                             return Offset(0f, consumed)
                         }
                         // At the top, dragging down on a collapsible, collapsed thread grows the reveal in
                         // pixels (tracks the finger), gently resisting near full so it never runs ahead.
                         if (available.y > 0f && canPull.value && !listState.canScrollBackward) {
-                            if (reveal.value == 0f) pullHaptics.tick() // a click as it starts unwrapping
                             val full = thinkingFullPx.intValue
                             val rubber = if (full > 0) {
                                 (1f - reveal.value / full).coerceIn(THINKING_PULL_RUBBER_FLOOR, 1f)
                             } else {
                                 1f
                             }
-                            scope.launch { reveal.snapTo(reveal.value + available.y * rubber) }
+                            val next = reveal.value + available.y * rubber
+                            val nowPast = next >= triggerPx()
+                            if (nowPast && !pastThreshold.value) pullHaptics.tick() // click as the pull reaches the open point
+                            pastThreshold.value = nowPast
+                            scope.launch { reveal.snapTo(next) }
                             return Offset(0f, available.y)
                         }
                         return Offset.Zero
@@ -235,8 +247,7 @@ fun HomeScreen(
                     override suspend fun onPreFling(available: Velocity): Velocity {
                         if (reveal.value <= 0f) return Velocity.Zero
                         val full = thinkingFullPx.intValue
-                        val trigger = minOf(full * THINKING_EXPAND_THRESHOLD, expandTriggerMaxPx)
-                        if (full > 0 && reveal.value >= trigger) {
+                        if (full > 0 && reveal.value >= triggerPx()) {
                             reveal.animateTo(full.toFloat())
                             thinkingExpanded = true
                         } else {

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -21,19 +21,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.text.style.TextOverflow
@@ -139,95 +135,80 @@ private fun ThinkingDisclosure(
     expansionFraction: Float = 0f,
 ) {
     val canExpand = process.isNotEmpty()
-    // Both header and timeline ride the same continuous progress so the whole disclosure lifts as one.
+    // Drives the chevron pivot from the live reveal: 0f collapsed (points right), 1f open (points down).
     val openFraction = if (expanded) 1f else expansionFraction.coerceIn(0f, 1f)
-    // The band's visible colour over the page; also handed to the timeline/avatar discs so they sit
-    // flush on it instead of reading as bright page-coloured halos. rememberUpdatedState keeps a stable
-    // State the discs read at draw time, so they don't recompose as the colour animates.
-    val bandColor = lerp(MaterialTheme.colorScheme.background, MaterialTheme.colorScheme.surfaceContainerLow, openFraction)
-    val bandColorState = rememberUpdatedState(bandColor)
-    // Full-bleed band over header + timeline: transparent collapsed, fading to a quiet fill as it opens.
-    // It bleeds past the side content padding (Spacing.xl) to hug both edges; the inner row/body re-inset
-    // by the same amount so the summary text, chevron, and timeline stay put.
-    CompositionLocalProvider(LocalTimelineSurface provides bandColorState) {
-        Column(
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // The header (and its tap ripple) bleeds past the list's content padding to span the full
+        // screen width; start/end padding re-insets the summary, avatars, and chevron to the margin.
+        Row(
             modifier = Modifier
                 .bleedHorizontally(Spacing.xl)
                 .fillMaxWidth()
-                .background(bandColor),
+                .let { if (canExpand) it.clickable { onToggle() } else it }
+                .heightIn(min = ROW_MIN_HEIGHT)
+                .padding(start = Spacing.xl, top = Spacing.sm, end = Spacing.xl, bottom = Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .let { if (canExpand) it.clickable { onToggle() } else it }
-                    .heightIn(min = ROW_MIN_HEIGHT)
-                    .padding(start = Spacing.xl, top = Spacing.sm, end = Spacing.xl, bottom = Spacing.sm),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-            ) {
-                if (inProgress) {
-                    // Live: the model's current gerund summary + a spinner.
-                    Text(
-                        text = summary ?: "Thinking…",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
+            if (inProgress) {
+                // Live: the model's current gerund summary + a spinner.
+                Text(
+                    text = summary ?: "Thinking…",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                CircularProgressIndicator(
+                    modifier = Modifier.size(SPINNER_SIZE),
+                    strokeWidth = SPINNER_STROKE,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                // Settled: an avatar-stack of the tools that ran + how long it took.
+                val tools = process.filterIsInstance<ProcessItem.Tool>()
+                if (tools.isNotEmpty()) ToolStack(tools)
+                Text(
+                    text = thoughtForLabel(durationSeconds),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                if (canExpand) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+                        contentDescription = if (expanded) "Collapse" else "Expand",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.graphicsLayer { rotationZ = openFraction * 90f },
                     )
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(SPINNER_SIZE),
-                        strokeWidth = SPINNER_STROKE,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                } else {
-                    // Settled: an avatar-stack of the tools that ran + how long it took.
-                    val tools = process.filterIsInstance<ProcessItem.Tool>()
-                    if (tools.isNotEmpty()) ToolStack(tools)
-                    Text(
-                        text = thoughtForLabel(durationSeconds),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
-                    if (canExpand) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
-                            contentDescription = if (expanded) "Collapse" else "Expand",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.graphicsLayer { rotationZ = openFraction * 90f },
-                        )
-                    }
                 }
             }
-            // Single pixel-accurate reveal: the pull drives expandPx 1:1 with the finger; tap/release animate
-            // the same value (owned by HomeScreen), so there's no second source to dip against. Fully expanded
-            // clips to Float.MAX_VALUE → the natural height, re-measured so a still-streaming timeline isn't
-            // cut. Settled turns always compose (at h=0 when collapsed) so the full height is ready for tap/pull.
-            val revealing = expanded || expandPx > 0f || !inProgress
-            if (canExpand && revealing) {
-                // Re-inset by the bleed amount so the timeline aligns to the content margin, not the screen edge.
-                Box(modifier = Modifier.padding(horizontal = Spacing.xl)) {
-                    ExpandReveal(
-                        targetPx = if (expanded) Float.MAX_VALUE else expandPx,
-                        peeking = !expanded,
-                        onFullHeight = onFullHeight,
-                    ) {
-                        TimelineColumn {
-                            process.forEachIndexed { i, item ->
-                                val isFirst = i == 0
-                                val isLast = inProgress && i == process.lastIndex
-                                when (item) {
-                                    is ProcessItem.Reasoning -> ProcessTextRow(item.text, isFirst, isLast)
-                                    is ProcessItem.Narration -> ProcessTextRow(item.text, isFirst, isLast)
-                                    is ProcessItem.Tool -> ToolStepRow(item, isFirst, isLast)
-                                }
-                            }
-                            if (!inProgress) DoneRow(isFirst = process.isEmpty(), isLast = true)
+        }
+        // Single pixel-accurate reveal: the pull drives expandPx 1:1 with the finger; tap/release animate
+        // the same value (owned by HomeScreen), so there's no second source to dip against. Fully expanded
+        // clips to Float.MAX_VALUE → the natural height, re-measured so a still-streaming timeline isn't
+        // cut. Settled turns always compose (at h=0 when collapsed) so the full height is ready for tap/pull.
+        val revealing = expanded || expandPx > 0f || !inProgress
+        if (canExpand && revealing) {
+            ExpandReveal(
+                targetPx = if (expanded) Float.MAX_VALUE else expandPx,
+                peeking = !expanded,
+                onFullHeight = onFullHeight,
+            ) {
+                TimelineColumn {
+                    process.forEachIndexed { i, item ->
+                        val isFirst = i == 0
+                        val isLast = inProgress && i == process.lastIndex
+                        when (item) {
+                            is ProcessItem.Reasoning -> ProcessTextRow(item.text, isFirst, isLast)
+                            is ProcessItem.Narration -> ProcessTextRow(item.text, isFirst, isLast)
+                            is ProcessItem.Tool -> ToolStepRow(item, isFirst, isLast)
                         }
                     }
+                    if (!inProgress) DoneRow(isFirst = process.isEmpty(), isLast = true)
                 }
             }
         }
@@ -267,19 +248,18 @@ private val TOOL_DISC_ICON = 13.dp
 private val TOOL_STACK_OVERLAP = 8.dp
 
 /**
- * Avatar-stack of the tools that ran this turn. Each icon sits in a ring matching the surface behind it,
- * so where the discs overlap (negative spacing) the later one occludes the earlier with a clean gap.
+ * Avatar-stack of the tools that ran this turn. Each icon sits in a page-coloured ring, so where
+ * the discs overlap (negative spacing) the later one occludes the earlier with a clean gap.
  */
 @Composable
 private fun ToolStack(tools: List<ProcessItem.Tool>) {
-    val ringSurface = LocalTimelineSurface.current
-    val ringFallback = MaterialTheme.colorScheme.background
     Row(horizontalArrangement = Arrangement.spacedBy(-TOOL_STACK_OVERLAP)) {
         tools.forEach { tool ->
             Box(
                 modifier = Modifier
                     .size(TOOL_DISC_SIZE)
-                    .drawBehind { drawCircle(ringSurface?.value ?: ringFallback) },
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.background),
                 contentAlignment = Alignment.Center,
             ) {
                 Box(

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ThinkingTimeline.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ThinkingTimeline.kt
@@ -1,5 +1,6 @@
 package fr.bsodium.cron.ui.screens.home.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,15 +10,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import fr.bsodium.cron.ui.theme.Spacing
@@ -27,10 +27,6 @@ private val TIMELINE_RULE_WIDTH = 2.dp
 private val ICON_MASK_SIZE = 24.dp
 /** Row content padding; doubles as the inter-step gap (sm keeps the timeline rule visible between discs). */
 private val TIMELINE_CONTENT_VPAD = Spacing.sm
-
-/** Surface colour behind the timeline icons — the elevation band when the disclosure is open. Read at
- *  draw time (via the stable [State]) so rows don't recompose as it animates. Null → the page colour. */
-internal val LocalTimelineSurface = staticCompositionLocalOf<State<Color>?> { null }
 
 /** Stacks timeline rows so their per-row [TimelineRow] rules join into one thread. */
 @Composable
@@ -48,9 +44,8 @@ internal fun TimelineRow(
 ) {
     // Low-emphasis connector tone with enough contrast for a 2dp line against the page.
     val ruleColor = MaterialTheme.colorScheme.surfaceContainerHigh
-    // The disc matches whatever sits behind the timeline — the elevation band when open, else the page.
-    val maskSurface = LocalTimelineSurface.current
-    val maskFallback = MaterialTheme.colorScheme.background
+    // The disc masks the connector rule behind the icon, so it matches the page it sits on.
+    val maskColor = MaterialTheme.colorScheme.background
     // Centre the disc on the content's FIRST line (not the whole multi-line row): disc centre =
     // contentTopPad + firstLine/2, so its top inset is that minus half the disc.
     val discTop = (TIMELINE_CONTENT_VPAD + (firstLineHeight - ICON_MASK_SIZE) / 2)
@@ -96,7 +91,8 @@ internal fun TimelineRow(
                             .align(Alignment.TopCenter)
                             .padding(top = discTop)
                             .size(ICON_MASK_SIZE)
-                            .drawBehind { drawCircle(maskSurface?.value ?: maskFallback) },
+                            .clip(CircleShape)
+                            .background(maskColor),
                         contentAlignment = Alignment.Center,
                     ) { icon() }
                 }


### PR DESCRIPTION
## What

Three tweaks to the home-screen AI thinking block:

- **Drop the elevation band.** The expand animation tinted the whole disclosure (and the timeline icon / header avatar discs) from `background` → `surfaceContainerLow`. It's gone — the block keeps its default page background in every state, collapsed or expanded. The discs revert to the static page colour and `LocalTimelineSurface` is removed.
- **Full-width header.** The header row bleeds past the list's `Spacing.xl` content padding to span the full screen width, so its tap ripple reaches both edges. Start/end padding re-insets the summary, avatars, and chevron to the content margin, so nothing visibly moves — only the touch/ripple area grows.
- **Haptic at the open threshold.** The pull-to-expand click fired the moment the drag started; it now clicks once as the pull crosses the release-to-open threshold (`minOf(40% of full height, 120dp)` — the same point `onPreFling` uses), tracked per-turn so dragging back below and re-crossing clicks again.

## Verification

- `:app:assembleDebug` + `:app:lintDebug` — both pass, no lint errors; previews compile.
- Installed and launched on a Pixel 7 emulator: renders without crash.
- The expanded thinking-block visual and the haptic itself were **not** exercised end-to-end: the planner call fails with `http_error` on the emulator (no backend/API key configured), so there's no live AI thread to expand. The full-width header reuses the exact bleed mechanism that previously rendered the band to the screen edges. Worth an eyeball on a device with the backend configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)