### PR TITLE
fix: assistant address, thinking-thread answer, and wrong-day alarm

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ai/SystemPrompts.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/SystemPrompts.kt
@@ -79,6 +79,10 @@ object SystemPrompts {
         - Health Connect records from a wearable (confidence: high) outweigh phone heuristics.
 
         Location and commute rules:
+        - When an "Address" line is present in the current location, that is the device-resolved
+          place — refer to it as-is if you mention where the user is. Never infer, guess, or state an
+          address, neighbourhood, or city from the lat/lng yourself; the coordinates are only for
+          commute math.
         - When the anchor event has a location, your origin is usable, AND geocode_address +
           estimate_commute are available to you, use them to get the real travel time rather than
           guessing. If those tools are not in your tool list, or a call errors, fall back to the
@@ -158,6 +162,8 @@ object SystemPrompts {
           and set wake = anchor_start − max(commute, travel_buffer) − preparation_time. Don't guess; if
           those tools are absent or error, use a flat +30 min travel estimate and note it. travel_buffer
           and preparation_time are distinct values from the day plan.
+        - Never state a specific address, neighbourhood, or city unless it appears verbatim in the
+          event log or day plan; do not infer a place from coordinates.
 
         Be terse. Each turn should call exactly one terminal tool and then stop.
 

--- a/app/src/main/java/fr/bsodium/cron/alarm/AlarmScheduler.kt
+++ b/app/src/main/java/fr/bsodium/cron/alarm/AlarmScheduler.kt
@@ -14,6 +14,7 @@ import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
 
 /**
  * Schedules the **mutable** wake alarm decided by the AI.
@@ -115,12 +116,17 @@ class AlarmScheduler(private val context: Context) {
         val MIN_LEAD: kotlin.time.Duration = kotlin.time.Duration.parse("60s")
 
         /**
-         * Pure clamp: bounds [requested] to `[now + MIN_LEAD, hardLatest@sessionDate]`.
+         * Pure clamp: the **session owns the alarm date**, the model only chooses the time-of-day.
+         * The requested instant's local time-of-day is pinned onto [sessionDate], then bounded to
+         * `[now + MIN_LEAD, hardLatest@sessionDate]`. Pinning means a model that emits the wrong date
+         * (e.g. today instead of tomorrow's morning) can't arm the alarm on the wrong day.
          *
-         * - If [requested] is in the past or too close to [now], it slides up to `now + MIN_LEAD`.
+         * - If the pinned time is in the past or too close to [now], it slides up to `now + MIN_LEAD`.
          *   This is NOT considered a hard-latest clamp.
-         * - If [requested] exceeds the hard latest, it slides down to the hard latest and
+         * - If it exceeds the hard latest, it slides down to the hard latest and
          *   [ClampedSchedule.clampedToHardLatest] becomes true.
+         * - `maxOf(lower, upper)` guards the degenerate case where `now` is already past the hard
+         *   latest (`lower > upper`) so `coerceIn` can't throw.
          */
         fun clamp(
             requested: Instant,
@@ -129,13 +135,14 @@ class AlarmScheduler(private val context: Context) {
             sessionDate: LocalDate,
             timezone: TimeZone,
         ): ClampedSchedule {
+            val onDate = requested.toLocalDateTime(timezone).time.atDate(sessionDate).toInstant(timezone)
             val lower = now + MIN_LEAD
             val upper = hardLatest.atDate(sessionDate).toInstant(timezone)
-            val actual = requested.coerceIn(lower, upper)
+            val actual = onDate.coerceIn(lower, maxOf(lower, upper))
             return ClampedSchedule(
                 requestedInstant = requested,
                 actualInstant = actual,
-                clampedToHardLatest = actual == upper && requested > upper,
+                clampedToHardLatest = actual == upper && onDate > upper,
             )
         }
     }

--- a/app/src/main/java/fr/bsodium/cron/location/LocationProvider.kt
+++ b/app/src/main/java/fr/bsodium/cron/location/LocationProvider.kt
@@ -4,7 +4,10 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
+import android.location.Address
+import android.location.Geocoder
 import android.location.Location
+import android.os.Build
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.google.android.gms.location.CurrentLocationRequest
@@ -15,11 +18,14 @@ import fr.bsodium.cron.session.model.LocationSource
 import fr.bsodium.cron.settings.PollCheckpointStore
 import fr.bsodium.cron.settings.SettingsRepository
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import java.util.Locale
 import kotlin.coroutines.resume
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
@@ -93,7 +99,7 @@ class LocationProvider(private val context: Context) {
         return fallback(checkpoints, settings, reason = "no_fresh_fix")
     }
 
-    private fun persistAndReturn(
+    private suspend fun persistAndReturn(
         location: Location,
         source: LocationSource,
         checkpoints: PollCheckpointStore,
@@ -111,6 +117,7 @@ class LocationProvider(private val context: Context) {
             accuracyMeters = location.accuracy.takeIf { it > 0f },
             source = source,
             capturedAt = capturedAt,
+            address = reverseGeocode(location.latitude, location.longitude),
         )
     }
 
@@ -129,6 +136,7 @@ class LocationProvider(private val context: Context) {
                 accuracyMeters = null,
                 source = LocationSource.LastKnown,
                 capturedAt = storedAt,
+                address = reverseGeocode(stored.first, stored.second),
             )
         }
 
@@ -142,6 +150,7 @@ class LocationProvider(private val context: Context) {
                 accuracyMeters = null,
                 source = LocationSource.HomeAddress,
                 capturedAt = Clock.System.now(),
+                address = reverseGeocode(homeLat, homeLng),
             )
         }
 
@@ -154,12 +163,49 @@ class LocationProvider(private val context: Context) {
         )
     }
 
