### PR TITLE
perf(startup): branded splash + off-main start-destination (kill the white screen)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -124,6 +124,7 @@ tasks.configureEach {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,7 +71,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Cron">
+            android:theme="@style/Theme.Cron.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/fr/bsodium/cron/MainActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/MainActivity.kt
@@ -14,12 +14,13 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.material3.Scaffold
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -40,7 +41,9 @@ import fr.bsodium.cron.ui.screens.onboarding.OnboardingViewModel
 import fr.bsodium.cron.ui.screens.settings.SETTINGS_ROOT
 import fr.bsodium.cron.ui.screens.settings.settingsGraph
 import fr.bsodium.cron.ui.theme.CronTheme
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 
 private const val FORWARD_MS = 350
 private const val TAB_MS = 220
@@ -80,21 +83,29 @@ class MainActivity : ComponentActivity() {
      */
     @Suppress("UnusedMaterial3ScaffoldPaddingParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splash = installSplashScreen()
         super.onCreate(savedInstanceState)
         // System-driven bar styling — dark icons on a light page, light icons on dark.
         enableEdgeToEdge()
 
         val settings = SettingsRepository(this)
-        val secureStore = SecureKeyStore(this)
+        // Resolve the start destination off the main thread: SecureKeyStore init (keystore/Tink) and the
+        // DataStore read both block, and gating the first frame on them shows a white window. The branded
+        // splash stays up until this lands, then the NavHost composes immediately.
+        val startDestination = mutableStateOf<String?>(null)
+        splash.setKeepOnScreenCondition { startDestination.value == null }
 
         setContent {
             CronTheme {
-                val onboardingDone: Boolean? by produceState<Boolean?>(initialValue = null) {
-                    value = settings.onboardingComplete.first()
+                LaunchedEffect(Unit) {
+                    if (startDestination.value == null) {
+                        startDestination.value = withContext(Dispatchers.IO) {
+                            val done = settings.onboardingComplete.first()
+                            if (done && SecureKeyStore(this@MainActivity).hasAnthropicKey()) ROUTE_HOME else "onboarding"
+                        }
+                    }
                 }
-                val done = onboardingDone ?: return@CronTheme
-
-                val startDestination = if (done && secureStore.hasAnthropicKey()) ROUTE_HOME else "onboarding"
+                val start = startDestination.value ?: return@CronTheme
                 val navController = rememberNavController()
                 val backStackEntry by navController.currentBackStackEntryAsState()
                 val currentRoute = backStackEntry?.destination?.route
@@ -126,7 +137,7 @@ class MainActivity : ComponentActivity() {
                     Box(modifier = Modifier.fillMaxSize()) {
                     NavHost(
                         navController = navController,
-                        startDestination = startDestination,
+                        startDestination = start,
                     ) {
                         composable(
                             route = "onboarding",

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Launch splash background — matches the app's dark page background so dark-mode launches don't flash light. -->
+    <color name="splash_background">#FF0A0A0A</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <!-- Launch splash background — matches the app's light page background (values-night overrides for dark). -->
+    <color name="splash_background">#FFF8F5F0</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.Cron" parent="android:Theme.Material.Light.NoActionBar" />
+
+    <!-- Launch theme: a branded splash (icon on splash_background) shown until MainActivity resolves the
+         start destination off the main thread, then it hands off to Theme.Cron. splash_background adapts
+         via values-night, so dark-mode launches don't flash light. -->
+    <style name="Theme.Cron.Starting" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/splash_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="postSplashScreenTheme">@style/Theme.Cron</item>
+    </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ agp = "9.2.1"
 kotlin = "2.3.10"
 ksp = "2.3.8"
 coreKtx = "1.17.0"
+coreSplashscreen = "1.0.1"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
@@ -32,6 +33,7 @@ androidxTestCore = "1.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
## Problem

On app open there's a "white screen for a good second." The first frame is gated on main-thread work, and there's no splash so you see the bare white window:

- `MainActivity.onCreate` constructs `SecureKeyStore(this)` on the main thread — `EncryptedSharedPreferences.create(...)` + `MasterKey.Builder().build()` does Android Keystore/Tink init, the classic 200–800ms cold-start main-thread stall — and `hasAnthropicKey()` is read *in composition*.
- The start destination also waits on `produceState { settings.onboardingComplete.first() }`, and `done ?: return@CronTheme` renders **nothing** until the DataStore read returns.
- No `core-splashscreen`; the `Theme.Material.Light` window is white during the wait.

## Fix

- **Branded splash:** add `androidx.core:core-splashscreen`, `installSplashScreen()` in `onCreate`, and a `Theme.Cron.Starting` (icon on `@color/splash_background`, `postSplashScreenTheme = Theme.Cron`). `splash_background` has a `values-night` variant so dark launches don't flash light.
- **Off-main start destination:** resolve it in `withContext(Dispatchers.IO)` — the onboarding read and `SecureKeyStore`/`hasAnthropicKey()` no longer run on the main thread or gate the first frame. The splash is kept up (`setKeepOnScreenCondition`) until the destination lands, then the NavHost composes immediately.

Net: a branded splash covers the brief async resolve instead of a white void, and the keystore/Tink init is off the UI thread.

The **home-tab switch lag** is addressed separately by **#81** (plan-building off the main thread) and **#82** (bundled Roboto Flex → synchronous font resolution) — merge those alongside this.

## Verification

`:app:assembleDebug` + `:app:lintDebug` green. **On device (real check — emulator wiped):** cold launch shows the splash (not white), then home/onboarding; profiler should show `EncryptedSharedPreferences`/`MasterKey` off the main thread at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)