### PR TITLE
feat(home): clock empty-state illustration, themed tri-hue to Material You

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextPlanHint.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextPlanHint.kt
@@ -1,5 +1,6 @@
 package fr.bsodium.cron.ui.screens.home.components
 
+import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -89,21 +91,30 @@ private fun nextPlanSubline(autoAlarmsEnabled: Boolean, eveningTriggerTime: Loca
 }
 
 /**
- * The empty-state artwork, its fixed palette retinted onto Material You (three distinct roles, contrast
- * mirroring the original dark-ink / green / white-paper): ink + the few black strokes → `onSurface`
- * (line-art legible in light & dark), the green → `primary` (the lone chromatic accent), the white
- * surfaces → `surfaceVariant` (a soft raised fill). All 109 paths kept — `recolored` only swaps colors.
+ * The empty-state clock, its fixed palette retinted onto Material You across three accent hues so it tracks
+ * the wallpaper instead of reading monochrome: the dial → `primary`, the background "speed wings" →
+ * `tertiary` (their lighter overlay → `tertiaryContainer`), the bells + feet → `secondary`; the numbers,
+ * hands, ticks and shading → `onSurface` (line-art legible in light & dark); the dial face/sheen → `surface`
+ * and the ground shadow → `surfaceVariant`. `recolored` only swaps colors, preserving every path's alpha.
  */
 @Composable
 private fun NoPlanIllustration(modifier: Modifier = Modifier) {
     val scheme = MaterialTheme.colorScheme
     val source = ImageVector.vectorResource(R.drawable.ic_no_plan_illustration)
-    val illustration = remember(source, scheme.onSurface, scheme.primary, scheme.surfaceVariant) {
+    val illustration = remember(
+        source,
+        scheme.onSurface, scheme.primary, scheme.secondary, scheme.tertiary,
+        scheme.tertiaryContainer, scheme.surface, scheme.surfaceVariant,
+    ) {
         source.recolored { original ->
             when (original) {
                 NO_PLAN_INK, NO_PLAN_BLACK -> scheme.onSurface
-                NO_PLAN_ACCENT -> scheme.primary
-                NO_PLAN_PAPER -> scheme.surfaceVariant
+                NO_PLAN_PRIMARY -> scheme.primary
+                NO_PLAN_SECONDARY -> scheme.secondary
+                NO_PLAN_TERTIARY -> scheme.tertiary
+                NO_PLAN_TERTIARY_LIGHT -> scheme.tertiaryContainer
+                NO_PLAN_PAPER -> scheme.surface
+                NO_PLAN_GROUND -> scheme.surfaceVariant
                 else -> original
             }
         }
@@ -111,17 +122,25 @@ private fun NoPlanIllustration(modifier: Modifier = Modifier) {
     Image(imageVector = illustration, contentDescription = null, modifier = modifier)
 }
 
-/** Source fills/strokes of `ic_no_plan_illustration`, remapped onto `colorScheme` (see [recolored]). */
+/** Source fills of `ic_no_plan_illustration` (sentinel hues assigned per region), remapped onto
+ *  `colorScheme` (see [recolored]). */
 private val NO_PLAN_INK = Color(0xFF263238)
-private val NO_PLAN_ACCENT = Color(0xFF92E3A9)
-private val NO_PLAN_PAPER = Color(0xFFFFFFFF)
 private val NO_PLAN_BLACK = Color(0xFF000000)
+private val NO_PLAN_PRIMARY = Color(0xFF407BFF)
+private val NO_PLAN_SECONDARY = Color(0xFFEE3377)
+private val NO_PLAN_TERTIARY = Color(0xFF11AA99)
+private val NO_PLAN_TERTIARY_LIGHT = Color(0xFF66E0D0)
+private val NO_PLAN_PAPER = Color(0xFFFFFFFF)
+private val NO_PLAN_GROUND = Color(0xFFF5F5F5)
 
-@Preview(showBackground = true, name = "No-plan illustration")
+@Preview(showBackground = true, name = "No-plan illustration — light")
+@Preview(showBackground = true, name = "No-plan illustration — dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun NoPlanIllustrationPreview() {
     CronTheme {
-        NoPlanIllustration(Modifier.padding(Spacing.xl).size(220.dp))
+        Surface(color = MaterialTheme.colorScheme.background) {
+            NoPlanIllustration(Modifier.padding(Spacing.xl).size(220.dp))
+        }
     }
 }
 

--- a/app/src/main/res/drawable/ic_no_plan_illustration.xml
+++ b/app/src/main/res/drawable/ic_no_plan_illustration.xml
@@ -4,678 +4,226 @@
     android:viewportWidth="500"
     android:viewportHeight="500">
     <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeMiterLimit="10"
-        android:pathData="M412.65 353.78c-0.92-1 2.8-6.6 1.81-7.51s-6.28 3.2-7.35 2.38 1.53-7 0.39-7.72-5.57 4.32-6.78 3.7 0.22-7.15-1-7.65-4.68 5.27-6 4.89-1.1-7.07-2.43-7.33-3.63 6-5 5.9-2.38-6.75-3.74-6.76-2.46 6.6-3.82 6.71-3.56-6.2-4.91-6-1.2 6.93-2.52 7.3-4.64-5.45-5.92-5 0.1 7-1.13 7.64-5.57-4.49-6.74-3.78 1.4 6.9 0.3 7.72-6.3-3.4-7.32-2.48 2.62 6.55 1.7 7.54-6.82-2.18-7.64-1.11 3.77 5.95 3 7.1-7.11-0.88-7.72 0.33 4.81 5.14 4.31 6.41-7.14 0.44-7.52 1.74 5.68 4.17 5.42 5.51-6.94 1.74-7.08 3.1 6.35 3.05 6.34 4.42-6.51 3-6.39 4.33 6.79 1.85 7 3.19-5.85 4.12-5.48 5.44 7 0.56 7.5 1.84-5 5.12-4.39 6.35 7-0.75 7.72 0.42-4 6-3.14 7.06 6.74-2 7.66-1-2.79 6.6-1.8 7.51 6.27-3.2 7.34-2.38-1.53 7-0.39 7.72 5.57-4.31 6.78-3.7-0.22 7.15 1.05 7.65 4.67-5.27 6-4.89 1.1 7.08 2.43 7.33 3.63-6 5-5.9 2.37 6.75 3.73 6.76 2.46-6.6 3.82-6.71 3.57 6.2 4.91 6 1.21-6.93 2.52-7.3 4.65 5.45 5.92 5-0.09-7 1.14-7.64 5.56 4.49 6.73 3.78-1.4-6.9-0.3-7.72 6.3 3.4 7.32 2.48-2.61-6.55-1.7-7.54 6.83 2.18 7.65 1.11-3.78-5.95-3.06-7.1 7.11 0.88 7.72-0.33-4.81-5.14-4.31-6.4 7.14-0.45 7.52-1.75-5.67-4.17-5.42-5.51 6.95-1.74 7.08-3.09-6.35-3.06-6.34-4.42 6.51-3 6.39-4.34-6.79-1.85-7-3.19 5.85-4.12 5.48-5.44-7-0.56-7.5-1.83 5-5.13 4.39-6.36-7 0.75-7.71-0.42 4-6 3.13-7.06S413.58 354.8 412.65 353.78ZM397.41 408c-1.27 4.67-10.83 6.16-21.37 3.31s-18.05-8.95-16.78-13.62 10.82-6.16 21.36-3.31S398.67 403.35 397.41 408Zm-9.54-21a6.21 6.21 0 1 1 0.46-8.76A6.21 6.21 0 0 1 387.87 387ZM372.7 372.83c-5.61 7.52-13.31 11.27-17.19 8.38s-2.47-11.35 3.14-18.87S372 351.07 375.84 354 378.32 365.31 372.7 372.83ZM410 368.3c4.86 9.77 5.28 19.44 0.95 21.59s-11.79-4-16.65-13.78-5.29-19.44-1-21.6S405.13 358.53 410 368.3Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeMiterLimit="10"
-        android:pathData="M334.92 407.58c0-0.8 3.77-1.76 3.69-2.54s-3.95-1.06-4.09-1.83 3.38-2.42 3.16-3.18-4.07-0.3-4.36-1 2.88-3 2.53-3.71-4.07 0.45-4.48-0.22 2.27-3.47 1.79-4.1-3.91 1.19-4.44 0.61 1.6-3.84 1-4.37-3.63 1.89-4.26 1.41 0.87-4.06 0.2-4.48-3.21 2.52-3.92 2.17 0.11-4.15-0.63-4.44-2.69 3.07-3.46 2.86-0.66-4.1-1.44-4.25-2.07 3.52-2.87 3.45S312 380 311.17 380s-1.42 3.83-2.2 3.91-2.09-3.59-2.87-3.45-0.68 4-1.43 4.25-2.73-3.14-3.46-2.86 0.08 4.09-0.63 4.44-3.25-2.58-3.92-2.17 0.83 4 0.2 4.48-3.68-1.94-4.26-1.41 1.55 3.78 1 4.37-4-1.25-4.45-0.61 2.22 3.43 1.8 4.1-4.12-0.49-4.48 0.22 2.81 3 2.52 3.71-4.14 0.27-4.36 1 3.31 2.4 3.17 3.18-4 1-4.1 1.83 3.7 1.74 3.7 2.54-3.77 1.76-3.7 2.54 3.95 1.05 4.1 1.82-3.38 2.43-3.17 3.18 4.08 0.31 4.36 1-2.87 3-2.52 3.71 4.07-0.46 4.48 0.21-2.27 3.48-1.8 4.11 3.91-1.2 4.45-0.61-1.6 3.83-1 4.37 3.63-1.89 4.26-1.42-0.88 4.07-0.2 4.48 3.21-2.52 3.92-2.17-0.11 4.16 0.63 4.44 2.69-3.07 3.46-2.85 0.65 4.1 1.43 4.24 2.08-3.51 2.87-3.44 1.4 3.91 2.2 3.91 1.41-3.84 2.19-3.91 2.1 3.59 2.87 3.44 0.69-4 1.44-4.24 2.72 3.14 3.46 2.85-0.08-4.08 0.63-4.44 3.25 2.59 3.92 2.17-0.83-4-0.2-4.48 3.67 2 4.26 1.42-1.55-3.79-1-4.37 4 1.24 4.44 0.61-2.21-3.44-1.79-4.11 4.12 0.5 4.48-0.21-2.81-3-2.53-3.71 4.15-0.27 4.36-1-3.31-2.39-3.16-3.18 4-1 4.09-1.82S334.92 408.38 334.92 407.58Zm-27.65 17.47c-2.36 1.53-7.06-1.55-10.5-6.87s-4.31-10.87-1.95-12.39 7.06 1.55 10.5 6.87S309.63 423.53 307.27 425.05Zm4.06-12.77a3.61 3.61 0 1 1 3.6-3.61A3.61 3.61 0 0 1 311.33 412.28Zm-1.05-12c-5.34 1.06-10.12-0.31-10.67-3.07s3.34-5.85 8.68-6.92 10.13 0.31 10.68 3.07S315.63 399.21 310.28 400.28Zm17.85 12.53c-1.7 6.1-5.27 10.44-8 9.69s-3.53-6.32-1.83-12.42 5.26-10.44 8-9.69S329.83 406.7 328.13 412.81Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeMiterLimit="10"
-        android:pathData="M230.85 77.22c0-0.8 3.77-1.76 3.7-2.54s-4-1.06-4.1-1.83 3.38-2.42 3.17-3.17-4.08-0.31-4.36-1 2.87-3 2.52-3.71-4.06 0.46-4.48-0.21 2.27-3.48 1.8-4.11-3.91 1.19-4.44 0.61 1.6-3.83 1-4.37-3.62 1.89-4.25 1.41 0.87-4.06 0.2-4.48-3.22 2.53-3.93 2.17 0.11-4.15-0.63-4.44-2.69 3.08-3.45 2.86-0.66-4.1-1.44-4.25-2.08 3.52-2.87 3.45-1.4-3.91-2.2-3.91-1.41 3.84-2.19 3.91S202.81 50 202 50.12s-0.68 4-1.44 4.25-2.72-3.14-3.46-2.86 0.08 4.09-0.62 4.44-3.26-2.58-3.93-2.17 0.83 4 0.2 4.49-3.67-2-4.26-1.42 1.55 3.79 1 4.37-4-1.24-4.44-0.61 2.21 3.44 1.8 4.11-4.13-0.5-4.48 0.21 2.81 3 2.52 3.71-4.15 0.27-4.36 1 3.31 2.39 3.16 3.17-4 1-4.09 1.83 3.69 1.74 3.69 2.54-3.76 1.76-3.69 2.54 4 1.06 4.09 1.83-3.38 2.42-3.16 3.17 4.07 0.31 4.36 1-2.88 3-2.52 3.71 4.06-0.46 4.48 0.21-2.28 3.48-1.8 4.11 3.91-1.19 4.44-0.61-1.6 3.84-1 4.37 3.63-1.89 4.26-1.41-0.87 4.06-0.2 4.48 3.22-2.53 3.93-2.17-0.12 4.15 0.62 4.44 2.7-3.08 3.46-2.86 0.66 4.1 1.44 4.25 2.08-3.52 2.87-3.45 1.39 3.91 2.19 3.91 1.42-3.84 2.2-3.91 2.1 3.59 2.87 3.45 0.68-4 1.44-4.25 2.72 3.14 3.45 2.86-0.07-4.09 0.63-4.44 3.26 2.58 3.93 2.17-0.83-4-0.2-4.48 3.67 1.94 4.25 1.41-1.55-3.78-1-4.37 4 1.24 4.44 0.61-2.22-3.43-1.8-4.11 4.13 0.5 4.48-0.21-2.81-3-2.52-3.71 4.14-0.27 4.36-1-3.31-2.39-3.17-3.17 4-1 4.1-1.83S230.85 78 230.85 77.22ZM203.2 94.7c-2.36 1.52-7.06-1.55-10.5-6.87s-4.31-10.88-1.95-12.4 7.06 1.55 10.5 6.87S205.57 93.17 203.2 94.7Zm4.06-12.78a3.6 3.6 0 1 1 3.6-3.6A3.6 3.6 0 0 1 207.26 81.92Zm-1-12c-5.35 1.06-10.12-0.31-10.67-3.06s3.34-5.86 8.68-6.92 10.12 0.3 10.67 3.06S211.56 68.85 206.22 69.92Zm17.85 12.53c-1.7 6.1-5.27 10.44-8 9.69s-3.53-6.31-1.83-12.42 5.27-10.44 8-9.68S225.76 76.35 224.07 82.45Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeMiterLimit="10"
-        android:pathData="M166 412c1-0.91 6.55 2.89 7.48 1.92s-3.11-6.33-2.27-7.39 7 1.65 7.71 0.51-4.22-5.63-3.59-6.83 7.15 0.33 7.67-0.93-5.2-4.76-4.8-6 7.09-1 7.37-2.32-6-3.73-5.82-5.08 6.79-2.26 6.82-3.62-6.56-2.57-6.65-3.93 6.26-3.47 6-4.81-6.92-1.32-7.26-2.64 5.52-4.56 5.05-5.84-7 0-7.62-1.26 4.58-5.49 3.88-6.67-6.92 1.29-7.72 0.17 3.5-6.24 2.59-7.27-6.58 2.51-7.56 1.58 2.28-6.79 1.22-7.63-6 3.68-7.14 2.94 1-7.09-0.2-7.72-5.22 4.73-6.48 4.21-0.33-7.15-1.63-7.55-4.26 5.61-5.59 5.33-1.63-7-3-7.12-3.16 6.29-4.52 6.26-2.88-6.55-4.24-6.46-1.95 6.77-3.3 7-4-5.92-5.35-5.57-0.67 7-2 7.47-5-5.07-6.29-4.49 0.64 7-0.54 7.71-5.89-4.06-7-3.25 1.93 6.77 0.89 7.67-6.55-2.89-7.48-1.92 3.1 6.33 2.26 7.39-3.48 5.13-4.11 6.32-7.16-0.33-7.67 0.93 5.19 4.76 4.79 6-7.09 1-7.37 2.32 6 3.73 5.83 5.08-6.79 2.26-6.82 3.62 6.55 2.57 6.65 3.93-6.26 3.47-6 4.81 6.91 1.32 7.26 2.64-5.52 4.56-5.06 5.85 7 0 7.63 1.25-4.58 5.5-3.89 6.68 6.92-1.29 7.73-0.18-3.5 6.24-2.6 7.27 6.59-2.51 7.57-1.58-2.29 6.79-1.23 7.63 6-3.68 7.14-2.94-1 7.09 0.21 7.72 5.22-4.73 6.47-4.21 0.33 7.15 1.63 7.55 4.26-5.61 5.59-5.33 1.64 7 3 7.12 3.16-6.29 4.52-6.26 2.88 6.55 4.24 6.46 2-6.77 3.29-7 4 5.92 5.35 5.57 0.67-7 2-7.47 5 5.07 6.29 4.49-0.65-7 0.53-7.71 5.9 4.06 7 3.25S165 412.89 166 412Zm-54-16.11c-4.65-1.33-6-10.92-3-21.41s9.23-17.91 13.89-16.57 6 10.93 3 21.41S116.66 397.22 112 395.88Zm21.18-9.2a6.21 6.21 0 1 1 8.76 0.6A6.22 6.22 0 0 1 133.18 386.68Zm14.4-14.94c-7.43-5.73-11.06-13.49-8.11-17.32s11.38-2.3 18.82 3.43 11.06 13.49 8.1 17.32S155 377.47 147.58 371.74Zm3.94 37.36c-9.84 4.71-19.52 5-21.61 0.61S134.11 398 144 393.28s19.52-5 21.61-0.61S161.37 404.39 151.52 409.1Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeMiterLimit="10"
-        android:pathData="M399.59 157.21c1.25-0.59 5.5 4.59 6.66 3.91s-1.24-6.94-0.14-7.73 6.25 3.51 7.27 2.62-2.5-6.58-1.57-7.56 6.79 2.29 7.63 1.23-3.68-6-2.94-7.15 7.09 1 7.73-0.19-4.72-5.23-4.2-6.49 7.15-0.3 7.56-1.6-5.6-4.28-5.31-5.61 7-1.6 7.13-3-6.28-3.17-6.25-4.54 6.56-2.86 6.47-4.22-6.76-2-7-3.31 5.92-4 5.58-5.34-7-0.67-7.48-2 5.09-5 4.5-6.28-7 0.59-7.7-0.57 4.07-5.89 3.28-7-6.79 1.87-7.67 0.85 2.91-6.54 1.93-7.48S408.77 89 407.7 88.1s1.66-7 0.52-7.7-5.64 4.21-6.84 3.58 0.35-7.15-0.9-7.67-4.78 5.18-6.08 4.77-1-7.09-2.29-7.38-3.74 6-5.1 5.81-2.23-6.8-3.6-6.83-2.58 6.55-3.94 6.64-3.45-6.27-4.81-6-1.31 6.91-2.64 7.26-4.55-5.53-5.84-5.06 0 7-1.27 7.62-5.5-4.59-6.66-3.91 1.24 6.94 0.14 7.72-6.24-3.5-7.27-2.62 2.51 6.59 1.57 7.57-6.78-2.3-7.63-1.23 3.68 6 2.94 7.14-7.09-1-7.72 0.2 4.71 5.23 4.19 6.48-7.15 0.31-7.55 1.61 5.59 4.27 5.31 5.61-7 1.6-7.14 3 6.29 3.18 6.25 4.54-6.56 2.86-6.47 4.23 6.76 2 7 3.3-5.92 4-5.57 5.35 7 0.67 7.47 2-5.08 5-4.5 6.28 7-0.6 7.7 0.57-4.07 5.89-3.28 7 6.79-1.88 7.68-0.85-2.92 6.54-1.94 7.47 6.33-3.1 7.39-2.26-1.66 7-0.52 7.71 5.64-4.22 6.84-3.58-0.35 7.15 0.91 7.67 4.77-5.18 6.07-4.77 1 7.09 2.29 7.37 3.74-6 5.1-5.8 2.24 6.8 3.6 6.83 2.58-6.55 3.94-6.64 3.46 6.27 4.81 6.05 1.32-6.92 2.64-7.26 4.55 5.52 5.84 5.06S398.34 157.79 399.59 157.21Zm-47.45-30.39c-4.11-2.57-2.74-12.15 3.05-21.4S369 90.76 373.11 93.33s2.74 12.15-3.05 21.4S356.24 129.39 352.14 126.82Zm22.9-3a6.2 6.2 0 1 1 8.24 3A6.2 6.2 0 0 1 375 123.82Zm18-10.38c-5.56-7.56-6.91-16-3-18.89s11.57 0.94 17.13 8.5 6.91 16 3 18.88S398.56 121 393 113.44Zm-6.53 37c-10.76 1.81-20.13-0.6-20.93-5.37s7.27-10.11 18-11.92 20.14 0.6 20.94 5.38S397.24 148.63 386.47 150.43Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeMiterLimit="10"
-        android:pathData="M169.36 92.61c-0.92-1 2.76-6.61 1.76-7.52s-6.25 3.24-7.33 2.42 1.5-7 0.35-7.71-5.55 4.34-6.76 3.73 0.18-7.16-1.08-7.65-4.65 5.29-6 4.92-1.14-7.07-2.47-7.32-3.6 6.06-5 5.93-2.41-6.74-3.77-6.74-2.43 6.61-3.79 6.73-3.6-6.18-4.94-5.93-1.17 6.94-2.48 7.31-4.68-5.42-6-4.93 0.13 7-1.09 7.65-5.6-4.47-6.76-3.75 1.43 6.89 0.34 7.72-6.31-3.36-7.33-2.44 2.65 6.53 1.74 7.53-6.84-2.14-7.65-1.06 3.8 5.93 3.09 7.07-7.11-0.84-7.72 0.37 4.84 5.12 4.35 6.39-7.15 0.48-7.52 1.78 5.7 4.14 5.45 5.48-6.93 1.78-7.06 3.14 6.36 3 6.36 4.38-6.49 3-6.37 4.38 6.81 1.8 7.05 3.14-5.83 4.16-5.45 5.47 7 0.52 7.51 1.8-5 5.15-4.36 6.38 7-0.79 7.72 0.38-3.93 6-3.1 7.07 6.73-2.06 7.65-1-2.75 6.62-1.76 7.53 6.26-3.24 7.34-2.43-1.5 7-0.35 7.72 5.54-4.34 6.76-3.73-0.18 7.15 1.08 7.64 4.65-5.29 6-4.92 1.13 7.07 2.47 7.32 3.6-6.05 4.95-5.93 2.41 6.74 3.77 6.75 2.43-6.61 3.78-6.74 3.6 6.19 4.94 5.94 1.18-6.94 2.49-7.31 4.67 5.42 5.95 4.93-0.14-7 1.09-7.65 5.59 4.46 6.76 3.74-1.44-6.89-0.34-7.72 6.31 3.37 7.33 2.44-2.65-6.53-1.74-7.52 6.83 2.14 7.65 1.06-3.81-5.93-3.09-7.08 7.11 0.85 7.71-0.37-4.83-5.12-4.34-6.38 7.14-0.48 7.51-1.79-5.7-4.14-5.45-5.47 6.94-1.78 7.06-3.14-6.36-3-6.35-4.39 6.49-3 6.36-4.37-6.8-1.81-7-3.15 5.83-4.15 5.46-5.46-7-0.53-7.51-1.8 5-5.16 4.35-6.38-7 0.79-7.71-0.38 3.92-6 3.1-7.07S170.29 93.63 169.36 92.61Zm-15 54.32c-1.24 4.68-10.8 6.22-21.35 3.42S115 141.5 116.19 136.82s10.8-6.21 21.35-3.42S155.64 142.25 154.4 146.93Zm-9.65-21a6.2 6.2 0 1 1 0.41-8.76A6.21 6.21 0 0 1 144.75 126Zm-15.24-14.08c-5.57 7.55-13.25 11.34-17.15 8.47s-2.53-11.33 3-18.88S128.65 90.12 132.55 93 135.08 104.32 129.51 111.87Zm37.27-4.72c4.91 9.74 5.39 19.41 1.07 21.59s-11.81-4-16.73-13.7-5.39-19.41-1.07-21.59S161.87 97.4 166.78 107.15Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeMiterLimit="10"
-        android:pathData="M168.56 396.56a171.87 171.87 0 0 0 183.41 0Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeMiterLimit="10"
-        android:pathData="M168.56 106A171.87 171.87 0 0 1 352 106Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M385.74 151.22H333.58a2.17 2.17 0 1 1 0-4.33h52.16a2.17 2.17 0 0 1 0 4.33Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M338.24 145.13h9.15v9.15H338.24z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M385.74 173.88H333.58a2.16 2.16 0 1 1 0-4.32h52.16a2.16 2.16 0 0 1 0 4.32Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M355.89 167.8h9.15v9.15H355.89z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M385.74 196.54H333.58a2.16 2.16 0 1 1 0-4.32h52.16a2.16 2.16 0 0 1 0 4.32Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M372.01 190.46h9.15v9.15H372.01z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M130 180.35h7.95v7.95H130z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M144.02 180.35h7.95v7.95H144.02z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M158.05 180.35h7.95v7.95H158.05z"/>
-    <path
-        android:fillColor="#FF92E3A9"
-        android:strokeColor="#FF000000"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M172.07 180.35h7.95v7.95H172.07z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M186.1 180.35h7.95v7.95H186.1z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M130 164.94h7.95v7.95H130z"/>
-    <path
-        android:fillColor="#FF92E3A9"
-        android:strokeColor="#FF000000"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M144.02 164.94h7.95v7.95H144.02z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M158.05 164.94h7.95v7.95H158.05z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M172.07 164.94h7.95v7.95H172.07z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M186.1 164.94h7.95v7.95H186.1z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M130 149.52h7.95v7.95H130z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M144.02 149.52h7.95v7.95H144.02z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M158.05 149.52h7.95v7.95H158.05z"/>
-    <path
-        android:fillColor="#FF92E3A9"
-        android:strokeColor="#FF000000"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M172.07 149.52h7.95v7.95H172.07z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M186.1 149.52h7.95v7.95H186.1z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M174.5 286a32.23 32.23 0 0 0 7.25-3.05 31.68 31.68 0 0 0 10.18-9.37 31.78 31.78 0 0 0-12.79-47 31.63 31.63 0 0 0-18.75-2.44 31.77 31.77 0 0 0-7.82 60.16A31.56 31.56 0 0 0 174.5 286Zm-37.69-32.77a29.12 29.12 0 1 1 55.49 14.38 29.93 29.93 0 0 1-2.54 4.46 29.13 29.13 0 0 1-52.95-14.44"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M174.5 286a32.23 32.23 0 0 0 7.25-3.05 31.68 31.68 0 0 0 10.18-9.37 31.78 31.78 0 0 0-12.79-47 31.63 31.63 0 0 0-18.75-2.44 31.77 31.77 0 0 0-7.82 60.16A31.56 31.56 0 0 0 174.5 286Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M183.12 289.32c0.59-0.3 1.18-0.62 1.76-1A38 38 0 0 0 159.31 218 38 38 0 1 0 176.2 292q1.1-0.31 2.19-0.69M137 242.15a31.77 31.77 0 1 1 57.72 26.57 32.09 32.09 0 0 1-2.78 4.86A31.68 31.68 0 0 1 181.75 283 32.23 32.23 0 0 1 174.5 286 31.77 31.77 0 0 1 137 242.15Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M207.5 250.85a41.62 41.62 0 0 1-3.59 22.1l-3.51-1.61A37.8 37.8 0 0 0 203.86 254"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M203.4 249.38A38 38 0 0 0 159.31 218l-0.66-3.81a41.91 41.91 0 0 1 48.27 33"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M194.71 268.72l-2.41-1.11a29.11 29.11 0 0 0-31.45-40.86l-0.46-2.62a31.77 31.77 0 0 1 34.32 44.59Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M181.75 283l-1.33-2.3a29.05 29.05 0 0 0 9.34-8.58l2.17 1.51A31.68 31.68 0 0 1 181.75 283Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M186.81 291.71l-1.93-3.35a37.73 37.73 0 0 0 12.19-11.2l3.18 2.2A41.74 41.74 0 0 1 186.81 291.71Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M128.94 235.6a41.79 41.79 0 0 1 15.81-16.36l1.95 3.34A38 38 0 0 0 176.2 292l1.05 3.71a41.89 41.89 0 0 1-50.27-56"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M247.07 152.12a22.72 22.72 0 0 0 12.45-8.87 22.27 22.27 0 0 0 2-3.47 22.67 22.67 0 0 0-11.11-30.09A22.44 22.44 0 0 0 237 108a22.68 22.68 0 1 0 10.07 44.17Zm-26.9-23.4a20.83 20.83 0 0 1 10.26-16.39 21 21 0 0 1 6.9-2.52A20.79 20.79 0 0 1 259.78 139a20.25 20.25 0 0 1-1.81 3.19 20.59 20.59 0 0 1-6.67 6.12 20 20 0 0 1-4.75 2 20.77 20.77 0 0 1-26.38-18.43"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M247.07 152.12a22.72 22.72 0 0 0 12.45-8.87 22.27 22.27 0 0 0 2-3.47 22.67 22.67 0 0 0-11.11-30.09A22.44 22.44 0 0 0 237 108a22.68 22.68 0 1 0 10.07 44.17Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M253.23 154.48c0.42-0.21 0.84-0.44 1.25-0.68a27 27 0 0 0 11.08-12.16 27.16 27.16 0 0 0-29.33-38.1 27.54 27.54 0 0 0-9 3.29 27.16 27.16 0 0 0 21.06 49.59c0.52-0.15 1-0.32 1.56-0.5m-29.56-35.11a22.68 22.68 0 1 1 41.21 19 22.27 22.27 0 0 1-2 3.47 22.69 22.69 0 0 1-39.23-22.44Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M270.64 127a29.74 29.74 0 0 1-2.57 15.78l-2.51-1.16A27 27 0 0 0 268 129.27"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M267.71 126a27.18 27.18 0 0 0-31.48-22.43l-0.47-2.71a29.9 29.9 0 0 1 34.46 23.54"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M261.5 139.78l-1.72-0.8a20.79 20.79 0 0 0-22.45-29.17L237 108a22.44 22.44 0 0 1 13.39 1.74A22.67 22.67 0 0 1 261.5 139.78Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M252.25 149.93l-0.95-1.64a20.59 20.59 0 0 0 6.67-6.12l1.55 1.08A22.58 22.58 0 0 1 252.25 149.93Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M255.86 156.19l-1.38-2.39a26.79 26.79 0 0 0 8.71-8l2.27 1.58A29.76 29.76 0 0 1 255.86 156.19Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M214.55 116.13a29.74 29.74 0 0 1 11.29-11.68l1.39 2.38a27.16 27.16 0 0 0 21.06 49.59l0.75 2.65a29.91 29.91 0 0 1-35.89-39.95"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M226.21 372a15.84 15.84 0 0 0-1-4.42 20 20 0 0 0-4.8-7.25 26.11 26.11 0 0 0-2.89-2.46c-9.74-7.11-23.74-7.35-31.26-0.53a13.63 13.63 0 0 0-4.62 9.3 15.09 15.09 0 0 0 1 6.3 21.53 21.53 0 0 0 7.66 9.65c9.74 7.11 23.74 7.35 31.26 0.52A13.58 13.58 0 0 0 226.21 372Zm-28.34 13a26 26 0 0 1-6.41-3.41 19.71 19.71 0 0 1-7-8.83 13.77 13.77 0 0 1-0.89-5.78 12.52 12.52 0 0 1 4.23-8.52c6.9-6.25 19.73-6 28.65 0.48a23.58 23.58 0 0 1 2.65 2.25 18.29 18.29 0 0 1 4.39 6.65 14.1 14.1 0 0 1 0.88 4.05A12.45 12.45 0 0 1 220.11 382c-4.69 4.26-12.14 5.51-19.23 3.82"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M226.21 372a15.84 15.84 0 0 0-1-4.42 20 20 0 0 0-4.8-7.25 26.11 26.11 0 0 0-2.89-2.46c-9.74-7.11-23.74-7.35-31.26-0.53a13.63 13.63 0 0 0-4.62 9.3 15.09 15.09 0 0 0 1 6.3 21.53 21.53 0 0 0 7.66 9.65c9.74 7.11 23.74 7.35 31.26 0.52A13.58 13.58 0 0 0 226.21 372Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M229.83 368.13c-0.11-0.38-0.24-0.75-0.38-1.12a23.93 23.93 0 0 0-5.74-8.68 29.56 29.56 0 0 0-3.46-2.94c-11.66-8.52-28.41-8.8-37.42-0.64a16.33 16.33 0 0 0-5.52 11.14 17.93 17.93 0 0 0 1.16 7.54A25.76 25.76 0 0 0 187.64 385c11.66 8.52 28.41 8.8 37.42 0.63a16.28 16.28 0 0 0 5.53-13.3c0-0.43-0.07-0.86-0.13-1.29m-40.14 11.53a21.53 21.53 0 0 1-7.66-9.65 15.09 15.09 0 0 1-1-6.3 13.63 13.63 0 0 1 4.62-9.3c7.52-6.82 21.52-6.58 31.26 0.53a26.11 26.11 0 0 1 2.89 2.46 20 20 0 0 1 4.8 7.25 15.84 15.84 0 0 1 1 4.42 13.58 13.58 0 0 1-4.63 11.11C214.06 389.89 200.06 389.65 190.32 382.54Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M207.37 347.46a38 38 0 0 1 14.54 6.42l-1.66 1.51A34.17 34.17 0 0 0 209 350"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M205.72 349.3c-8.57-1.46-17.25 0.34-22.89 5.45a16.33 16.33 0 0 0-5.52 11.14l-2.71-0.44a17.94 17.94 0 0 1 6.09-12.26c6-5.41 15-7.45 24.05-6.19"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M217.57 357.82l-1.14 1c-8.92-6.52-21.75-6.73-28.65-0.48a12.52 12.52 0 0 0-4.23 8.52l-1.86-0.3a13.63 13.63 0 0 1 4.62-9.3C193.83 350.47 207.83 350.71 217.57 357.82Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M225.26 367.53l-1.79 0.22a18.29 18.29 0 0 0-4.39-6.65l1.38-0.82A20 20 0 0 1 225.26 367.53Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M232.05 366.69l-2.6 0.32a23.93 23.93 0 0 0-5.74-8.68l2-1.21A26.61 26.61 0 0 1 232.05 366.69Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M184.58 385.39a27.7 27.7 0 0 1-8.7-11.63l2.59-0.33A25.76 25.76 0 0 0 187.64 385c11.66 8.52 28.41 8.8 37.42 0.63a16.28 16.28 0 0 0 5.53-13.3l2.71 0.22a17.92 17.92 0 0 1-6.1 14.65c-9.62 8.73-27.29 8.7-40.07 0.11"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M373 322.34a48 48 0 0 0 10.89-4.59 47.54 47.54 0 0 0 15.29-14.06 46.53 46.53 0 0 0 4.17-7.3A47.7 47.7 0 1 0 373 322.34Zm-56.58-49.2a43.72 43.72 0 1 1 83.32 21.58 44.74 44.74 0 0 1-3.82 6.7 43.73 43.73 0 0 1-79.5-21.68"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M373 322.34a48 48 0 0 0 10.89-4.59 47.54 47.54 0 0 0 15.29-14.06 46.53 46.53 0 0 0 4.17-7.3A47.7 47.7 0 1 0 373 322.34Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M386 327.32c0.9-0.46 1.78-0.93 2.65-1.43a56.82 56.82 0 0 0 18.31-16.83 57.9 57.9 0 0 0 5-8.74 57.1 57.1 0 1 0-36.33 31.06c1.1-0.31 2.2-0.66 3.28-1M316.7 256.5a47.7 47.7 0 1 1 86.66 39.89 46.53 46.53 0 0 1-4.17 7.3 47.54 47.54 0 0 1-15.29 14.06A48 48 0 0 1 373 322.34 47.7 47.7 0 0 1 316.7 256.5Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M422.57 269.56a62.58 62.58 0 0 1-5.4 33.19l-5.27-2.43a56.75 56.75 0 0 0 5.2-26"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M416.41 267.35a57.12 57.12 0 0 0-66.19-47.16l-1-5.71A62.9 62.9 0 0 1 421.69 264"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M403.36 296.39l-3.61-1.67a43.72 43.72 0 0 0-47.23-61.34l-0.69-3.93a47.7 47.7 0 0 1 51.53 66.94Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M383.9 317.75l-2-3.45a43.61 43.61 0 0 0 14-12.88l3.26 2.27A47.54 47.54 0 0 1 383.9 317.75Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M391.5 330.91l-2.9-5a56.82 56.82 0 0 0 18.31-16.83l4.76 3.31A62.54 62.54 0 0 1 391.5 330.91Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M304.62 246.67a62.53 62.53 0 0 1 23.73-24.57l2.92 5a57.1 57.1 0 0 0 44.3 104.27l1.57 5.58a62.89 62.89 0 0 1-75.46-84"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M331.92 154.34s3.43-1.07 3.55 0.47-0.24 6.64-1 7.47-2.71 0.95-3.54 1.07-3.33-4.27-1.91-6.64S331.92 154.34 331.92 154.34Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M321.51 166.5s5.55-10.09 6.44-11.61 7.32-5.17 8.7-6.06 2.28-0.88 2.28 0.38-2.78 2.53-3.66 3.28a44.73 44.73 0 0 0-4.29 4.17 15.39 15.39 0 0 0-0.26 1.89s4.42-1.26 5.68-1.77 2.27-1.13 1.9 0.26-0.64 2-1.52 2.52-2.14 1.26-3 1.64a13.68 13.68 0 0 0-2.77 2.15 15.79 15.79 0 0 1-3 1.64l-1.9 5Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M206 185.58l-2-1.15s-1.56-7.07-2.52-8.87-2.6-2-3.34-1.15 0.67 1.8 1.19 2.3 0.74 2 0.81 3.45a15.85 15.85 0 0 1 0 2.21s-5 5.75-5 7 0.66 1.72 2.67 3 3.48 5.26 3.48 5.26l6.83-1.48s-0.52-2.95-0.52-3.69 1.26-5.59 1.11-6.41-2.59-3.37-3-4.85-1.56-0.08-1.26 1.24a11.27 11.27 0 0 0 1.63 3.12 7.16 7.16 0 0 1-1.19 1.8 5.87 5.87 0 0 0-1.92 2.47c-0.37 1.15-0.6 1.72-0.37 2.22"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M200.14 182.37s-2.08-1.23-2.74-0.57a1.56 1.56 0 0 0-0.3 2c0.3 0.66 1 3.7 1.56 4a1 1 0 0 0 1.48-0.5c0.22-0.57-0.59-4-0.59-4Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M196.88 182.87s-1.86 1-2 2.3 1.56 3.28 2.45 3.45 1.34-0.82 1.34-0.82Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M194.8 186a2.89 2.89 0 0 0-0.59 1.56c0 0.82 0 3.28 0.89 3.37s0.44-1.73 0.52-2.22a6.81 6.81 0 0 1 0.44-1.32Z"/>
-    <path
-        android:fillColor="#FF92E3A9"
-        android:strokeColor="#FF000000"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M321.51 166.5c-2.6 1.54-17.78 16.17-17.78 16.17l-10.3 4.26s-5-0.24-6.63-0.47a34.15 34.15 0 0 0-8.77 0.59c-2.84 0.59-9.23 1.42-9.23 1.42l-0.27 1.05c-0.66-3.22-1-17.26-1-17.26l-6.78 0.3-6.77-0.3S253.62 188 252.88 190s-12.77 1.86-16.86 3.22-6.32 7.56-6.81 11.15-7.06 12.14-7.31 12.51-10.84-18.16-12.45-22.37l-8.55 3.34s7.74 16.93 9.72 23.12 11.15 15.49 12.39 14.5 14.38-16.23 14.38-16.23a84.86 84.86 0 0 1 4 11.4c1.36 5.45 1.49 10.78 0.87 12.76s-4.59 14.41-6.71 19.87-6.07 15.17-1.22 29.43S246 318.93 246 323.63s-2.73 7.43-1.36 16.69 5.61 29.27 5.61 35.49a33.85 33.85 0 0 1-1.52 10.77c-0.45 1.82-4.24 5.92-5.15 6.83s-2.58 1.51-1.52 2.73 16.67 0.15 18.73 0c2.07 0.14 17.75 1.12 18.74 0s-0.61-1.82-1.52-2.73-4.7-5-5.16-6.83a34.28 34.28 0 0 1-1.51-10.77c0-6.22 4.24-26.24 5.61-35.49s-1.37-12-1.37-16.69 6.83-16.69 11.68-30.95 0.91-24-1.21-29.43-6.09-17.89-6.71-19.87a9.67 9.67 0 0 1-0.32-2.19l2.36-13.05a17.26 17.26 0 0 0 2.25-5c1.15-3.7-0.59-5.8-1.42-8.76s-2.13-9.23-2.13-9.23 9.94-3.91 11.36-4.5 15.28-4.27 16.34-5S326.05 170 326.05 170Z"/>
-    <path
-        android:strokeColor="#FF000000"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M221.9 216.86s4.9 3.32 6.09 7.11"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M245.44 345.4c1.77 10.14 4.78 25.17 4.78 30.41a33.85 33.85 0 0 1-1.52 10.77c-0.45 1.82-4.24 5.92-5.15 6.83s-2.58 1.51-1.52 2.73 16.67 0.15 18.73 0c2.07 0.14 17.75 1.12 18.74 0s-0.61-1.82-1.52-2.73-4.7-5-5.16-6.83a34.28 34.28 0 0 1-1.51-10.77c0-5.24 3-20.27 4.78-30.41Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M267.54 172.26l-6.78 0.3-6.77-0.3s-0.14 5.76-0.41 10.75H268C267.67 178 267.54 172.26 267.54 172.26Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:pathData="M270.18 227.7a80.42 80.42 0 0 1-2.84-9.38 9.88 9.88 0 0 1 0.25-4.45h-0.17a17.3 17.3 0 0 0 1.7-8.25 7.39 7.39 0 0 0-0.37-1.69l-13.81 0.62a7 7 0 0 0 0 1.72 18.69 18.69 0 0 0 3 7.66h-0.23s2.39 3.44 2.06 5.61-1.76 8.7-1.76 8.7h0.2a16 16 0 0 0-0.64 5.41 7.91 7.91 0 0 0 0.37 1.7l13.82-0.63a7 7 0 0 0 0-1.71 16.72 16.72 0 0 0-1.69-5.31Z"/>
-    <path
-        android:strokeColor="#FF000000"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M255.18 264.08s7.82 9.15 8.48 9.15a14.88 14.88 0 0 0 2.66-0.67l7.32-7.48"/>
-    <path
-        android:strokeColor="#FF000000"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M263.66 273.23s-2.16 32.09-1 43.24-0.16 17.12-0.16 20.12-0.67 8-1.5 20.29a288.32 288.32 0 0 0 0.17 31.1 22.51 22.51 0 0 0 0.83 5c0.33 1.17 0.83 3 0.83 3"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M244.23 181.13h31.32a26 26 0 1 0-31.32 0Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M244.69 161.92c0 3.86-1.56 7-3.49 7s-3.5-3.12-3.5-7 1.57-7 3.5-7S244.69 158.06 244.69 161.92Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M249.58 156s1.4 5.94-0.35 11.18l10.48 5.59 1.05 5.75h15s6.64-6.45 5.94-9.95l-0.7-3.49s1.75-10.48-0.35-14.32S260.93 140.54 249.58 156Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M281.72 168.55l-0.7-3.49s1.75-10.48-0.35-14.32c-0.61-1.12-2.53-2.44-5.22-3.39l-0.15 0.23a16.92 16.92 0 0 1 1.81 9.89 47.61 47.61 0 0 0-0.83 8.24c0 1.16 0.33 4-1.15 6.27a41.47 41.47 0 0 1-4.29 5.77c-0.12 0.08 0.19 0.36 0.7 0.75h4.24S282.42 172.05 281.72 168.55Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M273.73 157.13a4.6 4.6 0 0 0-1.54 2.37c-0.28 1.4 2.24 7.56 1.26 8s-3.5-0.56-3.5-0.56"/>
-    <path
-        android:fillColor="#FF263238"
-        android:pathData="M263.52 159.5c0 0.85-0.5 1.54-1.12 1.54s-1.12-0.69-1.12-1.54 0.5-1.53 1.12-1.53S263.52 158.65 263.52 159.5Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:pathData="M275.69 159.36c0 0.85-0.5 1.54-1.12 1.54s-1.12-0.69-1.12-1.54 0.5-1.53 1.12-1.53S275.69 158.51 275.69 159.36Z"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M269.53 171.54a7.46 7.46 0 0 1-7.41-3.36"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M259.88 157s2.52-2.24 7-1"/>
-    <path
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M273.59 156.15s2.36-1.33 2.94 0"/>
-    <path
-        android:fillColor="#FF92E3A9"
-        android:strokeColor="#FF000000"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M253.42 151.75h22.87l2.76-2.49v-0.14C274.59 146 262.87 143.37 253.42 151.75Z"/>
-    <path
-        android:fillColor="#FF92E3A9"
-        android:strokeColor="#FF000000"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M255.29 170.39V150.24a25.89 25.89 0 0 0-5.71 5.74s1.4 5.94-0.35 11.18Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M244.15 189.17s2.29 1.39 8.23 5.59 9.78 3.84 14 1.74 8.57-7.33 8.57-7.33Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M241.2 183.52c0-0.73 0.29-1.42 0.8-1.94 0.51-0.51 1.21-0.8 1.94-0.8h31.2c0.73 0 1.42 0.29 1.94 0.8 0.51 0.51 0.8 1.21 0.8 1.94v2.9c0 0.73-0.29 1.42-0.8 1.94-0.51 0.51-1.21 0.8-1.94 0.8h-31.2c-0.73 0-1.42-0.29-1.94-0.8-0.51-0.51-0.8-1.21-0.8-1.94z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M241.2 154.93s-0.24-13.8 16-19"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M241.15 170.74a21.43 21.43 0 0 0 7.16 8.52"/>
-    <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeMiterLimit="10"
-        android:pathData="M266.37 228.59h166.91v46.02H266.37z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M82.77 248.47c0-2.21 1.79-4 4-4h172.35c2.21 0 4 1.79 4 4v0.97c0 2.21-1.79 4-4 4h-172.35c-2.21 0-4-1.79-4-4z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M260.26 231.21a20.09 20.09 0 1 0 20.09 20.08A20.08 20.08 0 0 0 260.26 231.21Zm0 32.74a12.66 12.66 0 1 1 12.66-12.66A12.66 12.66 0 0 1 260.26 264Z"/>
-    <path
-        android:fillColor="#FF92E3A9"
-        android:strokeColor="#FF000000"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M274.46 237.09a20 20 0 0 0-14.26-5.87v7.42a12.67 12.67 0 0 1 12.72 12.74h7.42A20 20 0 0 0 274.46 237.09Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:pathData="M280.17 251.39L259.81 250a1.29 1.29 0 0 0-1.38 1.29v0.22a1.29 1.29 0 0 0 1.38 1.29Z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M292.89 233.83h20.94v35.41H292.89z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M316.29 233.83h20.94v35.41H316.29z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M339.69 233.83h20.94v35.41H339.69z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M363.09 233.83h20.94v35.41H363.09z"/>
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:strokeColor="#FF263238"
-        android:strokeWidth="1"
-        android:strokeLineCap="round"
-        android:strokeLineJoin="round"
-        android:pathData="M386.49 233.83h20.94v35.41H386.49z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:pathData="M296.7 265.68V262.6l6.27-9.69c0.46-0.71 0.89-1.39 1.3-2a11.21 11.21 0 0 0 1-2 6.57 6.57 0 0 0 0.39-2.3 4 4 0 0 0-0.5-2.17 1.76 1.76 0 0 0-1.57-0.75 2.15 2.15 0 0 0-1.57 0.56 3 3 0 0 0-0.77 1.48 9.5 9.5 0 0 0-0.2 2v1.06h-4.27v-1.13a10.73 10.73 0 0 1 0.68-4 5.57 5.57 0 0 1 2.15-2.69 6.93 6.93 0 0 1 3.85-1 6.34 6.34 0 0 1 4.89 1.76 6.9 6.9 0 0 1 1.63 4.89 8.73 8.73 0 0 1-0.43 2.84 12.31 12.31 0 0 1-1.16 2.43c-0.49 0.77-1 1.57-1.57 2.38l-5.21 7.91h7.72v3.48Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:pathData="M322.88 265.68l5.05-22.08h-6.86v-3.33H332.2v2.67l-5.11 22.74Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:pathData="M350.76 266a7 7 0 0 1-3.89-1 5.33 5.33 0 0 1-2.1-2.71 11.85 11.85 0 0 1-0.62-4 9.26 9.26 0 0 1 0.2-2 6.61 6.61 0 0 1 0.6-1.67 5.68 5.68 0 0 1 0.95-1.34 5.25 5.25 0 0 1 1.29-1 6.43 6.43 0 0 1-1.9-2.15 7.26 7.26 0 0 1-0.8-3.47 8.81 8.81 0 0 1 0.68-3.59 4.85 4.85 0 0 1 2.08-2.32 7.06 7.06 0 0 1 3.51-0.8 6.82 6.82 0 0 1 3.52 0.82 4.94 4.94 0 0 1 2.05 2.32 8.35 8.35 0 0 1 0.64 3.57 7.29 7.29 0 0 1-0.77 3.48 6.18 6.18 0 0 1-1.86 2.14 5 5 0 0 1 1.28 1 5.44 5.44 0 0 1 1 1.34 7 7 0 0 1 0.6 1.67 9.91 9.91 0 0 1 0.2 2 11.16 11.16 0 0 1-0.61 4 5.44 5.44 0 0 1-2.1 2.71A6.94 6.94 0 0 1 350.76 266Zm0-3.29a1.91 1.91 0 0 0 1.56-0.63 3.25 3.25 0 0 0 0.67-1.58 12.64 12.64 0 0 0 0.16-2 9.3 9.3 0 0 0-0.16-2.06 3.56 3.56 0 0 0-0.71-1.61 1.84 1.84 0 0 0-1.52-0.63 1.82 1.82 0 0 0-1.49 0.63 3.75 3.75 0 0 0-0.72 1.6 10.54 10.54 0 0 0-0.2 2.07 11.64 11.64 0 0 0 0.17 2 3.24 3.24 0 0 0 0.71 1.59A1.93 1.93 0 0 0 350.76 262.73Zm0-12.14A1.62 1.62 0 0 0 352 250a3 3 0 0 0 0.64-1.42 10 10 0 0 0 0.19-2.07 5.08 5.08 0 0 0-0.47-2.36 1.66 1.66 0 0 0-1.6-0.91 1.73 1.73 0 0 0-1.61 0.91 4.62 4.62 0 0 0-0.52 2.33 10.13 10.13 0 0 0 0.2 2.08 3.12 3.12 0 0 0 0.68 1.44A1.68 1.68 0 0 0 350.76 250.59Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:pathData="M373.19 266.05a7 7 0 0 1-3.93-0.94 4.79 4.79 0 0 1-1.93-2.66 13.6 13.6 0 0 1-0.54-4.05H371a13.74 13.74 0 0 0 0.17 2.27 3 3 0 0 0 0.69 1.54 1.9 1.9 0 0 0 1.52 0.52A1.7 1.7 0 0 0 375 262a4.46 4.46 0 0 0 0.59-2q0.12-1.28 0.12-3a17.45 17.45 0 0 0-0.17-2.57 3.53 3.53 0 0 0-0.68-1.71 1.92 1.92 0 0 0-1.57-0.61 2 2 0 0 0-1.5 0.61 3.72 3.72 0 0 0-0.88 1.62h-3.73l0.25-14.15h11.42v3.89H371l-0.25 6.12a3.22 3.22 0 0 1 1.36-0.91 6.51 6.51 0 0 1 2-0.41 4.92 4.92 0 0 1 3.27 0.85 5.48 5.48 0 0 1 1.85 2.73 13.74 13.74 0 0 1 0.59 4.26 23.55 23.55 0 0 1-0.27 3.7 8.17 8.17 0 0 1-1 2.93 5 5 0 0 1-2 1.93A7.15 7.15 0 0 1 373.19 266.05Z"/>
-    <path
-        android:fillColor="#FF263238"
-        android:pathData="M396.48 266.05a6.64 6.64 0 0 1-3.68-0.94 5.91 5.91 0 0 1-2.2-2.6 9.38 9.38 0 0 1-0.73-3.83V247.42a10 10 0 0 1 0.7-3.9 5.6 5.6 0 0 1 2.17-2.62 7.93 7.93 0 0 1 7.49 0 5.72 5.72 0 0 1 2.17 2.62 10 10 0 0 1 0.7 3.9v11.26a9.22 9.22 0 0 1-0.74 3.83 5.82 5.82 0 0 1-2.19 2.6A6.65 6.65 0 0 1 396.48 266.05Zm0-3.73a1.76 1.76 0 0 0 1.45-0.59 3.23 3.23 0 0 0 0.62-1.45 8.64 8.64 0 0 0 0.16-1.66V247.49a11.14 11.14 0 0 0-0.14-1.74 3.11 3.11 0 0 0-0.61-1.46 1.78 1.78 0 0 0-1.48-0.6 1.74 1.74 0 0 0-1.47 0.6 3.11 3.11 0 0 0-0.61 1.46 10 10 0 0 0-0.14 1.74v11.13a7.93 7.93 0 0 0 0.17 1.66 3.37 3.37 0 0 0 0.64 1.45A1.72 1.72 0 0 0 396.48 262.32Z"/>
+        android:pathData="M463.39,461.55c0,3.39-93.52,6.13-208.87,6.13s-208.87-2.75-208.87-6.13,93.52-6.13,208.87-6.13,208.87,2.75,208.87,6.13Z"
+        android:fillColor="#F5F5F5"/>
+    <path
+        android:pathData="M107.36,328.65c-.13,0-.26-.05-.36-.15-.19-.2-.19-.51,0-.71,5.72-5.57,9.43-9.13,13.14-12.7,3.7-3.56,7.41-7.11,13.12-12.68,.2-.19,.51-.19,.71,0,.19,.2,.19,.51,0,.71-5.71,5.56-9.42,9.12-13.12,12.68-3.71,3.56-7.42,7.12-13.13,12.69-.1,.09-.22,.14-.35,.14Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M99.67,335.5c-.13,0-.26-.05-.36-.15-.19-.2-.19-.51,0-.71l4.65-4.53c.2-.19,.51-.19,.71,0,.19,.2,.19,.51,0,.71l-4.65,4.53c-.1,.09-.22,.14-.35,.14Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M96.66,372.61c-.12,0-.25-.05-.35-.14-.2-.19-.21-.51-.02-.71l50.55-52.84c.19-.2,.51-.21,.71-.02,.2,.19,.21,.51,.02,.71l-50.55,52.84c-.1,.1-.23,.15-.36,.15Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M136.36,359.89c-.12,0-.25-.04-.34-.14-.2-.19-.21-.51-.02-.71,4.29-4.56,7.25-7.8,10.11-10.93,2.86-3.13,5.82-6.37,10.12-10.94,.19-.2,.51-.21,.71-.02,.2,.19,.21,.51,.02,.71-4.29,4.56-7.25,7.8-10.11,10.93-2.86,3.13-5.82,6.37-10.12,10.94-.1,.1-.23,.16-.36,.16Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M159.36,334.95c-.12,0-.24-.04-.33-.13-.21-.18-.23-.5-.04-.71l3.98-4.48c.18-.21,.5-.22,.71-.04,.21,.18,.23,.5,.04,.71l-3.98,4.48c-.1,.11-.24,.17-.37,.17Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M161.28,240c-3.79-8.63-8.17-17.26-15.07-23.67-10.32-9.57-24.78-12.89-38.45-16.26-29.71-7.33-58.94-16.58-87.46-27.68-5.53-2.15-10.89,3.45-8.53,8.9,2.62,6.06,5.63,11.91,9.5,17.25,6.93,9.56,17.09,17.41,28.81,18.87-4.28,.43-8.81,.95-11.86,4.4-1.55,1.75-2.2,4.19-1.42,6.39,1.3,3.65,5.49,4.41,9.09,4.81,7.11,.78,14.23,1.56,21.34,2.34-5.37,1.41-8.77,7.54-7.74,12.99,1.03,5.45,5.93,9.75,11.38,10.75,4.81,.88,9.86-.59,13.84-3.46-2.77,2.93-2.91,8.15-.42,11.5,2.89,3.89,8.27,5.33,13.06,4.57,4.79-.76,9.09-3.37,12.96-6.29,2.28,4.89,7.35,8.36,12.74,8.71,5.39,.35,10.87-2.44,13.76-6.99,2.45,8.28,13.6,12.54,20.95,8,4.76,7.52,9.52,15.03,14.27,22.55l3.88-15.67c-3.76-14.36-8.65-28.41-14.62-42Z"
+        android:fillColor="#11AA99"/>
+    <path
+        android:pathData="M161.28,240c-3.79-8.63-8.17-17.26-15.07-23.67-10.32-9.57-24.78-12.89-38.45-16.26-29.71-7.33-58.94-16.58-87.46-27.68-5.53-2.15-10.89,3.45-8.53,8.9,2.62,6.06,5.63,11.91,9.5,17.25,6.93,9.56,17.09,17.41,28.81,18.87-4.28,.43-8.81,.95-11.86,4.4-1.55,1.75-2.2,4.19-1.42,6.39,1.3,3.65,5.49,4.41,9.09,4.81,7.11,.78,14.23,1.56,21.34,2.34-5.37,1.41-8.77,7.54-7.74,12.99,1.03,5.45,5.93,9.75,11.38,10.75,4.81,.88,9.86-.59,13.84-3.46-2.77,2.93-2.91,8.15-.42,11.5,2.89,3.89,8.27,5.33,13.06,4.57,4.79-.76,9.09-3.37,12.96-6.29,2.28,4.89,7.35,8.36,12.74,8.71,5.39,.35,10.87-2.44,13.76-6.99,2.45,8.28,13.6,12.54,20.95,8,4.76,7.52,9.52,15.03,14.27,22.55l3.88-15.67c-3.76-14.36-8.65-28.41-14.62-42Z"
+        android:fillColor="#66E0D0"
+        android:fillAlpha="0.8"/>
+    <path
+        android:pathData="M333.73,233.97c4.56-8.25,9.7-16.45,17.16-22.2,11.15-8.6,25.85-10.59,39.77-12.7,30.25-4.6,60.2-11.16,89.61-19.63,5.7-1.64,10.53,4.42,7.69,9.63-3.16,5.8-6.69,11.35-11.02,16.32-7.77,8.89-18.6,15.78-30.41,16.17,4.22,.82,8.69,1.75,11.41,5.46,1.38,1.88,1.81,4.38,.84,6.5-1.62,3.52-5.86,3.9-9.48,3.96-7.16,.13-14.31,.26-21.47,.39,5.22,1.89,8.05,8.31,6.53,13.64-1.52,5.33-6.79,9.17-12.31,9.67-4.87,.44-9.76-1.48-13.46-4.71,2.49,3.17,2.16,8.38-.63,11.49-3.23,3.62-8.72,4.56-13.43,3.37-4.7-1.19-8.74-4.18-12.33-7.44-2.71,4.67-8.08,7.66-13.48,7.52s-10.6-3.41-13.07-8.21c-3.2,8.03-14.68,11.25-21.59,6.07-5.42,7.05-10.84,14.11-16.26,21.16l-2.44-15.96c5.05-13.95,11.2-27.51,18.38-40.5Z"
+        android:fillColor="#11AA99"/>
+    <path
+        android:pathData="M333.73,233.97c4.56-8.25,9.7-16.45,17.16-22.2,11.15-8.6,25.85-10.59,39.77-12.7,30.25-4.6,60.2-11.16,89.61-19.63,5.7-1.64,10.53,4.42,7.69,9.63-3.16,5.8-6.69,11.35-11.02,16.32-7.77,8.89-18.6,15.78-30.41,16.17,4.22,.82,8.69,1.75,11.41,5.46,1.38,1.88,1.81,4.38,.84,6.5-1.62,3.52-5.86,3.9-9.48,3.96-7.16,.13-14.31,.26-21.47,.39,5.22,1.89,8.05,8.31,6.53,13.64-1.52,5.33-6.79,9.17-12.31,9.67-4.87,.44-9.76-1.48-13.46-4.71,2.49,3.17,2.16,8.38-.63,11.49-3.23,3.62-8.72,4.56-13.43,3.37-4.7-1.19-8.74-4.18-12.33-7.44-2.71,4.67-8.08,7.66-13.48,7.52s-10.6-3.41-13.07-8.21c-3.2,8.03-14.68,11.25-21.59,6.07-5.42,7.05-10.84,14.11-16.26,21.16l-2.44-15.96c5.05-13.95,11.2-27.51,18.38-40.5Z"
+        android:fillColor="#66E0D0"
+        android:fillAlpha="0.8"/>
+    <path
+        android:pathData="M158.74,272.93 a82.62,82.62 0 1,0 165.24,0 a82.62,82.62 0 1,0 -165.24,0Z"
+        android:fillColor="#407BFF"/>
+    <path
+        android:pathData="M158.74,272.93 a82.62,82.62 0 1,0 165.24,0 a82.62,82.62 0 1,0 -165.24,0Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <path
+        android:pathData="M162.99,254.82 a82.62,82.62 0 1,0 165.24,0 a82.62,82.62 0 1,0 -165.24,0Z"
+        android:fillColor="#407BFF"/>
+    <path
+        android:pathData="M169.73,254.82 a75.88,75.88 0 1,0 151.76,0 a75.88,75.88 0 1,0 -151.76,0Z"
+        android:fillColor="#407BFF"/>
+    <path
+        android:pathData="M169.73,254.82 a75.88,75.88 0 1,0 151.76,0 a75.88,75.88 0 1,0 -151.76,0Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.7"/>
+    <path
+        android:pathData="M273.28,184.14l-99.88,94.05s6.88,17.4,13.14,24.26l107.34-106.18s-9.17-8.19-20.6-12.12Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4"/>
+    <path
+        android:pathData="M303.66,206.49l-111.79,101.9s1.75,2.79,9.81,8l110.36-98.46s-1.28-3.98-8.38-11.45Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4"/>
+    <path
+        android:pathData="M243.73,187.18v9.06h-1.68v-7.65h-1.91v-1.41h3.6Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M252.09,194.82v1.42h-6.68v-1.13l3.6-3.42c.41-.39,.68-.73,.82-1.02,.14-.29,.21-.58,.21-.86,0-.42-.14-.75-.43-.97-.29-.22-.7-.34-1.26-.34-.92,0-1.63,.31-2.12,.94l-1.18-.91c.35-.47,.83-.84,1.43-1.11,.6-.26,1.27-.39,2.01-.39,.98,0,1.77,.23,2.36,.7,.59,.47,.88,1.1,.88,1.9,0,.49-.1,.95-.31,1.38-.21,.43-.6,.92-1.19,1.47l-2.42,2.3h4.27Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M246.32,316.52c.47,.23,.84,.55,1.11,.98,.27,.42,.4,.91,.4,1.46,0,.59-.15,1.1-.44,1.55-.29,.44-.69,.79-1.19,1.03-.5,.24-1.06,.36-1.68,.36-1.24,0-2.21-.39-2.89-1.17-.69-.78-1.03-1.89-1.03-3.34,0-1.02,.19-1.89,.56-2.61,.37-.72,.89-1.27,1.56-1.64,.67-.38,1.44-.56,2.32-.56,.47,0,.9,.05,1.31,.15,.41,.1,.77,.24,1.07,.43l-.62,1.27c-.45-.29-1.02-.44-1.72-.44-.87,0-1.55,.27-2.04,.8-.49,.54-.74,1.31-.74,2.32h0c.27-.3,.61-.53,1.02-.69,.41-.16,.88-.24,1.4-.24,.6,0,1.13,.11,1.61,.34Zm-.61,3.64c.33-.28,.49-.65,.49-1.12s-.16-.85-.49-1.13c-.33-.28-.77-.41-1.32-.41s-.99,.15-1.33,.44c-.34,.29-.51,.67-.51,1.11s.17,.8,.5,1.09c.33,.29,.79,.43,1.38,.43,.53,0,.95-.14,1.28-.42Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M277.61,198.15v9.06h-1.68v-7.65h-1.92v-1.41h3.6Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M278.34,307.61c.61,.5,.92,1.17,.92,2.03,0,.54-.13,1.04-.4,1.48-.27,.44-.67,.79-1.2,1.05-.54,.26-1.2,.39-1.98,.39-.65,0-1.27-.09-1.88-.28-.6-.19-1.11-.44-1.53-.77l.71-1.31c.34,.28,.74,.49,1.21,.65,.47,.16,.96,.24,1.46,.24,.6,0,1.06-.12,1.4-.37,.34-.25,.51-.58,.51-1.02,0-.47-.18-.82-.55-1.05-.37-.24-.99-.36-1.88-.36h-2.19l.47-4.93h5.32v1.41h-3.9l-.19,2.1h.87c1.28,0,2.22,.25,2.83,.74Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M213.25,198.15v9.06h-1.68v-7.65h-1.91v-1.41h3.6Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M218.18,198.15v9.06h-1.68v-7.65h-1.92v-1.41h3.6Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M213.25,303.36v9.06h-1.68v-7.65h-1.91v-1.41h3.6Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M218.18,303.36v9.06h-1.68v-7.65h-1.92v-1.41h3.6Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M300.45,225.5v1.42h-6.68v-1.13l3.6-3.42c.41-.39,.68-.73,.82-1.02,.14-.29,.21-.58,.21-.86,0-.42-.14-.75-.43-.97-.29-.22-.7-.34-1.26-.34-.92,0-1.63,.31-2.12,.94l-1.18-.91c.35-.47,.83-.84,1.43-1.11,.6-.26,1.27-.39,2.01-.39,.98,0,1.77,.23,2.36,.7s.88,1.1,.88,1.9c0,.49-.1,.95-.31,1.38-.21,.43-.6,.92-1.19,1.47l-2.42,2.3h4.27Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M302.24,287.45h-1.6v2.06h-1.63v-2.06h-4.97v-1.17l4.46-5.84h1.8l-4.21,5.58h2.96v-1.82h1.58v1.82h1.6v1.42Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M192.87,217.86v9.06h-1.68v-7.65h-1.92v-1.41h3.6Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M196.51,226.5c-.57-.37-1.02-.9-1.35-1.6-.33-.7-.49-1.54-.49-2.5s.16-1.8,.49-2.5c.33-.7,.78-1.24,1.35-1.61,.57-.37,1.22-.55,1.94-.55s1.37,.18,1.95,.55c.57,.37,1.02,.9,1.35,1.61,.33,.7,.49,1.54,.49,2.5s-.16,1.8-.49,2.5c-.33,.7-.78,1.24-1.35,1.6-.57,.37-1.22,.55-1.95,.55s-1.37-.18-1.94-.55Zm3.47-1.71c.37-.53,.56-1.33,.56-2.39s-.19-1.86-.56-2.39c-.37-.54-.89-.8-1.53-.8s-1.15,.27-1.52,.8c-.38,.54-.56,1.33-.56,2.39s.19,1.86,.56,2.39c.37,.54,.88,.8,1.52,.8s1.16-.27,1.53-.8Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M196.71,285.48c.25,.37,.38,.8,.38,1.29,0,.55-.15,1.04-.46,1.45-.31,.41-.74,.73-1.3,.95-.56,.22-1.21,.33-1.95,.33s-1.39-.11-1.95-.33c-.56-.22-.99-.54-1.29-.95-.3-.41-.45-.9-.45-1.45,0-.49,.12-.92,.38-1.29,.25-.37,.61-.66,1.07-.87-.36-.2-.64-.46-.83-.78-.19-.32-.29-.7-.29-1.12,0-.51,.14-.95,.42-1.33,.28-.38,.68-.67,1.18-.88,.51-.21,1.1-.31,1.76-.31s1.26,.1,1.77,.31c.51,.21,.91,.5,1.19,.88,.28,.38,.43,.82,.43,1.33,0,.42-.1,.79-.3,1.11-.2,.32-.48,.58-.85,.79,.47,.22,.84,.51,1.09,.87Zm-1.86,2.31c.36-.26,.54-.62,.54-1.07s-.18-.8-.54-1.06-.85-.39-1.48-.39-1.11,.13-1.46,.39c-.35,.26-.53,.61-.53,1.06s.18,.82,.53,1.07c.35,.26,.84,.39,1.46,.39s1.11-.13,1.48-.39Zm-2.72-5.95c-.31,.22-.46,.54-.46,.95s.15,.7,.46,.92c.31,.23,.72,.34,1.25,.34s.96-.11,1.27-.34c.31-.23,.47-.54,.47-.92s-.16-.72-.47-.95c-.32-.22-.74-.34-1.26-.34s-.94,.11-1.25,.34Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M308.36,253.95c.44,.47,.66,1.05,.66,1.75,0,.53-.13,1-.4,1.44-.27,.43-.67,.77-1.21,1.03-.54,.25-1.2,.38-1.97,.38-.65,0-1.27-.09-1.87-.28-.6-.19-1.11-.44-1.53-.77l.72-1.31c.33,.28,.73,.49,1.2,.65,.47,.16,.96,.24,1.46,.24,.6,0,1.06-.12,1.4-.37,.34-.25,.51-.58,.51-1s-.16-.75-.49-.99c-.32-.24-.82-.36-1.48-.36h-.83v-1.15l2.06-2.45h-4.12v-1.41h6.17v1.12l-2.2,2.61c.84,.1,1.48,.39,1.92,.85Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M186.69,250.39c.69,.78,1.03,1.89,1.03,3.34,0,1.02-.19,1.89-.56,2.61s-.89,1.27-1.56,1.64c-.67,.38-1.44,.56-2.32,.56-.47,0-.9-.05-1.31-.15-.41-.1-.77-.24-1.07-.43l.62-1.27c.45,.29,1.02,.44,1.72,.44,.87,0,1.55-.27,2.04-.8,.49-.53,.74-1.31,.74-2.32h0c-.27,.3-.61,.53-1.02,.69-.41,.16-.88,.24-1.4,.24-.6,0-1.13-.11-1.6-.34-.47-.23-.85-.55-1.11-.98-.27-.42-.4-.91-.4-1.46,0-.59,.15-1.1,.44-1.55,.29-.44,.69-.79,1.19-1.03,.5-.24,1.06-.36,1.68-.36,1.24,0,2.21,.39,2.89,1.16Zm-1.44,2.79c.34-.29,.51-.66,.51-1.11s-.17-.8-.5-1.09c-.33-.29-.79-.43-1.38-.43-.53,0-.95,.14-1.28,.42-.33,.28-.49,.65-.49,1.12s.16,.85,.49,1.13c.33,.28,.77,.41,1.32,.41s.99-.15,1.33-.44Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M244,254.99L245.67,205.76L248.01,205.76L250.78,254.99L244,254.99Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M244.43,258.29L221.44,235.38L223,233.64L248.97,253.25L244.43,258.29Z"
+        android:fillColor="#263238"/>
+    <path
+        android:pathData="M231.98,265.52L285.68,235.01L233.11,267.16L231.98,265.52Z"
+        android:fillColor="#407BFF"/>
+    <path
+        android:pathData="M254.51,254.99c0,3.93-3.19,7.12-7.12,7.12s-7.12-3.19-7.12-7.12,3.19-7.12,7.12-7.12,7.12,3.19,7.12,7.12Z"
+        android:fillColor="#407BFF"/>
+    <path
+        android:pathData="M254.51,254.99c0,3.93-3.19,7.12-7.12,7.12s-7.12-3.19-7.12-7.12,3.19-7.12,7.12-7.12,7.12,3.19,7.12,7.12Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <path
+        android:pathData="M189.17,326.97s-13.33,25.58-8.83,25.95c4.5,.37,20.11-17.77,20.11-17.77,0,0-1.67-8.98-11.27-8.18Z"
+        android:fillColor="#EE3377"/>
+    <path
+        android:pathData="M301.54,324.49s13.33,25.58,8.83,25.95c-4.5,.37-20.11-17.77-20.11-17.77,0,0,1.67-8.98,11.27-8.18Z"
+        android:fillColor="#EE3377"/>
+    <path
+        android:pathData="M156.56,211.79c.49-.59,56.76-51.53,56.76-51.53,0,0-21.55-18.66-46.8,6.44-25.25,25.09-9.96,45.09-9.96,45.09Z"
+        android:fillColor="#EE3377"/>
+    <path
+        android:pathData="M213.32,160.26c2.27,2.47-9.21,15.55-24.78,29.81-15.56,14.26-30.01,23.82-32.28,21.34-2.27-2.47,8.51-16.04,24.08-30.3,15.56-14.26,30.71-23.33,32.98-20.86Z"
+        android:fillColor="#EE3377"/>
+    <path
+        android:pathData="M213.32,160.26c2.27,2.47-9.21,15.55-24.78,29.81-15.56,14.26-30.01,23.82-32.28,21.34-2.27-2.47,8.51-16.04,24.08-30.3,15.56-14.26,30.71-23.33,32.98-20.86Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <group
+        android:translateX="-75.44"
+        android:translateY="171.39"
+        android:rotation="-42.5">
+        <path
+            android:pathData="M176.96,168.16L188.33,168.16L188.33,197.22L176.96,197.22Z"
+            android:fillColor="#EE3377"/>
+    </group>
+    <path
+        android:pathData="M160.78,167.7 a8.12,8.12 0 1,0 16.24,0 a8.12,8.12 0 1,0 -16.24,0Z"
+        android:fillColor="#EE3377"/>
+    <path
+        android:pathData="M166.48,167.45l-4.59,4.32c-.65,.8-11.94,16.82-2.53,31.91,3.57-4.85,7.79-9.61,12.42-14.31-4.88-3.94-10.48-11.21-5.3-21.92Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4"/>
+    <path
+        android:pathData="M176.65,184.58L185.08,176.94L186.96,179L178.97,187.12L176.65,184.58Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.2"/>
+    <path
+        android:pathData="M161.89,171.77L173.36,160.92L172.44,160.4L161.37,170.72L161.89,171.77Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <path
+        android:pathData="M274.98,159.6c.65,.4,59.15,48.77,59.15,48.77,0,0,15.37-24.01-13.09-45.39-28.46-21.38-46.06-3.38-46.06-3.38Z"
+        android:fillColor="#EE3377"/>
+    <path
+        android:pathData="M334.13,208.37c-2.12,2.6-16.71-6.88-33.06-20.24-16.35-13.35-27.88-26.28-25.76-28.88,2.12-2.6,17.09,6.12,33.44,19.47,16.35,13.35,27.5,27.04,25.38,29.64Z"
+        android:fillColor="#EE3377"/>
+    <path
+        android:pathData="M334.13,208.37c-2.12,2.6-16.71-6.88-33.06-20.24-16.35-13.35-27.88-26.28-25.76-28.88,2.12-2.6,17.09,6.12,33.44,19.47,16.35,13.35,27.5,27.04,25.38,29.64Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <group
+        android:translateX="183.98"
+        android:translateY="-153.66"
+        android:rotation="39.24">
+        <path
+            android:pathData="M301.84,166.7L313.21,166.7L313.21,195.76L301.84,195.76Z"
+            android:fillColor="#EE3377"/>
+    </group>
+    <path
+        android:pathData="M321.56,173.51c-4.44,.64-8.55-2.43-9.2-6.87-.64-4.44,2.43-8.55,6.87-9.2,4.44-.64,8.55,2.43,9.2,6.87,.64,4.44-2.43,8.55-6.87,9.2Z"
+        android:fillColor="#EE3377"/>
+    <path
+        android:pathData="M320.29,163.05l-4.94-3.92c-.89-.53-18.36-9.4-31.94,2.08,5.31,2.83,10.63,6.33,15.95,10.24,3.19-5.4,9.59-11.98,20.93-8.4Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4"/>
+    <path
+        android:pathData="M304.8,175.57L313.57,182.81L311.81,184.97L302.63,178.23L304.8,175.57Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.2"/>
+    <path
+        android:pathData="M315.36,159.12L327.75,168.91L328.13,167.93L316.32,158.46L315.36,159.12Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <path
+        android:pathData="M187.35,196.24s6.24-5.54,8.65-7.39l-.79-.86-8.57,7.49,.7,.77Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <path
+        android:pathData="M294.58,188.16s6.45,5.29,8.66,7.39l.72-.91-8.74-7.29-.65,.81Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <path
+        android:pathData="M63.63,212.96s48.98,6.64,59.28,13.86c10.3,7.23,31.28,35.56,31.28,35.56,0,0-25.74-27.17-36.04-33.51-10.3-6.34-54.52-15.91-54.52-15.91Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <path
+        android:pathData="M83.66,226.47s-4.5,14.09,6.65,13.7c11.16-.39,15.66-5.28,15.66-5.28,0,0-3.13,12.92,5.28,12.72,8.42-.2,14.29-5.48,14.29-5.48,0,0-12.14,10.35-18.01,7.92-5.87-2.44-3.38-10.85-3.38-10.85,0,0-13.75,6.68-19.43,2s-4.57-6.82-1.07-14.72Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <path
+        android:pathData="M427.6,210.29s-48.98,6.64-59.28,13.86c-10.3,7.23-31.28,35.56-31.28,35.56,0,0,25.74-27.17,36.04-33.51,10.3-6.34,54.52-15.91,54.52-15.91Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <path
+        android:pathData="M407.57,223.81s4.5,14.09-6.65,13.7c-11.16-.39-15.66-5.28-15.66-5.28,0,0,3.13,12.92-5.28,12.72-8.42-.2-14.29-5.48-14.29-5.48,0,0,12.14,10.35,18.01,7.92,5.87-2.44,3.38-10.85,3.38-10.85,0,0,13.75,6.68,19.43,2,5.68-4.68,4.57-6.82,1.07-14.72Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3"/>
+    <path
+        android:pathData="M216.78,173.79c-.15,0-.3-.09-.35-.25-.07-.19,.03-.41,.22-.48,15.57-5.73,33.03-6.77,49.16-2.91,.2,.05,.33,.25,.28,.45-.05,.2-.25,.32-.45,.28-16-3.83-33.3-2.8-48.73,2.88-.04,.02-.09,.02-.13,.02Z"
+        android:fillColor="#407BFF"/>
+    <path
+        android:pathData="M270.38,172.17s-.07,0-.1-.01l-2.47-.7c-.2-.06-.32-.26-.26-.46,.06-.2,.26-.32,.46-.26l2.47,.7c.2,.06,.32,.26,.26,.46-.05,.17-.2,.27-.36,.27Z"
+        android:fillColor="#407BFF"/>
 </vector>


### PR DESCRIPTION
## What

Replaces the resting **"No plan available yet"** illustration (`NextPlanHint`) — previously a calendar + person retinted near-monochrome — with the supplied **clock**, themed across **three dynamic Material You accents** so it tracks the wallpaper instead of reading flat.

| Region | Role |
|---|---|
| Dial ring + hub + hand | `primary` |
| Bells + feet | `secondary` |
| Background "speed wings" | `tertiary` (lighter overlay → `tertiaryContainer`) |
| Numbers, hands, ticks, shading | `onSurface` |
| Dial face + sheen | `surface` |
| Ground shadow | `surfaceVariant` |

`recolored()` maps **by source colour globally**, so distinct regions of the SVG were given distinct sentinel fills before converting; the lambda then maps each sentinel to its role and preserves every path's alpha. Added a dark-mode `@Preview` alongside the light one.

### Conversion note
svg2vectordrawable baked opacity into fill alpha and silently merged away the white dial face; svgo@3 crashes on this file. So the drawable was produced by a small self-contained SVG→vector-drawable pass (shapes→paths, circles emitted at `cx,cy,r` — their transforms are verified pure rotate-about-centre artifacts, drift <0.03px — rotated bell rects as `<group>`s, opacity → `fillAlpha`). All 64 paths preserved.

## Verification
`:app:assembleDebug` + `:app:lintDebug` green; aapt validates the vector drawable. **Not visually verified** — no SVG rasterizer available and the emulator is wiped — so the actual look (how the three hues read together, light + dark) needs an eye via the `NoPlanIllustrationPreview` (light/dark) or on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)