### PR TITLE
fix(settings): hoist TopAppBarState for predictive back preview

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/MainActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material3.TopAppBarState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -34,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import fr.bsodium.cron.ui.screens.settings.LocalSettingsListState
+import fr.bsodium.cron.ui.screens.settings.LocalSettingsTopAppBarState
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -154,8 +156,12 @@ class MainActivity : ComponentActivity() {
                     currentRoute?.startsWith("settings") == true
                 val fabRegistry = remember { FabRegistry() }
                 val settingsListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
+                val settingsTopAppBarState = rememberSaveable(saver = TopAppBarState.Saver) { TopAppBarState(0f, 0f, 1f) }
 
-                CompositionLocalProvider(LocalSettingsListState provides settingsListState) {
+                CompositionLocalProvider(
+                    LocalSettingsListState provides settingsListState,
+                    LocalSettingsTopAppBarState provides settingsTopAppBarState,
+                ) {
                     Scaffold(
                         bottomBar = {
                             AnimatedVisibility(

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Modifier
@@ -78,6 +79,9 @@ private val SETTINGS_SECTIONS: List<SettingsSection> = listOf(
 /** Scroll state for the settings root list, hoisted to MainActivity so PredictiveBackCard can snapshot it. */
 val LocalSettingsListState = compositionLocalOf { LazyListState() }
 
+/** App-bar collapse state for the settings root, hoisted so the predictive back preview reflects the real bar height. */
+val LocalSettingsTopAppBarState = compositionLocalOf { TopAppBarState(0f, 0f, 1f) }
+
 private val CARD_GAP = Spacing.xs
 private val GROUP_OUTER_RADIUS = Radius.xl
 private val GROUP_INNER_RADIUS = Radius.sm
@@ -88,8 +92,9 @@ private val GROUP_INNER_RADIUS = Radius.sm
 fun SettingsScreen(
     onOpenCategory: (String) -> Unit,
     listState: LazyListState = LocalSettingsListState.current,
+    topAppBarState: TopAppBarState = LocalSettingsTopAppBarState.current,
 ) {
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(state = topAppBarState)
     val navBottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
 
     Scaffold(


### PR DESCRIPTION
Closes #92 

## Summary

The predictive back preview was rendering with a fully expanded app bar (large title) even when the user had scrolled Settings and collapsed the bar. This happened because each `SettingsScreen` invocation was calling `TopAppBarDefaults.exitUntilCollapsedScrollBehavior()` with no arguments, which creates a fresh `TopAppBarState`.

Now `TopAppBarState` is hoisted via `CompositionLocal` in `MainActivity` (same pattern as `LazyListState`), so the preview reflects the real bar's collapse/expand state.

Refs #92 (prior commits fixed the list scroll position; this fixes the visual glitch)

## Changes

- **SettingsScreen.kt**: Added `LocalSettingsTopAppBarState` CompositionLocal and `topAppBarState` parameter
- **MainActivity.kt**: Hoisted `settingsTopAppBarState` via `rememberSaveable` and provided it

## Test plan

- [x] Open Settings and scroll down to collapse the large title
- [x] Tap a category (Commute, etc.)
- [x] Swipe from left edge and hold — the preview shows the collapsed bar (no giant "Settings" title)
- [x] Release — commit animations play, real screen appears at the correct scroll position
- [x] Retry — same behavior on subsequent gestures