### PR TITLE
feat(a11y): long-press tooltips on icon buttons + nav tabs as tabs

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/components/CronBottomBar.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/CronBottomBar.kt
@@ -49,6 +49,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -203,32 +208,41 @@ private fun RowScope.NavSlot(
         label = "nav-fill",
     )
     val haptics = rememberCronHaptics()
-    Box(
-        modifier = Modifier
-            // Square slot so the circular indicator nests with an equal margin on every side
-            // (x and y) inside the pill, rather than wider side gaps.
-            .size(NAV_SLOT_SIZE)
-            // Clip BEFORE clickable so the ripple respects the slot shape.
-            .clip(Radius.full)
-            .clickable(enabled = !selected) {
-                haptics.contextClick()
-                onNavigate(route)
-            },
-        contentAlignment = Alignment.Center,
-    ) {
+    IconTooltip(label) {
         Box(
             modifier = Modifier
-                .size(NAV_INDICATOR_SIZE)
-                .clip(CircleShape)
-                .background(container),
+                // Square slot so the circular indicator nests with an equal margin on every side
+                // (x and y) inside the pill, rather than wider side gaps.
+                .size(NAV_SLOT_SIZE)
+                // Clip BEFORE clickable so the ripple respects the slot shape.
+                .clip(Radius.full)
+                .clickable(enabled = !selected) {
+                    haptics.contextClick()
+                    onNavigate(route)
+                }
+                // Announce as a selected/unselected tab named [label] (the glyph itself is decorative);
+                // without this the inner Symbol's clearAndSetSemantics would report it as a plain image.
+                .semantics {
+                    role = Role.Tab
+                    this.selected = selected
+                    contentDescription = label
+                },
             contentAlignment = Alignment.Center,
         ) {
-            Symbol(
-                symbol = symbol,
-                contentDescription = label,
-                tint = iconTint,
-                fill = fill,
-            )
+            Box(
+                modifier = Modifier
+                    .size(NAV_INDICATOR_SIZE)
+                    .clip(CircleShape)
+                    .background(container),
+                contentAlignment = Alignment.Center,
+            ) {
+                Symbol(
+                    symbol = symbol,
+                    contentDescription = null,
+                    tint = iconTint,
+                    fill = fill,
+                )
+            }
         }
     }
 }
@@ -251,6 +265,7 @@ private fun PrimaryActionFab(action: FabAction?) {
     // Captured here because AnimatedContent's transitionSpec lambda is not composable.
     val iconScaleSpec = MaterialTheme.motionScheme.fastSpatialSpec<Float>()
     val iconAlphaSpec = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
+    IconTooltip(label = if (working) "Cancel" else "Run alarm plan") {
     FloatingActionButton(
         onClick = {
             if (working) {
@@ -291,6 +306,7 @@ private fun PrimaryActionFab(action: FabAction?) {
                 fill = 1f,
             )
         }
+    }
     }
 }
 

--- a/app/src/main/java/fr/bsodium/cron/ui/components/IconTooltip.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/IconTooltip.kt
@@ -1,0 +1,31 @@
+package fr.bsodium.cron.ui.components
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Wraps an icon-only button so a long-press (or hover) surfaces a plain tooltip with [label] — the visible
+ * affordance icon buttons otherwise lack. (Screen readers already get the label via the button's
+ * `contentDescription`; this is the sighted-user counterpart.) Centralises the experimental-API opt-in.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IconTooltip(
+    label: String,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+        tooltip = { PlainTooltip { Text(label) } },
+        state = rememberTooltipState(),
+        modifier = modifier,
+        content = content,
+    )
+}

