### PR TITLE
feat(ui): morphing thinking shape, shorter evening-plan answer, fade fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,6 +134,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.graphics.shapes)
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.okhttp)

--- a/app/src/main/java/fr/bsodium/cron/ai/SystemPrompts.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/SystemPrompts.kt
@@ -112,13 +112,16 @@ object SystemPrompts {
         The app parses these STATUS/SUMMARY lines and strips them from the displayed text, so
         keep them short and each on its own line.
 
-        Style: write the final answer as two or three short paragraphs separated by blank lines,
-        not one dense block. Open with the decision (the wake time and the single biggest reason),
-        then give the supporting detail (calendar anchor, sleep, commute or buffer) in a following
-        paragraph. Keep it calm and scannable. Avoid em dashes: prefer a comma, a period, or a
-        reworded sentence, and use at most one in the whole answer. Light formatting is fine (a bold
-        time, or one short list when it genuinely helps), but do not use big headers, tables, or
-        multi-section breakdowns. The UI renders Markdown. No emojis or pictographs anywhere.
+        Style: keep the final answer short enough to read at a glance on a phone, without scrolling.
+        For an ordinary night, one short paragraph of two or three sentences is plenty: lead with the
+        decision (the wake time and the single biggest reason) and stop there. Only add more — one
+        extra short paragraph at most — when your reasoning led to an out-of-the-ordinary decision the
+        user wouldn't expect (an unusual wake time, skipping or cancelling the alarm, an unexpected
+        conflict or constraint); briefly say why. Don't pad an ordinary plan with supporting detail
+        the user can already assume. Keep it calm and scannable. Avoid em dashes: prefer a comma, a
+        period, or a reworded sentence, and use at most one in the whole answer. Light formatting is
+        fine (a bold time, or one short list when it genuinely helps), but do not use big headers,
+        tables, or multi-section breakdowns. The UI renders Markdown. No emojis or pictographs anywhere.
     """.trimIndent()
 
     /**

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -265,7 +265,9 @@ fun HomeScreen(
                     start = Spacing.xl,
                     end = Spacing.xl,
                     top = statusInsetTop + Spacing.xxl,
-                    bottom = navInsetBottom + Spacing.navBarClearance,
+                    // navBarClearance clears the pill; the extra xxxl matches the EdgeFades bottom
+                    // gradient's own xxxl so the last content (the thinking shape) rests above the fade.
+                    bottom = navInsetBottom + Spacing.navBarClearance + Spacing.xxxl,
                 ),
                 verticalArrangement = Arrangement.spacedBy(Spacing.xl),
             ) {

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -102,6 +102,12 @@ fun AiThinkingThread(
             Spacer(Modifier.height(Spacing.sm))
             ResponseBody(thread.response)
         }
+        val phase = when {
+            !inProgress -> ShapePhase.Resting
+            thread.response.isNullOrBlank() -> ShapePhase.Thinking
+            else -> ShapePhase.Writing
+        }
+        ThinkingShape(phase = phase, modifier = Modifier.padding(top = Spacing.md))
     }
 }
 

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ThinkingShape.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ThinkingShape.kt
@@ -1,0 +1,160 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package fr.bsodium.cron.ui.screens.home.components
+
+import android.graphics.Matrix
+import android.graphics.Path
+import android.graphics.RectF
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asComposePath
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.graphics.shapes.Morph
+import androidx.graphics.shapes.RoundedPolygon
+import androidx.graphics.shapes.toPath
+import fr.bsodium.cron.ui.theme.CronTheme
+
+/**
+ * Lifecycle phase that drives the [ThinkingShape] morph. Derived from the AI thread: not running →
+ * [Resting]; running with no answer yet → [Thinking]; running while the answer streams → [Writing].
+ */
+enum class ShapePhase { Resting, Thinking, Writing }
+
+/**
+ * A small brand-tinted Material shape under the AI thread that morphs with the assistant's state:
+ * cozy round shapes while thinking, sharp star shapes while the answer streams in, settling to a
+ * clover at rest — like a logo under a message.
+ */
+@Composable
+fun ThinkingShape(phase: ShapePhase, modifier: Modifier = Modifier) {
+    val color = MaterialTheme.colorScheme.primary
+    var current by remember { mutableStateOf(REST) }
+    var target by remember { mutableStateOf(REST) }
+    val progress = remember { Animatable(0f) }
+    val morph = remember(current, target) { Morph(current, target) }
+    val androidPath = remember { Path() }
+    val matrix = remember { Matrix() }
+
+    LaunchedEffect(phase) {
+        val cycle = when (phase) {
+            ShapePhase.Thinking -> COZY
+            ShapePhase.Writing -> SHARP
+            ShapePhase.Resting -> null
+        }
+        if (cycle == null) {
+            target = REST
+            progress.snapTo(0f)
+            progress.animateTo(1f, REST_SPEC)
+            current = REST
+            target = REST
+            progress.snapTo(0f)
+            return@LaunchedEffect
+        }
+        val step = if (phase == ShapePhase.Writing) WRITING_STEP_SPEC else THINKING_STEP_SPEC
+        var i = 0
+        while (true) {
+            val next = cycle[i % cycle.size]
+            target = next
+            progress.snapTo(0f)
+            progress.animateTo(1f, step)
+            current = next
+            i++
+        }
+    }
+
+    Canvas(modifier = modifier.size(SHAPE_SIZE)) {
+        drawMorph(morph, progress.value, color, androidPath, matrix)
+    }
+}
+
+/** Renders [morph] at [progress], fit and centered into the draw bounds (works for any polygon space). */
+private fun DrawScope.drawMorph(
+    morph: Morph,
+    progress: Float,
+    color: Color,
+    path: Path,
+    matrix: Matrix,
+) {
+    path.rewind()
+    morph.toPath(progress.coerceIn(0f, 1f), path)
+    val bounds = RectF()
+    path.computeBounds(bounds, true)
+    val span = maxOf(bounds.width(), bounds.height())
+    if (span <= 0f) return
+    val scale = size.minDimension / span
+    matrix.reset()
+    matrix.setScale(scale, scale)
+    matrix.postTranslate(
+        (size.width - bounds.width() * scale) / 2f - bounds.left * scale,
+        (size.height - bounds.height() * scale) / 2f - bounds.top * scale,
+    )
+    path.transform(matrix)
+    drawPath(path.asComposePath(), color = color)
+}
+
+private val SHAPE_SIZE = 28.dp
+
+// Slow, gentle cadence while thinking; snappy while the answer streams; a soft landing into the clover.
+private val THINKING_STEP_SPEC = tween<Float>(durationMillis = 1400, easing = FastOutSlowInEasing)
+private val WRITING_STEP_SPEC = tween<Float>(durationMillis = 240, easing = FastOutSlowInEasing)
+private val REST_SPEC = tween<Float>(durationMillis = 420, easing = FastOutSlowInEasing)
+
+// Resting clover; cozy round shapes for thinking; sharp star shapes for streaming.
+private val REST: RoundedPolygon = MaterialShapes.Clover4Leaf
+private val COZY: List<RoundedPolygon> = listOf(
+    MaterialShapes.Cookie9Sided,
+    MaterialShapes.Cookie6Sided,
+    MaterialShapes.SoftBurst,
+    MaterialShapes.Sunny,
+    MaterialShapes.Puffy,
+    MaterialShapes.Clover4Leaf,
+)
+private val SHARP: List<RoundedPolygon> = listOf(
+    MaterialShapes.Burst,
+    MaterialShapes.Boom,
+    MaterialShapes.VerySunny,
+    MaterialShapes.Gem,
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun ThinkingShapePreview() {
+    CronTheme {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(16.dp),
+        ) {
+            StaticShape(REST)
+            StaticShape(COZY.first())
+            StaticShape(SHARP.first())
+        }
+    }
+}
+
+@Composable
+private fun StaticShape(polygon: RoundedPolygon) {
+    val color = MaterialTheme.colorScheme.primary
+    val morph = remember(polygon) { Morph(polygon, polygon) }
+    val path = remember { Path() }
+    val matrix = remember { Matrix() }
+    Canvas(modifier = Modifier.size(SHAPE_SIZE)) { drawMorph(morph, 0f, color, path, matrix) }
+}

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ThinkingShape.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ThinkingShape.kt
@@ -6,10 +6,9 @@ import android.graphics.Matrix
 import android.graphics.Path
 import android.graphics.RectF
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
@@ -80,23 +79,25 @@ fun ThinkingShape(phase: ShapePhase, modifier: Modifier = Modifier) {
             progress.snapTo(0f)
             coroutineScope {
                 launch { progress.animateTo(1f, REST_SPEC) }
-                launch { rotation.animateTo(nearestUpright(rotation.value), REST_SPIN_SPEC) }
+                launch { rotation.animateTo(nearestUpright(rotation.value), REST_SPEC) }
             }
             current = REST
             target = REST
             progress.snapTo(0f)
             return@LaunchedEffect
         }
-        val step = if (phase == ShapePhase.Writing) WRITING_STEP_SPEC else THINKING_STEP_SPEC
+        val writing = phase == ShapePhase.Writing
+        val morphSpec = if (writing) WRITING_STEP_SPEC else THINKING_STEP_SPEC
+        val spinSpec = if (writing) WRITING_SPIN_SPEC else THINKING_SPIN_SPEC
         var i = 0
         while (true) {
             val next = cycle[i % cycle.size]
             target = next
             progress.snapTo(0f)
-            // Morph and a quick springy spin run together — one spin per morph step.
+            // Morph and spin share a duration, so the spin lasts exactly as long as the morph.
             coroutineScope {
-                launch { progress.animateTo(1f, step) }
-                launch { rotation.animateTo(rotation.value + STEP_DEG, SPIN_SPEC) }
+                launch { progress.animateTo(1f, morphSpec) }
+                launch { rotation.animateTo(rotation.value + STEP_DEG, spinSpec) }
             }
             current = next
             i++
@@ -151,13 +152,18 @@ private val STROKE_WIDTH = 2.dp
 private const val STEP_DEG = 120f
 
 // Slow, gentle cadence while thinking; snappy while the answer streams; a soft landing into the heart.
-private val THINKING_STEP_SPEC = tween<Float>(durationMillis = 1100, easing = FastOutSlowInEasing)
-private val WRITING_STEP_SPEC = tween<Float>(durationMillis = 240, easing = FastOutSlowInEasing)
-private val REST_SPEC = tween<Float>(durationMillis = 420, easing = FastOutSlowInEasing)
+private const val THINKING_STEP_MS = 1100
+private const val WRITING_STEP_MS = 240
+private const val REST_MS = 420
+private val THINKING_STEP_SPEC = tween<Float>(durationMillis = THINKING_STEP_MS, easing = FastOutSlowInEasing)
+private val WRITING_STEP_SPEC = tween<Float>(durationMillis = WRITING_STEP_MS, easing = FastOutSlowInEasing)
+private val REST_SPEC = tween<Float>(durationMillis = REST_MS, easing = FastOutSlowInEasing)
 private val FILL_SPEC = tween<Float>(durationMillis = 360, easing = FastOutSlowInEasing)
-// Quick, springy spin per morph step; calm critically-damped settle to upright at rest.
-private val SPIN_SPEC = spring<Float>(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium)
-private val REST_SPIN_SPEC = spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow)
+// The spin shares the morph's per-phase duration so it lasts exactly as long as the morph, with a
+// mild ease-out-back overshoot for a springy arrival.
+private val SPIN_EASING = CubicBezierEasing(0.34f, 1.4f, 0.64f, 1f)
+private val THINKING_SPIN_SPEC = tween<Float>(durationMillis = THINKING_STEP_MS, easing = SPIN_EASING)
+private val WRITING_SPIN_SPEC = tween<Float>(durationMillis = WRITING_STEP_MS, easing = SPIN_EASING)
 
 // Filled heart at rest; cozy round shapes for thinking; sharp star shapes for streaming.
 private val REST: RoundedPolygon = MaterialShapes.Heart

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ThinkingShape.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ThinkingShape.kt
@@ -7,6 +7,9 @@ import android.graphics.Path
 import android.graphics.RectF
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
@@ -26,12 +29,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asComposePath
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.graphics.shapes.Morph
 import androidx.graphics.shapes.RoundedPolygon
 import androidx.graphics.shapes.toPath
 import fr.bsodium.cron.ui.theme.CronTheme
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 /**
  * Lifecycle phase that drives the [ThinkingShape] morph. Derived from the AI thread: not running →
@@ -40,9 +47,9 @@ import fr.bsodium.cron.ui.theme.CronTheme
 enum class ShapePhase { Resting, Thinking, Writing }
 
 /**
- * A small brand-tinted Material shape under the AI thread that morphs with the assistant's state:
- * cozy round shapes while thinking, sharp star shapes while the answer streams in, settling to a
- * clover at rest — like a logo under a message.
+ * A small brand-tinted Material shape under the AI thread that morphs with the assistant's state,
+ * spinning springily with each morph: an outlined cozy shape while thinking, a filled sharp star
+ * while the answer streams in, settling to a filled heart at rest — like a logo under a message.
  */
 @Composable
 fun ThinkingShape(phase: ShapePhase, modifier: Modifier = Modifier) {
@@ -50,9 +57,16 @@ fun ThinkingShape(phase: ShapePhase, modifier: Modifier = Modifier) {
     var current by remember { mutableStateOf(REST) }
     var target by remember { mutableStateOf(REST) }
     val progress = remember { Animatable(0f) }
+    val rotation = remember { Animatable(0f) }
     val morph = remember(current, target) { Morph(current, target) }
     val androidPath = remember { Path() }
     val matrix = remember { Matrix() }
+    // Outline while thinking (no answer yet); fill in once the answer streams and at rest.
+    val fill by animateFloatAsState(
+        targetValue = if (phase == ShapePhase.Thinking) 0f else 1f,
+        animationSpec = FILL_SPEC,
+        label = "shape-fill",
+    )
 
     LaunchedEffect(phase) {
         val cycle = when (phase) {
@@ -61,9 +75,13 @@ fun ThinkingShape(phase: ShapePhase, modifier: Modifier = Modifier) {
             ShapePhase.Resting -> null
         }
         if (cycle == null) {
+            // Settle to the heart, upright (nearest full turn) so it lands level.
             target = REST
             progress.snapTo(0f)
-            progress.animateTo(1f, REST_SPEC)
+            coroutineScope {
+                launch { progress.animateTo(1f, REST_SPEC) }
+                launch { rotation.animateTo(nearestUpright(rotation.value), REST_SPIN_SPEC) }
+            }
             current = REST
             target = REST
             progress.snapTo(0f)
@@ -75,21 +93,30 @@ fun ThinkingShape(phase: ShapePhase, modifier: Modifier = Modifier) {
             val next = cycle[i % cycle.size]
             target = next
             progress.snapTo(0f)
-            progress.animateTo(1f, step)
+            // Morph and a quick springy spin run together — one spin per morph step.
+            coroutineScope {
+                launch { progress.animateTo(1f, step) }
+                launch { rotation.animateTo(rotation.value + STEP_DEG, SPIN_SPEC) }
+            }
             current = next
             i++
         }
     }
 
     Canvas(modifier = modifier.size(SHAPE_SIZE)) {
-        drawMorph(morph, progress.value, color, androidPath, matrix)
+        drawMorph(morph, progress.value, rotation.value, fill, color, androidPath, matrix)
     }
 }
 
-/** Renders [morph] at [progress], fit and centered into the draw bounds (works for any polygon space). */
+/**
+ * Renders [morph] at [progress], rotated by [rotationDeg] and fit-and-centered into the draw bounds
+ * (with [SHAPE_FIT] margin so rotation never clips). [fillFraction] crossfades stroke→fill.
+ */
 private fun DrawScope.drawMorph(
     morph: Morph,
     progress: Float,
+    rotationDeg: Float,
+    fillFraction: Float,
     color: Color,
     path: Path,
     matrix: Matrix,
@@ -100,26 +127,40 @@ private fun DrawScope.drawMorph(
     path.computeBounds(bounds, true)
     val span = maxOf(bounds.width(), bounds.height())
     if (span <= 0f) return
-    val scale = size.minDimension / span
+    val scale = size.minDimension * SHAPE_FIT / span
     matrix.reset()
     matrix.setScale(scale, scale)
     matrix.postTranslate(
         (size.width - bounds.width() * scale) / 2f - bounds.left * scale,
         (size.height - bounds.height() * scale) / 2f - bounds.top * scale,
     )
+    matrix.postRotate(rotationDeg, size.width / 2f, size.height / 2f)
     path.transform(matrix)
-    drawPath(path.asComposePath(), color = color)
+    val composePath = path.asComposePath()
+    val fill = fillFraction.coerceIn(0f, 1f)
+    if (fill > 0f) drawPath(composePath, color = color.copy(alpha = fill))
+    if (fill < 1f) drawPath(composePath, color = color.copy(alpha = 1f - fill), style = Stroke(width = STROKE_WIDTH.toPx()))
 }
 
-private val SHAPE_SIZE = 28.dp
+private fun nearestUpright(deg: Float): Float = (deg / 360f).roundToInt() * 360f
 
-// Slow, gentle cadence while thinking; snappy while the answer streams; a soft landing into the clover.
-private val THINKING_STEP_SPEC = tween<Float>(durationMillis = 1400, easing = FastOutSlowInEasing)
+// Canvas is a touch larger than the visible shape so a spun shape never clips at the edges.
+private val SHAPE_SIZE = 32.dp
+private const val SHAPE_FIT = 0.8f
+private val STROKE_WIDTH = 2.dp
+private const val STEP_DEG = 120f
+
+// Slow, gentle cadence while thinking; snappy while the answer streams; a soft landing into the heart.
+private val THINKING_STEP_SPEC = tween<Float>(durationMillis = 1100, easing = FastOutSlowInEasing)
 private val WRITING_STEP_SPEC = tween<Float>(durationMillis = 240, easing = FastOutSlowInEasing)
 private val REST_SPEC = tween<Float>(durationMillis = 420, easing = FastOutSlowInEasing)
+private val FILL_SPEC = tween<Float>(durationMillis = 360, easing = FastOutSlowInEasing)
+// Quick, springy spin per morph step; calm critically-damped settle to upright at rest.
+private val SPIN_SPEC = spring<Float>(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium)
+private val REST_SPIN_SPEC = spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow)
 
-// Resting clover; cozy round shapes for thinking; sharp star shapes for streaming.
-private val REST: RoundedPolygon = MaterialShapes.Clover4Leaf
+// Filled heart at rest; cozy round shapes for thinking; sharp star shapes for streaming.
+private val REST: RoundedPolygon = MaterialShapes.Heart
 private val COZY: List<RoundedPolygon> = listOf(
     MaterialShapes.Cookie9Sided,
     MaterialShapes.Cookie6Sided,
@@ -143,18 +184,18 @@ private fun ThinkingShapePreview() {
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier.padding(16.dp),
         ) {
-            StaticShape(REST)
-            StaticShape(COZY.first())
-            StaticShape(SHARP.first())
+            StaticShape(REST, fill = 1f)
+            StaticShape(COZY.first(), fill = 0f)
+            StaticShape(SHARP.first(), fill = 1f)
         }
     }
 }
 
 @Composable
-private fun StaticShape(polygon: RoundedPolygon) {
+private fun StaticShape(polygon: RoundedPolygon, fill: Float) {
     val color = MaterialTheme.colorScheme.primary
     val morph = remember(polygon) { Morph(polygon, polygon) }
     val path = remember { Path() }
     val matrix = remember { Matrix() }
-    Canvas(modifier = Modifier.size(SHAPE_SIZE)) { drawMorph(morph, 0f, color, path, matrix) }
+    Canvas(modifier = Modifier.size(SHAPE_SIZE)) { drawMorph(morph, 0f, 0f, fill, color, path, matrix) }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.4"
 composeBom = "2026.02.01"
 material3 = "1.5.0-alpha18"
+graphicsShapes = "1.0.1"
 workRuntimeKtx = "2.11.1"
 lifecycleViewmodelCompose = "2.10.0"
 okhttp = "5.3.2"
@@ -46,6 +47,7 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+androidx-graphics-shapes = { group = "androidx.graphics", name = "graphics-shapes", version.ref = "graphicsShapes" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntimeKtx" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }


### PR DESCRIPTION
Home-screen polish bundle.

## 1. Morphing Material shape under the AI thread
A small brand-primary Material shape sits at the bottom-left of the AI thread, like a logo under a message, morphing with the assistant's state:
- **Thinking** → gentle continuous morph through round cozy cookie shapes
- **Writing** (answer streaming) → rapid morph through sharp star shapes
- **Resting** (done/idle) → settles to and holds the clover

Adds `androidx.graphics:graphics-shapes`. New `ThinkingShape.kt` cycles `MaterialShapes` via `Morph`, fit-and-centered into a 28dp canvas, `colorScheme.primary` tint, flat, with a `@Preview`. Phase is derived in `AiThinkingThread` from `isRunning` + `response` presence; visible only while an AI thread exists.

## 2. Shorter evening-plan answer
The nightly answer overflowed the screen and forced scrolling. Tightened the `EVENING_PLAN` system prompt: one short paragraph (wake time + the single biggest reason) for an ordinary night, expanding by at most one paragraph only when the reasoning led to an out-of-the-ordinary decision (unusual wake time, skip/cancel, unexpected conflict). Existing constraints (no em dashes, light formatting, no headers/tables/emojis) kept. `OVERNIGHT_REPLAN` untouched.

## 3. Fix: shape dimmed by the bottom nav fade
The `EdgeFades` bottom gradient is `navBar + navBarClearance + xxxl` tall, but the home `LazyColumn` bottom padding was only `navBar + navBarClearance`, so the shape rested ~32dp inside the fade. Added `Spacing.xxxl` to the bottom contentPadding so it clears the fade at rest; the fade aesthetic is unchanged for scrolling content.

## Verification
- `./gradlew :app:assembleDebug :app:lintDebug :app:checkFileLength :app:testDebugUnitTest` — all green.
- Headless render (Robolectric `NATIVE`) confirmed the three shape phases: clover at rest, round cookie thinking, sharp star writing — each fully rendered, centered, primary-tinted at ~28dp.
- Occlusion fix confirmed geometrically (shape's rest position moves to the fade's transparent top edge); brevity is prompt-only (observed in day-to-day use).