+    /**
+     * Resolves coordinates to a human-readable address so the planner is handed a real place name
+     * instead of being left to (unreliably) reverse-geocode raw lat/lng itself. Best-effort: returns
+     * null when the platform geocoder is absent, errors, or times out.
+     */
+    private suspend fun reverseGeocode(lat: Double, lng: Double): String? {
+        if (!Geocoder.isPresent()) return null
+        // Locale.getDefault(): the address is human-language for the model, not a numeric readout —
+        // the documented exception to the Locale.US formatting rule.
+        val geocoder = Geocoder(context, Locale.getDefault())
+        return withTimeoutOrNull(REVERSE_GEOCODE_TIMEOUT.inWholeMilliseconds) {
+            runCatching {
+                val address = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    suspendCancellableCoroutine { cont ->
+                        geocoder.getFromLocation(lat, lng, 1, object : Geocoder.GeocodeListener {
+                            override fun onGeocode(addresses: MutableList<Address>) = cont.resume(addresses.firstOrNull())
+                            override fun onError(errorMessage: String?) = cont.resume(null)
+                        })
+                    }
+                } else {
+                    @Suppress("DEPRECATION") // synchronous getFromLocation is the only option below API 33
+                    withContext(Dispatchers.IO) { geocoder.getFromLocation(lat, lng, 1)?.firstOrNull() }
+                }
+                address?.let(::formatAddress)
+            }.onFailure { Log.w(TAG, "reverseGeocode failed", it) }.getOrNull()
+        }
+    }
+
+    private fun formatAddress(address: Address): String? =
+        address.getAddressLine(0)
+            ?: listOfNotNull(
+                address.locality ?: address.subAdminArea,
+                address.adminArea,
+                address.countryName,
+            ).joinToString(", ").takeIf { it.isNotBlank() }
+
     companion object {
         private const val TAG = "LocationProvider"
         private const val MAX_ACCURACY_METERS = 500f
         // Looser cap for a balanced-power CURRENT fix: city-level accuracy is acceptable when the
         // alternative is a stale fix in the wrong city (commute origin only needs the right area).
         private const val COARSE_MAX_ACCURACY_METERS = 5000f
+        private val REVERSE_GEOCODE_TIMEOUT = 5.seconds
     }
 
     private fun isRecent(location: Location, maxAge: kotlin.time.Duration): Boolean =

--- a/app/src/main/java/fr/bsodium/cron/session/model/Events.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/model/Events.kt
@@ -91,4 +91,6 @@ data class LocationPayload(
     val accuracyMeters: Float? = null,
     val source: LocationSource,
     val capturedAt: Instant,
+    /** Device-resolved human-readable address; null when reverse geocoding is unavailable or fails. */
+    val address: String? = null,
 )

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiThreadMapper.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiThreadMapper.kt
@@ -116,14 +116,9 @@ object AiThreadMapper {
             return kept.joinToString("\n").trim()
         }
 
