### PR TITLE
feat: developer settings screen (debug builds)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ local.properties
 # Signing keystores — never commit
 *.jks
 *.keystore
+
+# Claude Code local state
+.claude/

--- a/app/src/debug/java/fr/bsodium/cron/ai/AnthropicClientFactory.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ai/AnthropicClientFactory.kt
@@ -1,22 +1,18 @@
 package fr.bsodium.cron.ai
 
-import android.content.Context
 import android.util.Log
 import fr.bsodium.cron.debug.FakeAnthropicClient
-import fr.bsodium.cron.debug.MockApiPrefs
 
-/** DEBUG variant — returns [FakeAnthropicClient] when the mock toggle is on; real client otherwise. */
+/** DEBUG variant — returns [FakeAnthropicClient] when [useMock] is true; real client otherwise. */
 object AnthropicClientFactory {
 
     private const val TAG = "AnthropicClientFactory"
 
-    fun create(context: Context, apiKeyProvider: () -> String?): AnthropicMessages {
-        val prefs = MockApiPrefs(context)
-        return if (prefs.isEnabled && prefs.isMockActive) {
+    fun create(useMock: Boolean, apiKeyProvider: () -> String?): AnthropicMessages =
+        if (useMock) {
             Log.i(TAG, "Using FakeAnthropicClient")
             FakeAnthropicClient()
         } else {
             AnthropicClient(apiKeyProvider = apiKeyProvider)
         }
-    }
 }

--- a/app/src/debug/java/fr/bsodium/cron/ai/AnthropicClientFactory.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ai/AnthropicClientFactory.kt
@@ -12,7 +12,7 @@ object AnthropicClientFactory {
 
     fun create(context: Context, apiKeyProvider: () -> String?): AnthropicMessages {
         val prefs = MockApiPrefs(context)
-        return if (prefs.isEnabled) {
+        return if (prefs.isEnabled && prefs.isMockActive) {
             Log.i(TAG, "Using FakeAnthropicClient")
             FakeAnthropicClient()
         } else {

--- a/app/src/debug/java/fr/bsodium/cron/ai/ToolRegistryFactory.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ai/ToolRegistryFactory.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import fr.bsodium.cron.debug.FakeToolRegistry
 import fr.bsodium.cron.debug.MockApiPrefs
 
-/** DEBUG variant — returns [FakeToolRegistry] when mock mode is on; null otherwise (caller builds real). */
+/** DEBUG variant — returns [FakeToolRegistry] when mock mode is enabled and active; null otherwise. */
 object ToolRegistryFactory {
-    fun mockOrNull(context: Context): ToolRegistry? =
-        if (MockApiPrefs(context).isEnabled) FakeToolRegistry.build() else null
+    fun mockOrNull(context: Context): ToolRegistry? {
+        val prefs = MockApiPrefs(context)
+        return if (prefs.isEnabled && prefs.isMockActive) FakeToolRegistry.build() else null
+    }
 }

--- a/app/src/debug/java/fr/bsodium/cron/ai/ToolRegistryFactory.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ai/ToolRegistryFactory.kt
@@ -6,8 +6,11 @@ import fr.bsodium.cron.debug.MockApiPrefs
 
 /** DEBUG variant — returns [FakeToolRegistry] when mock mode is enabled and active; null otherwise. */
 object ToolRegistryFactory {
-    fun mockOrNull(context: Context): ToolRegistry? {
+    fun shouldUseMock(context: Context): Boolean {
         val prefs = MockApiPrefs(context)
-        return if (prefs.isEnabled && prefs.isMockActive) FakeToolRegistry.build() else null
+        return prefs.isEnabled && prefs.isMockActive
     }
+
+    fun mockOrNull(useMock: Boolean): ToolRegistry? =
+        if (useMock) FakeToolRegistry.build() else null
 }

--- a/app/src/debug/java/fr/bsodium/cron/debug/MockApiPrefs.kt
+++ b/app/src/debug/java/fr/bsodium/cron/debug/MockApiPrefs.kt
@@ -2,17 +2,24 @@ package fr.bsodium.cron.debug
 
 import android.content.Context
 
-/** DEBUG-ONLY. Persists the mock-API toggle across process restarts. */
+/** DEBUG-ONLY. Persists mock-API preferences across process restarts. */
 class MockApiPrefs(context: Context) {
 
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
+    /** Capability gate — enables the mock infrastructure and shows the FAB chevron. */
     var isEnabled: Boolean
         get() = prefs.getBoolean(KEY_ENABLED, false)
         set(value) { prefs.edit().putBoolean(KEY_ENABLED, value).apply() }
 
+    /** Active mode — when true the next run uses canned responses instead of the real API. */
+    var isMockActive: Boolean
+        get() = prefs.getBoolean(KEY_ACTIVE, true)
+        set(value) { prefs.edit().putBoolean(KEY_ACTIVE, value).apply() }
+
     companion object {
         private const val PREFS_NAME = "mock_api"
         private const val KEY_ENABLED = "mock_api_enabled"
+        private const val KEY_ACTIVE = "mock_api_active"
     }
 }

--- a/app/src/debug/java/fr/bsodium/cron/ui/components/MockModeChevron.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ui/components/MockModeChevron.kt
@@ -26,6 +26,8 @@ fun rememberFabChevron(): FabChevronSlot? {
     val context = LocalContext.current
     val prefs = remember { MockApiPrefs(context) }
     val isMock = remember { mutableStateOf(prefs.isEnabled) }
+    isMock.value = prefs.isEnabled
+    if (!isMock.value) return null
     val showMenu = remember { mutableStateOf(false) }
     return remember(prefs) {
         FabChevronSlot(

--- a/app/src/debug/java/fr/bsodium/cron/ui/components/MockModeChevron.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ui/components/MockModeChevron.kt
@@ -25,9 +25,9 @@ import fr.bsodium.cron.ui.theme.Symbol
 fun rememberFabChevron(): FabChevronSlot? {
     val context = LocalContext.current
     val prefs = remember { MockApiPrefs(context) }
-    val isMock = remember { mutableStateOf(prefs.isEnabled) }
-    isMock.value = prefs.isEnabled
-    if (!isMock.value) return null
+    if (!prefs.isEnabled) return null
+    val isMock = remember { mutableStateOf(prefs.isMockActive) }
+    isMock.value = prefs.isMockActive
     val showMenu = remember { mutableStateOf(false) }
     return remember(prefs) {
         FabChevronSlot(
@@ -57,7 +57,7 @@ fun rememberFabChevron(): FabChevronSlot? {
                             else Box(Modifier.size(24.dp))
                         },
                         onClick = {
-                            prefs.isEnabled = false
+                            prefs.isMockActive = false
                             isMock.value = false
                             showMenu.value = false
                         },
@@ -78,7 +78,7 @@ fun rememberFabChevron(): FabChevronSlot? {
                             else Box(Modifier.size(24.dp))
                         },
                         onClick = {
-                            prefs.isEnabled = true
+                            prefs.isMockActive = true
                             isMock.value = true
                             showMenu.value = false
                         },

--- a/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
@@ -35,7 +35,7 @@ fun DeveloperSettingsScreen(onBack: () -> Unit) {
     SettingsDetailScaffold(title = "Developer", onBack = onBack) {
         SwitchRow(
             title = "Mock API responses",
-            subtitle = "Use canned tool results instead of calling Anthropic",
+            subtitle = "Allow switching between mock and real API responses",
             checked = mockEnabled,
             onCheckedChange = { enabled ->
                 prefs.isEnabled = enabled

--- a/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
@@ -1,0 +1,90 @@
+package fr.bsodium.cron.ui.screens.settings.categories
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import fr.bsodium.cron.debug.MockApiPrefs
+import fr.bsodium.cron.session.SessionRepository
+import fr.bsodium.cron.ui.screens.settings.components.SettingsDetailScaffold
+import fr.bsodium.cron.ui.screens.settings.components.SwitchRow
+import fr.bsodium.cron.ui.theme.Spacing
+import kotlinx.coroutines.launch
+
+@Composable
+fun DeveloperSettingsScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val prefs = remember { MockApiPrefs(context) }
+    var mockEnabled by remember { mutableStateOf(prefs.isEnabled) }
+    var showClearDialog by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    SettingsDetailScaffold(title = "Developer", onBack = onBack) {
+        SwitchRow(
+            title = "Mock API responses",
+            subtitle = "Use canned tool results instead of calling Anthropic",
+            checked = mockEnabled,
+            onCheckedChange = { enabled ->
+                prefs.isEnabled = enabled
+                mockEnabled = enabled
+            },
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Clear all runs",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                Text(
+                    text = "Delete every session and its AI messages",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            TextButton(onClick = { showClearDialog = true }) {
+                Text(
+                    text = "Clear",
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+
+    if (showClearDialog) {
+        AlertDialog(
+            onDismissRequest = { showClearDialog = false },
+            title = { Text("Delete all sessions?") },
+            text = { Text("This removes every run, including AI messages and events. This cannot be undone.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showClearDialog = false
+                    scope.launch { SessionRepository(context).clearAll() }
+                }) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearDialog = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}

--- a/app/src/main/java/fr/bsodium/cron/session/SessionRepository.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionRepository.kt
@@ -154,6 +154,8 @@ class SessionRepository(private val context: Context) {
         ))
     }
 
+    suspend fun clearAll(): Int = db.sessionDao().deleteAll()
+
     companion object {
         /**
          * The "morning" date the session targets.

--- a/app/src/main/java/fr/bsodium/cron/session/db/SessionDao.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/db/SessionDao.kt
@@ -36,4 +36,7 @@ interface SessionDao {
 
     @Query("DELETE FROM sessions WHERE createdAt < :olderThanMillis")
     suspend fun deleteOlderThan(olderThanMillis: Long): Int
+
+    @Query("DELETE FROM sessions")
+    suspend fun deleteAll(): Int
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/components/CronBottomBar.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/CronBottomBar.kt
@@ -150,9 +150,9 @@ private fun FabSlot(
     }
 }
 
-private val FAB_SLOT_WIDTH = 56.dp
-private val FAB_SLOT_HEIGHT = 56.dp
 private val SPLIT_MAIN_WIDTH = 120.dp
+private val FAB_SLOT_WIDTH = SPLIT_MAIN_WIDTH
+private val FAB_SLOT_HEIGHT = 56.dp
 private val SPLIT_CHEVRON_WIDTH = 56.dp
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 private val SPLIT_FAB_SLOT_WIDTH = SPLIT_MAIN_WIDTH + SplitButtonDefaults.Spacing + SPLIT_CHEVRON_WIDTH
@@ -308,7 +308,7 @@ private fun PrimaryActionFab(action: FabAction?) {
         label = "fab-press",
     )
     val iconAlphaSpec = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
-    IconTooltip(label = if (working) "Cancel" else "Run alarm plan") {
+    IconTooltip(label = if (working) "Cancel" else "Re-plan") {
         FloatingActionButton(
             onClick = {
                 if (working) {
@@ -319,10 +319,12 @@ private fun PrimaryActionFab(action: FabAction?) {
                     action.onClick()
                 }
             },
-            modifier = Modifier.graphicsLayer {
-                scaleX = pressScale
-                scaleY = pressScale
-            },
+            modifier = Modifier
+                .size(width = SPLIT_MAIN_WIDTH, height = FAB_SLOT_HEIGHT)
+                .graphicsLayer {
+                    scaleX = pressScale
+                    scaleY = pressScale
+                },
             shape = RoundedCornerShape(Radius.lg),
             containerColor = MaterialTheme.colorScheme.primary,
             contentColor = MaterialTheme.colorScheme.onPrimary,
@@ -337,16 +339,26 @@ private fun PrimaryActionFab(action: FabAction?) {
             AnimatedContent(
                 targetState = working,
                 transitionSpec = {
-                    (fadeIn(iconAlphaSpec)) togetherWith (fadeOut(iconAlphaSpec))
+                    fadeIn(iconAlphaSpec) togetherWith fadeOut(iconAlphaSpec)
                 },
                 contentAlignment = Alignment.Center,
                 label = "fab-icon",
             ) { isWorking ->
-                Symbol(
-                    symbol = if (isWorking) MaterialSymbol.Stop else MaterialSymbol.PlayArrow,
-                    contentDescription = if (isWorking) "Cancel" else "Run alarm plan",
-                    fill = 1f,
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Symbol(
+                        symbol = if (isWorking) MaterialSymbol.Stop else MaterialSymbol.Update,
+                        contentDescription = null,
+                        modifier = Modifier.padding(start = 16.dp, end = Spacing.sm),
+                        fill = 1f,
+                    )
+                    Text(
+                        text = if (isWorking) "Stop" else "Re-plan",
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsNavGraph.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsNavGraph.kt
@@ -27,6 +27,7 @@ import fr.bsodium.cron.ui.screens.settings.categories.AssistantSettingsScreen
 import fr.bsodium.cron.ui.screens.settings.categories.BuffersSettingsScreen
 import fr.bsodium.cron.ui.screens.settings.categories.CalendarSettingsScreen
 import fr.bsodium.cron.ui.screens.settings.categories.CommuteSettingsScreen
+import fr.bsodium.cron.ui.screens.settings.categories.DeveloperSettingsScreen
 import fr.bsodium.cron.ui.screens.settings.categories.FreeDaysSettingsScreen
 import fr.bsodium.cron.ui.screens.settings.categories.ReliabilitySettingsScreen
 import fr.bsodium.cron.ui.screens.settings.categories.ScheduleSettingsScreen
@@ -43,6 +44,7 @@ const val SETTINGS_ACCOUNT = "settings/account"
 const val SETTINGS_APP = "settings/app"
 const val SETTINGS_ABOUT = "settings/about"
 const val SETTINGS_CALENDAR = "settings/calendar"
+const val SETTINGS_DEVELOPER = "settings/developer"
 
 private const val PUSH_MS = 240
 
@@ -186,6 +188,9 @@ fun NavGraphBuilder.settingsGraph(
         }
         settingsDetail(SETTINGS_ABOUT) {
             AboutSettingsScreen(onBack = { navController.popBackStack() })
+        }
+        settingsDetail(SETTINGS_DEVELOPER) {
+            DeveloperSettingsScreen(onBack = { navController.popBackStack() })
         }
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.tooling.preview.Preview
+import fr.bsodium.cron.BuildConfig
 import fr.bsodium.cron.ui.components.PageAppBar
 import fr.bsodium.cron.ui.screens.settings.components.SettingsCategoryRow
 import fr.bsodium.cron.ui.theme.CronTheme
@@ -48,8 +49,8 @@ private val ACCOUNT_CATEGORY =
     SettingsCategory(SETTINGS_ACCOUNT, MaterialSymbol.Person, "Account", "Display name and API key")
 
 /** Categories grouped into labeled, connected-card sections: timing · assistant + system · app. */
-private val SETTINGS_SECTIONS: List<SettingsSection> = listOf(
-    SettingsSection(
+private val SETTINGS_SECTIONS: List<SettingsSection> = buildList {
+    add(SettingsSection(
         "TIMING",
         listOf(
             SettingsCategory(SETTINGS_SCHEDULE, MaterialSymbol.Schedule, "Schedule", "When Cron plans tonight's alarm"),
@@ -58,22 +59,30 @@ private val SETTINGS_SECTIONS: List<SettingsSection> = listOf(
             SettingsCategory(SETTINGS_COMMUTE, MaterialSymbol.DirectionsCar, "Commute", "How the planner estimates travel"),
             SettingsCategory(SETTINGS_CALENDAR, MaterialSymbol.CalendarMonth, "Calendar", "Which events the planner sees"),
         ),
-    ),
-    SettingsSection(
+    ))
+    add(SettingsSection(
         "ASSISTANT",
         listOf(
             SettingsCategory(SETTINGS_ASSISTANT, MaterialSymbol.AutoAwesome, "Assistant", "Instructions and token budget"),
             SettingsCategory(SETTINGS_RELIABILITY, MaterialSymbol.Shield, "Reliability", "Permissions that keep alarms on time"),
         ),
-    ),
-    SettingsSection(
+    ))
+    add(SettingsSection(
         "APP",
         listOf(
             SettingsCategory(SETTINGS_APP, MaterialSymbol.Settings, "Preferences", "Haptic feedback"),
             SettingsCategory(SETTINGS_ABOUT, MaterialSymbol.Info, "About", "Credits and attributions"),
         ),
-    ),
-)
+    ))
+    if (BuildConfig.DEBUG) {
+        add(SettingsSection(
+            "DEVELOPER",
+            listOf(
+                SettingsCategory(SETTINGS_DEVELOPER, MaterialSymbol.Build, "Developer", "Mock mode and debug tools"),
+            ),
+        ))
+    }
+}
 
 // Connected-card group: large radius on a group's outer corners, a barely-rounded seam where
 // same-group cards meet, a tight gap within a group. Between sections the header carries the gap.

--- a/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
@@ -79,15 +79,18 @@ class AiTurnWorker(
             return Result.failure()
         }
 
+        val useMock = ToolRegistryFactory.shouldUseMock(applicationContext)
+        Log.i(TAG, "Mock decision for $sessionId: useMock=$useMock")
+
         val apiKey = SecureKeyStore(applicationContext).anthropicApiKey
-        if (apiKey.isNullOrBlank()) {
+        if (!useMock && apiKey.isNullOrBlank()) {
             Log.w(TAG, "Anthropic API key not set — skipping AI turn for $sessionId")
             return Result.failure(workDataOf(KEY_REASON to REASON_NO_API_KEY))
         }
 
         val budget = BudgetStore(applicationContext)
         val limit = settingsRepository.currentDailyTokenLimit()
-        if (!budget.hasHeadroom(limit)) {
+        if (!useMock && !budget.hasHeadroom(limit)) {
             val used = budget.usedToday()
             Log.w(TAG, "Daily token budget exhausted ($used / $limit); skipping turn for $sessionId")
             return Result.failure(workDataOf(KEY_REASON to REASON_BUDGET, KEY_USED to used, KEY_LIMIT to limit))
@@ -102,9 +105,9 @@ class AiTurnWorker(
         val systemPrompt = if (isEveningPlan) SystemPrompts.EVENING_PLAN else SystemPrompts.OVERNIGHT_REPLAN
 
         val allowedRsvp = settingsRepository.allowedRsvpStatuses.first()
-        val mockTools = ToolRegistryFactory.mockOrNull(applicationContext)
-        val tools = mockTools ?: buildToolRegistry(session, apiKey, allowedRsvp)
-        val client = AnthropicClientFactory.create(applicationContext, apiKeyProvider = { apiKey })
+        val mockTools = ToolRegistryFactory.mockOrNull(useMock)
+        val tools = mockTools ?: buildToolRegistry(session, apiKey ?: "", allowedRsvp)
+        val client = AnthropicClientFactory.create(useMock, apiKeyProvider = { apiKey })
         // Anthropic requires max_tokens > thinking budget, so widen the ceiling on evening_plan turns.
         val thinking = if (isEveningPlan) ThinkingConfig(budgetTokens = THINKING_BUDGET) else null
         val maxTokens = if (isEveningPlan) THINKING_BUDGET + 2048 else 2048

--- a/app/src/release/java/fr/bsodium/cron/ai/AnthropicClientFactory.kt
+++ b/app/src/release/java/fr/bsodium/cron/ai/AnthropicClientFactory.kt
@@ -1,9 +1,8 @@
 package fr.bsodium.cron.ai
 
-import android.content.Context
-
 /** RELEASE variant — always returns the real [AnthropicClient]. */
 object AnthropicClientFactory {
-    fun create(context: Context, apiKeyProvider: () -> String?): AnthropicMessages =
+    @Suppress("UNUSED_PARAMETER")
+    fun create(useMock: Boolean, apiKeyProvider: () -> String?): AnthropicMessages =
         AnthropicClient(apiKeyProvider = apiKeyProvider)
 }

--- a/app/src/release/java/fr/bsodium/cron/ai/ToolRegistryFactory.kt
+++ b/app/src/release/java/fr/bsodium/cron/ai/ToolRegistryFactory.kt
@@ -5,5 +5,8 @@ import android.content.Context
 /** RELEASE variant — mock tools are never available. */
 object ToolRegistryFactory {
     @Suppress("UNUSED_PARAMETER")
-    fun mockOrNull(context: Context): ToolRegistry? = null
+    fun shouldUseMock(context: Context): Boolean = false
+
+    @Suppress("UNUSED_PARAMETER")
+    fun mockOrNull(useMock: Boolean): ToolRegistry? = null
 }

--- a/app/src/release/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
+++ b/app/src/release/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
@@ -1,0 +1,7 @@
+package fr.bsodium.cron.ui.screens.settings.categories
+
+import androidx.compose.runtime.Composable
+
+/** RELEASE stub — route is unreachable (landing page hides the category); stripped by R8. */
+@Composable
+fun DeveloperSettingsScreen(onBack: () -> Unit) = Unit


### PR DESCRIPTION
## Summary

- Adds a **Developer** settings category (debug builds only) with two controls:
  - **Mock API toggle** — capability gate (`MockApiPrefs.isEnabled`); when ON, the FAB shows a chevron for switching between mock and real runs
  - **Clear all runs** — deletes every session + cascaded events/messages, with confirmation dialog
- **Two-flag model:** `isEnabled` (capability, Developer settings) and `isMockActive` (mode, FAB chevron) are independent — selecting "Real run" from the chevron doesn't disable mock capability
- **Extended FAB:** The default (non-split) FAB now shows icon + text ("Re-plan"/"Stop"), matching the split FAB's main button layout
- `SessionDao.deleteAll()` + `SessionRepository.clearAll()` for the clear action
- Debug/release variant split: release stub compiles but is unreachable

Closes #111
Refs #106

## Test plan

- [x] Debug build: Developer section visible at bottom of settings landing
- [x] Mock toggle ON → chevron appears; mock toggle OFF → chevron hidden
- [x] Chevron "Real run" → chevron stays, Developer settings toggle stays ON
- [x] Clear all runs shows confirmation dialog, then empties the session list
- [x] Default FAB shows "Re-plan" with Update icon at 120×56dp

🤖 Generated with [Claude Code](https://claude.com/claude-code)