### PR TITLE
perf(home): build the plan off the main thread, memoize settled turns

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiPlanMapper.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiPlanMapper.kt
@@ -82,6 +82,11 @@ object AiPlanMapper {
         rows: List<AiMessageEntity>,
         streaming: StreamingTurn?,
         events: List<SessionEvent>,
+        // Builds a settled turn's thread from its rows. Defaulted to the direct mapping; callers pass a
+        // memoizing impl so immutable settled turns aren't re-decoded on every emission.
+        threadFor: (turn: Int, rows: List<AiMessageEntity>) -> AiThreadUi = { turn, turnRows ->
+            AiThreadMapper.build(turnRows) ?: AiThreadUi(turn, summary = null, process = emptyList(), response = null)
+        },
     ): AiPlanUi? {
         val byTurn = rows.groupBy { it.turnIndex }
         val streamingTurn = streaming?.turnIndex
@@ -91,7 +96,7 @@ object AiPlanMapper {
         // The live partial overrides the persisted rows of its turn → never a duplicate/stale iteration.
         fun threadOf(turn: Int): AiThreadUi =
             if (turn == streamingTurn && streaming != null) AiThreadMapper.buildFromBlocks(turn, streaming.blocks)
-            else AiThreadMapper.build(byTurn.getValue(turn)) ?: AiThreadUi(turn, summary = null, process = emptyList(), response = null)
+            else threadFor(turn, byTurn.getValue(turn))
 
         fun startOf(turn: Int): Long =
             byTurn[turn]?.minOfOrNull { it.createdAt }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
@@ -14,6 +14,7 @@ import fr.bsodium.cron.calendar.requestCalendarSync
 import fr.bsodium.cron.location.LocationProvider
 import fr.bsodium.cron.session.SessionFsm
 import fr.bsodium.cron.session.SessionRepository
+import fr.bsodium.cron.session.db.AiMessageEntity
 import fr.bsodium.cron.session.db.CronDatabase
 import fr.bsodium.cron.session.db.toModel
 import fr.bsodium.cron.session.model.ActionType
@@ -33,6 +34,7 @@ import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -113,7 +115,8 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         .distinctUntilChanged()
         .flatMapLatest { id ->
             if (id == null) flowOf(null)
-            else db.eventDao().observeBySession(id).map { events -> buildSleepStats(events) }
+            // Off the main thread: buildSleepStats decodes every event's JSON.
+            else db.eventDao().observeBySession(id).map { events -> buildSleepStats(events) }.flowOn(Dispatchers.Default)
         }
 
     /** Latest-turn AI thread — the live streaming partial overrides the settled DB state while a turn
@@ -125,13 +128,23 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             if (id == null) {
                 flowOf(null)
             } else {
+                // One cache per session so settled turns (immutable) build once instead of being
+                // re-decoded on every DB/streaming emission. Confined to this Default-dispatched flow.
+                val threadCache = TurnThreadCache()
                 combine(
                     db.aiMessageDao().observeBySession(id),
                     db.eventDao().observeBySession(id),
                     StreamingTurnStore.active,
                 ) { rows, events, streaming ->
-                    AiPlanMapper.buildPlan(rows, streaming?.takeIf { it.sessionId == id }, events.map { it.toModel() })
+                    AiPlanMapper.buildPlan(
+                        rows,
+                        streaming?.takeIf { it.sessionId == id },
+                        events.map { it.toModel() },
+                        threadFor = threadCache::threadFor,
+                    )
                 }.conflate()
+                    // Off the main thread: buildPlan decodes every turn's content JSON + every event's JSON.
+                    .flowOn(Dispatchers.Default)
             }
         }
 
@@ -424,3 +437,21 @@ private data class HomePrefs(
     val autoAlarmsEnabled: Boolean,
     val eveningTriggerTime: LocalTime,
 )
+
+/**
+ * Per-session memo for [AiPlanMapper.buildPlan]: a settled turn's rows are immutable, so its
+ * [AiThreadUi] is rebuilt only when the turn's rows change (keyed by their ids). Caps the per-emission
+ * cost at the streaming/changed turn instead of re-decoding every turn's JSON. One instance per session,
+ * confined to a single Default-dispatched flow, so a plain map needs no synchronization.
+ */
+private class TurnThreadCache {
+    private val cache = HashMap<Int, Pair<List<Long>, AiThreadUi>>()
+
+    fun threadFor(turn: Int, rows: List<AiMessageEntity>): AiThreadUi {
+        val signature = rows.map { it.id }
+        cache[turn]?.let { (sig, thread) -> if (sig == signature) return thread }
+        val thread = AiThreadMapper.build(rows) ?: AiThreadUi(turn, summary = null, process = emptyList(), response = null)
+        cache[turn] = signature to thread
+        return thread
+    }
+}


### PR DESCRIPTION
## Problem

Opening the app or switching back to Home lags, and the lag grows with the number of replan tabs for the day (a 5–6 replan day from repeated calendar changes becomes badly janky).

## Root cause

`HomeViewModel.aiPlanFlow` builds the iteration list inside a `combine` with **no `flowOn`**, so the transform runs on `viewModelScope` — the **main thread**. Each `AiPlanMapper.buildPlan` call iterates **all** turns and, per turn, runs `AiThreadMapper.build` → `decodeBlocks` (`SessionJson.decodeFromString`, twice per turn) plus regex parsing, and `events.map { it.toModel() }` decodes every event's JSON. It's **O(turns)** main-thread work re-run on every DB/streaming emission — blocking the first frames exactly when the screen composes. More replans → more turns decoded on the main thread → more lag.

## Fix

- **`flowOn(Dispatchers.Default)`** on `aiPlanFlow` and `sleepStatsFlow` — the JSON decode + parse now runs off the main thread. Behaviourally identical (same emissions/values); `stateIn`'s initial value covers the first frame while the first build runs in the background.
- **Per-session `TurnThreadCache`** — settled turns are immutable, so their `AiThreadUi` is memoized (keyed by the turn's row ids) and rebuilt only when the rows change. `buildPlan`'s per-emission cost drops from O(all turns) to O(changed turns). `buildPlan` gains a **defaulted** `threadFor` param, so it stays pure and `AiPlanMapperTest` is unchanged.

Out of scope: the `ReplanHistoryBar` strip is O(n) in composition but n is small and it isn't the open/re-entry bottleneck — revisit only if profiling shows it dominates after this.

## Verification

`:app:assembleDebug`, `:app:lintDebug`, `:app:checkFileLength`, `:app:testDebugUnitTest` all green — the unchanged `AiPlanMapperTest` proves the defaulted `threadFor` kept `buildPlan` output identical.

⚠️ **Not yet verified on device** (emulator wiped). The real check: open / switch to Home on a multi-replan session and confirm the jank is gone; ideally confirm via the profiler that `buildPlan`/`decodeFromString` no longer run on the main thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)