### PR TITLE
perf(home): stage the render — paint the alarm card + header first

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -33,6 +34,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -86,6 +88,16 @@ internal fun HomePlanContent(
     var cardFullHeightPx by remember { mutableIntStateOf(0) }
     var tabsHeightPx by remember { mutableIntStateOf(0) }
     val hasTabs = iterations.size > 1
+
+    // Staged render: paint the cheap header + alarm card on the first frame, then let the markdown-heavy
+    // thread pager and the SubcomposeLayout tab strip compose one frame later — off the critical paint
+    // path. withFrameNanos waits for that first frame to draw before flipping. Re-stages on every entry
+    // (plain remember, re-created when this composable is) so tab-switches feel instant too.
+    var deferHeavy by remember { mutableStateOf(true) }
+    LaunchedEffect(Unit) {
+        withFrameNanos {}
+        deferHeavy = false
+    }
 
     // Pager two-way bound to the tab selection (commit-on-settle, tap animation, midpoint haptic) — the
     // binding lives in PagerSelectionBinding.kt; it returns whether the user is actively dragging.
@@ -223,14 +235,19 @@ internal fun HomePlanContent(
                 Spacer(Modifier.height(with(density) { reservePx.toDp() }))
             }
             item(key = "thread") {
-                ThreadPager(
-                    iterations = iterations,
-                    pagerState = pagerState,
-                    pullStates = pullStates,
-                    onJumpToLatest = { swipeHaptics.tick(); selectedTurn = iterations.last().turnIndex },
-                    onPageHeight = { turn, px -> if (pageHeights[turn] != px) pageHeights[turn] = px },
-                    modifier = if (effPagerPx > 0) Modifier.height(with(density) { effPagerPx.toDp() }) else Modifier,
-                )
+                if (deferHeavy) {
+                    // Reserve the pager's slot so the list doesn't jump when the thread fades in next frame.
+                    Spacer(Modifier.height(with(density) { effPagerPx.toDp() }))
+                } else {
+                    ThreadPager(
+                        iterations = iterations,
+                        pagerState = pagerState,
+                        pullStates = pullStates,
+                        onJumpToLatest = { swipeHaptics.tick(); selectedTurn = iterations.last().turnIndex },
+                        onPageHeight = { turn, px -> if (pageHeights[turn] != px) pageHeights[turn] = px },
+                        modifier = if (effPagerPx > 0) Modifier.height(with(density) { effPagerPx.toDp() }) else Modifier,
+                    )
+                }
             }
             if (!hasNotificationPermission) {
                 item(key = "notif-permission") {
@@ -243,8 +260,9 @@ internal fun HomePlanContent(
             collapse = collapseState,
             // The history tabs ride in the overlay (above the scrim), sticky right below the card, so the
             // scroll gradient never fades them. Lifted out of the list for that reason. Always supplied so
-            // the strip can animate IN/OUT (visibility = hasTabs) rather than popping the layout.
-            belowCardVisible = hasTabs,
+            // the strip can animate IN/OUT rather than popping the layout — and deferred off the first
+            // frame (its SubcomposeLayout probes are heavy) so it fades in with the thread.
+            belowCardVisible = hasTabs && !deferHeavy,
             belowCard = {
                 ReplanHistoryBar(
                     iterations = iterations,

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
@@ -65,7 +65,9 @@ internal fun ThreadPager(
         key = { iterations.getOrNull(it)?.turnIndex ?: it },
         verticalAlignment = Alignment.Top,
         // No pageSpacing: each page's own xl padding forms a symmetric 2·xl gutter between adjacent content.
-        beyondViewportPageCount = 1, // pre-compose the neighbour so its markdown is parsed before it slides in
+        // 0 (not 1): entry parses only the visible page's markdown instead of two — the neighbour composes
+        // when a swipe starts, where a tiny cost is fine. Halves the thread's first-frame cost.
+        beyondViewportPageCount = 0,
     ) { page ->
         val iter = iterations.getOrNull(page) ?: return@HorizontalPager
         // getOrPut once per turnIndex; the current page always has its state ready for the caller's pull


### PR DESCRIPTION
## Problem

Switching to Home (and the splash→home handoff) takes ~0.66s before content appears, while other tabs are instant. It's **composition cost, not data**: on re-entry the VM survives, so the plan is already loaded and `homePhase` is `Plan` immediately — but `HomePlanContent` re-composes its whole heavy tree synchronously before the first frame:

- **Heavy:** `ThreadPager` → `AiThinkingThread` → `MarkdownBlock` renders the response with `rememberMarkdownState(immediate = true)`, a synchronous main-thread markdown parse (`immediate` is intentional — it avoids a blank-flash per streamed token, so we can't just turn it off). `ReplanHistoryBar` adds nested `SubcomposeLayout` probe passes.
- **Cheap:** the greeting row and the alarm card (its collapse is a measure-pass provider).

## Fix

Stage the render — paint the easy stuff first, defer the heavy stuff one frame:

- A `deferHeavy` flag (flipped after `withFrameNanos {}`) gates the `ThreadPager` item (behind a height-reserving `Spacer` so the list doesn't jump) and the tab strip's `belowCardVisible`. **Frame 1 = greeting + alarm card; frame 2+ = thread pager + replan strip fading in**, off the critical paint path.
- Safe: the sticky-card collapse reads the always-present `alarm-spacer` item, **not** the thread, so collapse is unaffected; all pager/selection/pull state is hoisted above the gate and survives.
- `ThreadPager` `beyondViewportPageCount` 1 → 0: entry parses **one** markdown body instead of two (the neighbour composes when a swipe starts — a deliberate gesture).

Re-stages on every entry (plain `remember`, re-created per composable), so tab-switches feel instant too.

## Verification

`:app:assembleDebug` + `:app:lintDebug` green; `HomePlanContentPreview` still renders the thread (its `LaunchedEffect` flips the flag). **On device (real check — emulator wiped):** Settings→Home should show the greeting + alarm card within a frame, with the thread + strip fading in a moment later; the sticky-card collapse on scroll must still behave. If the card *alone* still feels slow, the next lever is caching the LCD/greeting font measurement (noted in the plan).

Complements #81 (off-main `buildPlan`, cold-start/streaming) and #82 (bundled font, synchronous resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)