--- a/app/src/main/java/fr/bsodium/cron/ui/components/PageAppBar.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/PageAppBar.kt
@@ -51,13 +51,15 @@ fun PageAppBar(
         modifier = modifier,
         navigationIcon = {
             if (onBack != null) {
-                IconButton(onClick = onBack) {
-                    Symbol(
-                        symbol = MaterialSymbol.ArrowBack,
-                        contentDescription = "Back",
-                        tint = MaterialTheme.colorScheme.onBackground,
-                        autoMirror = true,
-                    )
+                IconTooltip("Back") {
+                    IconButton(onClick = onBack) {
+                        Symbol(
+                            symbol = MaterialSymbol.ArrowBack,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.onBackground,
+                            autoMirror = true,
+                        )
+                    }
                 }
             }
         },

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiFailureBanner.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiFailureBanner.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import fr.bsodium.cron.ui.screens.home.AiTurnFailure
 import fr.bsodium.cron.ui.theme.CronTheme
+import fr.bsodium.cron.ui.components.IconTooltip
 import fr.bsodium.cron.ui.theme.MaterialSymbol
 import fr.bsodium.cron.ui.theme.Radius
 import fr.bsodium.cron.ui.theme.Spacing
@@ -50,12 +51,14 @@ internal fun AiFailureBanner(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 TextButton(onClick = { onOpenSettings(); onDismiss() }) { Text("Open settings") }
-                IconButton(onClick = onDismiss) {
-                    Symbol(
-                        symbol = MaterialSymbol.Close,
-                        contentDescription = "Dismiss",
-                        tint = MaterialTheme.colorScheme.onErrorContainer,
-                    )
+                IconTooltip("Dismiss") {
+                    IconButton(onClick = onDismiss) {
+                        Symbol(
+                            symbol = MaterialSymbol.Close,
+                            contentDescription = "Dismiss",
+                            tint = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/SettingsChangedPill.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/SettingsChangedPill.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import fr.bsodium.cron.ui.components.IconTooltip
 import fr.bsodium.cron.ui.theme.MaterialSymbol
 import fr.bsodium.cron.ui.theme.Radius
 import fr.bsodium.cron.ui.theme.Spacing
@@ -44,12 +45,14 @@ internal fun SettingsChangedPill(
                 modifier = Modifier.weight(1f),
             )
             TextButton(onClick = onRewrite) { Text("Replan alarm") }
-            IconButton(onClick = onDismiss) {
-                Symbol(
-                    symbol = MaterialSymbol.Close,
-                    contentDescription = "Dismiss",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+            IconTooltip("Dismiss") {
+                IconButton(onClick = onDismiss) {
+                    Symbol(
+                        symbol = MaterialSymbol.Close,
+                        contentDescription = "Dismiss",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
Follow-up to the nav work: icon-only buttons had no long-press tooltip (the visible label affordance), and the nav tabs announced as a plain "image" to TalkBack.

## What

- **New `IconTooltip` wrapper** (`ui/components/IconTooltip.kt`) — Material 3 `TooltipBox` + `PlainTooltip`, centralising the experimental-API opt-in. Long-press (or hover) surfaces the label.
- **Applied to** the nav-bar tabs (Home/History/Settings), the FAB (Run alarm plan / Cancel), the app-bar back arrow (Back), and the dismiss buttons (Dismiss) — reusing the labels they already expose.
- **Nav tabs now announce as tabs.** They use `Modifier.clickable`, and the inner `Symbol`'s `clearAndSetSemantics` was reporting them as `Role.Image`. The slot now sets `role = Role.Tab` + `selected` + `contentDescription = label`, and the glyph is marked decorative (`contentDescription = null`).

Screen-reader labels already existed on all of these (this doesn't change what TalkBack *reads*, except upgrading the nav tabs from "image" to "selected tab").

## Verification

Build + lint green. **On-device checks still pending** (the test phone kept dropping off USB):
- Long-press a nav tab / FAB / back arrow → plain tooltip with the label. Confirm the **back-arrow** tooltip positions sensibly at the top of the screen (the plain provider prefers above; it should flip below if cramped — verify).
- Confirm the FAB still sits/scales correctly after being wrapped (TooltipBox shouldn't shift it).
- TalkBack: nav tabs announce as a selected/unselected **tab**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)