-        // The answer is the trailing run of Text blocks (after the last tool/reasoning block); text
-        // emitted earlier is thinking-process narration. While streaming, hold the answer back until
-        // the model marks it with a SUMMARY line — otherwise leading narration prose (which only reads
-        // as narration once a tool follows it) flashes as the answer for a beat before jumping up.
-        val structuralStart = blocks.indexOfLast { it !is ContentBlock.Text } + 1
-        val answerStart =
-            if (isStreaming && !blocks.trailingTextHasSummary(structuralStart)) blocks.size
-            else structuralStart
+        // The answer begins at the model's SUMMARY marker (see [answerStartOf]); everything before it is
+        // thinking-process narration. While streaming, nothing is the answer until the marker lands.
+        val answerStart = answerStartOf(blocks, isStreaming)
 
         val process = blocks.take(answerStart).mapNotNull { block ->
             when (block) {
@@ -231,12 +226,28 @@ object AiThreadMapper {
     private const val TAG = "AiThreadMapper"
 }
 
-/** True if any Text block from [from] onward carries a `SUMMARY:` line — the model's "answer starts
- *  here" marker, used to gate the streamed answer reveal. */
-private fun List<ContentBlock>.trailingTextHasSummary(from: Int): Boolean =
-    drop(from).filterIsInstance<ContentBlock.Text>().any { block ->
-        block.text.lineSequence().any { SUMMARY_LINE.matchEntire(it.trim()) != null }
+/**
+ * The index (into assistant-only blocks) where the answer begins. Anchored to the model's explicit
+ * `SUMMARY:` marker — the last Text block carrying one is the start of the final answer; everything
+ * before it is thinking-process. ("Last" so a stray `SUMMARY:` in earlier narration loses to the real
+ * answer.) Stream content is append-only, so this index is stable across frames — no flash, no demotion.
+ *
+ * With no marker: while streaming, hold at the end (reveal nothing as the answer yet); once settled,
+ * fall back to the trailing run of Text blocks so SUMMARY-less / do_nothing turns still surface a body.
+ */
+internal fun answerStartOf(blocks: List<ContentBlock>, isStreaming: Boolean): Int {
+    val assistant = blocks.filterNot { it is ContentBlock.ToolResult }
+    val summaryIndex = assistant.indexOfLast { it is ContentBlock.Text && it.text.hasSummaryLine() }
+    return when {
+        summaryIndex >= 0 -> summaryIndex
+        isStreaming -> assistant.size
+        else -> assistant.indexOfLast { it !is ContentBlock.Text } + 1
     }
+}
+
+/** True if any line of this text is a `SUMMARY:` directive — the model's "answer starts here" marker. */
+private fun String.hasSummaryLine(): Boolean =
+    lineSequence().any { SUMMARY_LINE.matchEntire(it.trim()) != null }
 
 /** True if [line] is a strict prefix of a directive keyword still being typed (e.g. "STATU", "SUMMAR"),
  *  before its colon completes — so we can hold it back from display while streaming. */

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
@@ -247,14 +247,18 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                 data = EventData.EveningPlan(timezone = tz.id, location = location),
             )
             val fsm = SessionFsm(getApplication(), repository)
-            val current = db.sessionDao().findCurrent()
-            if (current != null) {
-                // Append the fresh evening-plan event (latest wins in the worker), pull in any
-                // plan-affecting setting changed since bootstrap, then re-run the turn.
+            val current = repository.findCurrent()
+            val morning = SessionRepository.morningDate(Clock.System.now(), tz)
+            if (current != null && current.date == morning) {
+                // Same-morning replan: append the fresh evening-plan event (latest wins in the worker),
+                // pull in any plan-affecting setting changed since bootstrap, then re-run the turn.
                 repository.appendEvent(current.id, event)
                 fsm.refreshPlanFromSettings(current.id)
                 repository.triggerAiTurn(current.id)
             } else {
+                // No session, or a stale one targeting an earlier morning (e.g. a morning re-run of a
+                // session created last night) — let the FSM supersede the stale one and bootstrap a
+                // fresh session for the correct upcoming morning, so the alarm isn't pinned to today.
                 fsm.onEvent(event)
             }
         }

--- a/app/src/main/java/fr/bsodium/cron/worker/AiPromptBuilder.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/AiPromptBuilder.kt
@@ -48,6 +48,7 @@ object AiPromptBuilder {
             if (location != null) {
                 appendLine("## Current location")
                 appendLine("- Latitude: ${location.lat}, Longitude: ${location.lng}")
+                location.address?.let { appendLine("- Address: $it") }
                 appendLine("- Source: ${location.source.name.lowercase()}")
                 appendLine("- Accuracy: ±${location.accuracyMeters?.let { "${it.toInt()} m" } ?: "unknown"}")
                 appendLine("- Captured at: ${location.capturedAt}")

--- a/app/src/test/java/fr/bsodium/cron/alarm/AlarmSchedulerClampTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/alarm/AlarmSchedulerClampTest.kt
@@ -83,4 +83,27 @@ class AlarmSchedulerClampTest {
         assertEquals(hardLatestInstant, result.actualInstant)
         assertTrue(result.clampedToHardLatest)
     }
+
+    @Test
+    fun request_on_the_wrong_day_is_pinned_to_the_session_morning() {
+        // Model emitted the day AFTER the session morning. Only its time-of-day (07:30 Paris) is kept,
+        // re-pinned onto sessionDate — so the alarm can never arm on the wrong day.
+        val now = Instant.parse("2026-05-22T03:00:00Z") // 05:00 Paris, on sessionDate
+        val nextDay = Instant.parse("2026-05-23T05:30:00Z") // 07:30 Paris, one day late
+        val expected = Instant.parse("2026-05-22T05:30:00Z") // 07:30 Paris on sessionDate
+        val result = AlarmScheduler.clamp(nextDay, now, hardLatest, date, tz)
+        assertEquals(expected, result.actualInstant)
+        assertFalse(result.clampedToHardLatest)
+    }
+
+    @Test
+    fun now_already_past_hard_latest_falls_back_to_min_lead_without_throwing() {
+        // Degenerate bound (lower > upper): now is past today's hard latest. Must not throw; slides to
+        // now + MIN_LEAD.
+        val now = Instant.parse("2026-05-22T09:00:00Z") // 11:00 Paris, past the 10:00 hard latest
+        val requested = Instant.parse("2026-05-22T05:30:00Z") // 07:30 Paris
+        val result = AlarmScheduler.clamp(requested, now, hardLatest, date, tz)
+        assertEquals(now + AlarmScheduler.MIN_LEAD, result.actualInstant)
+        assertFalse(result.clampedToHardLatest)
+    }
 }

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/home/AiThreadMapperTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/home/AiThreadMapperTest.kt
@@ -154,4 +154,53 @@ class AiThreadMapperTest {
         assertEquals("Set a 6:40 alarm so you make stand-up.", thread.response)
         assertEquals("Set your alarm", thread.summary)
     }
+
+    private val answerThenTool = listOf(
+        ContentBlock.Thinking(thinking = "Considering the morning."),
+        ContentBlock.Text("SUMMARY: Set your alarm\n\nSet a 6:40 alarm so you make stand-up."),
+        ContentBlock.ToolUse(id = "t1", name = "set_alarm", input = SessionJson.parseToJsonElement("{}")),
+    )
+
+    @Test
+    fun a_tool_after_the_summary_answer_does_not_pull_it_back_into_thinking() {
+        // The answer is anchored to the SUMMARY marker, so a trailing tool_use can't demote it back
+        // into the thinking thread — the bug that the positional "trailing run" heuristic produced.
+        val thread = AiThreadMapper.buildFromBlocks(turnIndex = 0, blocks = answerThenTool)
+        assertEquals("Set a 6:40 alarm so you make stand-up.", thread.response)
+        assertTrue(thread.process.filterIsInstance<ProcessItem.Narration>().isEmpty())
+    }
+
+    @Test
+    fun the_last_summary_block_wins_over_a_stray_summary_in_earlier_narration() {
+        val blocks = listOf(
+            ContentBlock.Thinking(thinking = "Considering."),
+            ContentBlock.Text("SUMMARY: misformatted early line\n\nsome narration"),
+            ContentBlock.ToolUse(id = "t1", name = "read_calendar", input = SessionJson.parseToJsonElement("{}")),
+            ContentBlock.Text("SUMMARY: Real decision\n\nThe real answer."),
+        )
+        val thread = AiThreadMapper.buildFromBlocks(turnIndex = 0, blocks = blocks)
+        assertEquals("The real answer.", thread.response)
+        assertEquals("Real decision", thread.summary)
+        // The stray-SUMMARY block stays in the process as narration (its directive line stripped).
+        val narration = thread.process.filterIsInstance<ProcessItem.Narration>().single()
+        assertEquals("some narration", narration.text)
+    }
+
+    @Test
+    fun answer_start_anchors_on_the_summary_marker() {
+        val narrating = listOf(
+            ContentBlock.Thinking(thinking = "Considering."),
+            ContentBlock.Text("Looking at tomorrow."),
+        )
+        val answered = listOf(
+            ContentBlock.Thinking(thinking = "Considering."),
+            ContentBlock.Text("SUMMARY: x\n\nbody"),
+        )
+        // No SUMMARY yet while streaming: the boundary sits at the end, so nothing is the answer.
+        assertEquals(2, answerStartOf(narrating, isStreaming = true))
+        // SUMMARY present: the boundary anchors on the SUMMARY-bearing block.
+        assertEquals(1, answerStartOf(answered, isStreaming = true))
+        // Settled with no SUMMARY: fall back to the trailing run of Text blocks.
+        assertEquals(1, answerStartOf(narrating, isStreaming = false))
+    }
 }


### PR DESCRIPTION
## Why
Three field bug reports against the on-device planning assistant, unrelated to the settings work — split into their own branch.

## What
**1. Wrong geocoded address (`fix(planner)`)** — the evening-plan prompt fed the model only raw `lat`/`lng`, so it reverse-geocoded coordinates in its head and sometimes named the wrong place. Now `LocationProvider` resolves the address on-device (keyless `android.location.Geocoder`, API-33 async / pre-33 sync, 5 s timeout, best-effort → null) into a new `LocationPayload.address`, `AiPromptBuilder` surfaces it as an `Address:` line, and `SystemPrompts` tells the model to use it verbatim and never infer a place from coordinates.

**2. Thinking flashes as the response, then jumps back (`fix(home)`)** — the answer was identified *positionally* (the trailing run of `Text` blocks), so a `Text` block shown as the answer was demoted back into the thinking thread the moment a later `tool_use`/`Thinking` block streamed in after it. `answerStartOf` now anchors to the model's explicit **`SUMMARY:` marker** (the last `SUMMARY`-bearing `Text` block); stream content is append-only, so that boundary is stable across frames — no flash, no demotion, and streaming/settled agree. Rare trade-off: a tool/thinking block emitted *after* the SUMMARY answer is dropped from the process list rather than reordering.

**3. Alarm armed for today instead of the next morning (`fix(home)` + `fix(alarm)`)** — two compounding causes:
- `HomeViewModel.retryAiPlan` reused a still-open session dated *today* and skipped the staleness check `SessionFsm.onEvent` has. It now re-derives `morningDate(now)` and routes stale sessions through `onEvent`, which supersedes the stale session and bootstraps a fresh one for the correct upcoming morning.
- `AlarmScheduler.clamp` bounded the request to `hardLatest@sessionDate` but kept the model's own date, dragging a tomorrow plan onto today's hard latest. The session now owns the alarm *date* and the model owns the *time-of-day*: the requested time is pinned onto `sessionDate` before clamping, with a `maxOf(lower, upper)` guard so `coerceIn` can't throw when `now` is already past the hard latest.

## Verification
`assembleDebug`, `lintDebug`, `testDebugUnitTest`, `checkFileLength` all pass (largest file 452 lines). New/updated unit tests: `AiThreadMapperTest` (tool-after-answer no longer demotes; last-`SUMMARY`-wins over a stray earlier one) and `AlarmSchedulerClampTest` (wrong-day request pinned to the session morning; past-hard-latest `now` doesn't throw).

**Not yet verified on-device:** the live streaming reveal (bug 2) and the supersede-on-morning-run flow with a real reverse-geocoded `Address:` line (bugs 1 & 3) need a device run to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
