### PR TITLE
perf: defer heavy subtree on neighbor pager pages during swipe

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,9 +35,6 @@ fun gitVersionCode(): Int {
     }
 }
 
-// Fixed debug versionCode so switching branches never triggers a version-downgrade error on device.
-val isReleaseBuild = gradle.startParameter.taskNames.any { it.contains("Release", ignoreCase = true) }
-
 // Read local.properties for sensitive config (file is gitignored)
 val localProps = Properties().apply {
     rootProject.file("local.properties")
@@ -57,7 +54,7 @@ android {
         applicationId = "fr.bsodium.cron"
         minSdk = 26
         targetSdk = 36
-        versionCode = if (isReleaseBuild) gitVersionCode() else Int.MAX_VALUE
+        versionCode = gitVersionCode()
         versionName = gitVersionName()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,9 @@ fun gitVersionCode(): Int {
     }
 }
 
+// Fixed debug versionCode so switching branches never triggers a version-downgrade error on device.
+val isReleaseBuild = gradle.startParameter.taskNames.any { it.contains("Release", ignoreCase = true) }
+
 // Read local.properties for sensitive config (file is gitignored)
 val localProps = Properties().apply {
     rootProject.file("local.properties")
@@ -54,7 +57,7 @@ android {
         applicationId = "fr.bsodium.cron"
         minSdk = 26
         targetSdk = 36
-        versionCode = gitVersionCode()
+        versionCode = if (isReleaseBuild) gitVersionCode() else Int.MAX_VALUE
         versionName = gitVersionName()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
@@ -119,7 +119,7 @@ internal fun HomePlanContent(
     // getOrNull guards the transient post-replan frame where settledPage can lead the list (mirrors
     // pagerHeightPx below). Recomputes on settle, not per swipe frame, so the strip composes per selection.
     val selectedTurn by remember(iterations) {
-        derivedStateOf { iterations.getOrNull(pagerState.settledPage)?.turnIndex ?: iterations.last().turnIndex }
+        derivedStateOf { iterations.getOrNull(pagerState.targetPage)?.turnIndex ?: iterations.last().turnIndex }
     }
     // Continuous pager position (page + offset) handed to the tab strip as a PROVIDER: the strip reads it
     // inside snapshot flows / derived state, so a swipe frame never recomposes this screen or the strip.

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
@@ -82,14 +82,18 @@ internal fun ThreadPager(
         beyondViewportPageCount = 1,
     ) { page ->
         val iter = iterations.getOrNull(page) ?: return@HorizontalPager
-        // getOrPut once per turnIndex; the current page always has its state ready for the caller's pull
-        // connection. Wrapping in remember keeps the map write off the per-frame recomposition path.
-        val pull = remember(iter.turnIndex) { pullStates.getOrPut(iter.turnIndex) { PullState() } }
+        val pull = remember(iter.turnIndex) {
+            pullStates.getOrPut(iter.turnIndex) { PullState() }.also {
+                it.expanded = false
+                it.pastThreshold = false
+            }
+        }
         // Per-page staged render: defer heavy subtree (markdown parse + ExpandReveal SubcomposeLayout)
         // until the pager is idle. During a swipe, new neighbors compose cheap; the heavy content
         // composes only after the settle animation completes, off the gesture's critical path.
         var deferContent by remember(iter.turnIndex) { mutableStateOf(true) }
         LaunchedEffect(iter.turnIndex) {
+            pull.reveal.snapTo(0f)
             withFrameNanos {}
             snapshotFlow { pagerState.isScrollInProgress }
                 .filter { !it }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
@@ -68,16 +68,17 @@ internal fun ThreadPager(
         key = { iterations.getOrNull(it)?.turnIndex ?: it },
         verticalAlignment = Alignment.Top,
         // No pageSpacing: each page's own xl padding forms a symmetric 2·xl gutter between adjacent content.
-        // 0 (not 1): entry parses only the visible page's markdown instead of two — the neighbour composes
-        // when a swipe starts, where a tiny cost is fine. Halves the thread's first-frame cost.
-        beyondViewportPageCount = 0,
+        // Pre-compose the immediate neighbor so the swipe never pays a cold-compose cost. Safe because
+        // deferHeavy (HomeContent) gates the whole pager at entry, and per-page deferContent (below)
+        // prevents two simultaneous markdown parses on the same frame.
+        beyondViewportPageCount = 1,
     ) { page ->
         val iter = iterations.getOrNull(page) ?: return@HorizontalPager
         // getOrPut once per turnIndex; the current page always has its state ready for the caller's pull
         // connection. Wrapping in remember keeps the map write off the per-frame recomposition path.
         val pull = remember(iter.turnIndex) { pullStates.getOrPut(iter.turnIndex) { PullState() } }
-        // Per-page staged render: the neighbor composes cold when a swipe starts (beyondViewportPageCount = 0),
-        // so defer its heavy subtree (markdown parse + ExpandReveal SubcomposeLayout) by one frame.
+        // Per-page staged render: each page defers its heavy subtree (markdown parse + ExpandReveal
+        // SubcomposeLayout) by one frame, so two pages never parse markdown on the same frame at entry.
         var deferContent by remember(iter.turnIndex) { mutableStateOf(true) }
         LaunchedEffect(iter.turnIndex) { withFrameNanos {}; deferContent = false }
         val scope = rememberCoroutineScope()

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
@@ -102,7 +102,7 @@ internal fun ThreadPager(
                     if (!pagerState.isScrollInProgress) deferContent = false
                 }
         }
-        val immediateMarkdown = page == pagerState.settledPage || iter.thread.isStreaming
+        val immediateMarkdown = page == pagerState.settledPage || page == pagerState.targetPage || iter.thread.isStreaming
         val scope = rememberCoroutineScope()
         val isLatest = page == iterations.lastIndex
         // unbounded so the page measures its NATURAL height even when the pager is momentarily shorter

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -13,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -74,6 +76,10 @@ internal fun ThreadPager(
         // getOrPut once per turnIndex; the current page always has its state ready for the caller's pull
         // connection. Wrapping in remember keeps the map write off the per-frame recomposition path.
         val pull = remember(iter.turnIndex) { pullStates.getOrPut(iter.turnIndex) { PullState() } }
+        // Per-page staged render: the neighbor composes cold when a swipe starts (beyondViewportPageCount = 0),
+        // so defer its heavy subtree (markdown parse + ExpandReveal SubcomposeLayout) by one frame.
+        var deferContent by remember(iter.turnIndex) { mutableStateOf(true) }
+        LaunchedEffect(iter.turnIndex) { withFrameNanos {}; deferContent = false }
         val scope = rememberCoroutineScope()
         val isLatest = page == iterations.lastIndex
         // unbounded so the page measures its NATURAL height even when the pager is momentarily shorter
@@ -86,6 +92,7 @@ internal fun ThreadPager(
             AiThinkingThread(
                 thread = iter.thread,
                 modifier = Modifier.padding(horizontal = Spacing.xl), // re-inset after the pager's full-screen bleed
+                deferContent = deferContent,
                 expanded = pull.expanded,
                 onExpandedChange = { open ->
                     scope.launch {

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
@@ -98,6 +98,7 @@ internal fun ThreadPager(
                     if (!pagerState.isScrollInProgress) deferContent = false
                 }
         }
+        val immediateMarkdown = page == pagerState.settledPage || iter.thread.isStreaming
         val scope = rememberCoroutineScope()
         val isLatest = page == iterations.lastIndex
         // unbounded so the page measures its NATURAL height even when the pager is momentarily shorter
@@ -111,6 +112,7 @@ internal fun ThreadPager(
                 thread = iter.thread,
                 modifier = Modifier.padding(horizontal = Spacing.xl), // re-inset after the pager's full-screen bleed
                 deferContent = deferContent,
+                immediateMarkdown = immediateMarkdown,
                 expanded = pull.expanded,
                 onExpandedChange = { open ->
                     scope.launch {

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/ThreadPager.kt
@@ -13,8 +13,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filter
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,7 +26,12 @@ import fr.bsodium.cron.ui.components.bleedHorizontally
 import fr.bsodium.cron.ui.screens.home.components.AiThinkingThread
 import fr.bsodium.cron.ui.screens.home.components.ThreadRole
 import fr.bsodium.cron.ui.theme.Spacing
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+
+// isScrollInProgress flips false for a frame between drag-release and fling start (see
+// AlarmCollapseEffects.kt:28). Wait this out before treating the pager as settled.
+private const val SETTLE_DEBOUNCE_MS = 50L
 
 /** Per-iteration pull-to-expand state for the thinking disclosure — one instance per `turnIndex`, so
  *  each pager page keeps its own reveal/expanded state and the pull gesture drives only the settled page. */
@@ -77,10 +85,19 @@ internal fun ThreadPager(
         // getOrPut once per turnIndex; the current page always has its state ready for the caller's pull
         // connection. Wrapping in remember keeps the map write off the per-frame recomposition path.
         val pull = remember(iter.turnIndex) { pullStates.getOrPut(iter.turnIndex) { PullState() } }
-        // Per-page staged render: each page defers its heavy subtree (markdown parse + ExpandReveal
-        // SubcomposeLayout) by one frame, so two pages never parse markdown on the same frame at entry.
+        // Per-page staged render: defer heavy subtree (markdown parse + ExpandReveal SubcomposeLayout)
+        // until the pager is idle. During a swipe, new neighbors compose cheap; the heavy content
+        // composes only after the settle animation completes, off the gesture's critical path.
         var deferContent by remember(iter.turnIndex) { mutableStateOf(true) }
-        LaunchedEffect(iter.turnIndex) { withFrameNanos {}; deferContent = false }
+        LaunchedEffect(iter.turnIndex) {
+            withFrameNanos {}
+            snapshotFlow { pagerState.isScrollInProgress }
+                .filter { !it }
+                .collectLatest {
+                    delay(SETTLE_DEBOUNCE_MS)
+                    if (!pagerState.isScrollInProgress) deferContent = false
+                }
+        }
         val scope = rememberCoroutineScope()
         val isLatest = page == iterations.lastIndex
         // unbounded so the page measures its NATURAL height even when the pager is momentarily shorter

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -89,6 +89,7 @@ fun AiThinkingThread(
     thread: AiThreadUi,
     modifier: Modifier = Modifier,
     deferContent: Boolean = false,
+    immediateMarkdown: Boolean = true,
     // Controlled/uncontrolled: when [expanded] is null the disclosure manages its own state (previews,
     // tests); HomeScreen hoists it so the pull gesture can drive it. [expandPx] peeks the timeline open
     // by an absolute pixel height (1:1 with the drag); [onFullHeight] reports its measured full height.
@@ -137,6 +138,7 @@ fun AiThinkingThread(
             inProgress = inProgress,
             hasProcess = thread.process.isNotEmpty(),
             deferContent = deferContent,
+            immediateMarkdown = immediateMarkdown,
         )
         if (role is ThreadRole.Latest) {
             val phase = when {
@@ -202,8 +204,19 @@ internal fun ThinkingDisclosure(
         ) {
             // The tools called so far + a trailing pending loader disc; with no tools, a fallback assistant
             // disc (inside ToolStack) so the header always leads with an icon, never floating text.
-            val tools = process.filterIsInstance<ProcessItem.Tool>()
-            ToolStack(tools, pending = pending)
+            if (!deferContent) {
+                val tools = process.filterIsInstance<ProcessItem.Tool>()
+                ToolStack(tools, pending = pending)
+            } else {
+                ToolDisc {
+                    Symbol(
+                        symbol = MaterialSymbol.AutoAwesome,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        size = TOOL_DISC_ICON,
+                    )
+                }
+            }
             val headerColor = MaterialTheme.colorScheme.onSurfaceVariant
             if (!inProgress && isMocked) {
                 val verb = "Faked thinking"
@@ -406,6 +419,7 @@ private fun AnswerArea(
     inProgress: Boolean,
     hasProcess: Boolean,
     deferContent: Boolean = false,
+    immediateMarkdown: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     var lastResponse by remember { mutableStateOf("") }
@@ -426,7 +440,7 @@ private fun AnswerArea(
                         color = MaterialTheme.colorScheme.onSurface,
                     )
                 } else {
-                    ResponseBody(text, immediate = inProgress)
+                    ResponseBody(text, immediate = immediateMarkdown)
                 }
                 Spacer(Modifier.height(Spacing.sm))
             }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -202,21 +202,8 @@ internal fun ThinkingDisclosure(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         ) {
-            // The tools called so far + a trailing pending loader disc; with no tools, a fallback assistant
-            // disc (inside ToolStack) so the header always leads with an icon, never floating text.
-            if (!deferContent) {
-                val tools = process.filterIsInstance<ProcessItem.Tool>()
-                ToolStack(tools, pending = pending)
-            } else {
-                ToolDisc {
-                    Symbol(
-                        symbol = MaterialSymbol.AutoAwesome,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        size = TOOL_DISC_ICON,
-                    )
-                }
-            }
+            val tools = process.filterIsInstance<ProcessItem.Tool>()
+            ToolStack(tools, pending = pending, animated = !deferContent)
             val headerColor = MaterialTheme.colorScheme.onSurfaceVariant
             if (!inProgress && isMocked) {
                 val verb = "Faked thinking"
@@ -330,17 +317,19 @@ private val TOOL_DISC_LOADER = 18.dp
  * discs overlap (negative spacing) the later one occludes the earlier with a clean gap. While [pending], a
  * trailing loader disc leads the stack; as real tools land they fade in and the loader slides right
  * ([animateBounds] inside a [LookaheadScope] animates each disc's position/size).
+ *
+ * When [animated] is `false` the layout is identical but skips [LookaheadScope]/[animateBounds], avoiding
+ * the double-measure cost on deferred (off-screen) pages while keeping the correct disc count and width.
  */
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-private fun ToolStack(tools: List<ProcessItem.Tool>, pending: Boolean = false) {
-    // Tools present when the stack first composes don't individually animate (its appearance is enough);
-    // any that arrive later fade in.
+private fun ToolStack(tools: List<ProcessItem.Tool>, pending: Boolean = false, animated: Boolean = true) {
     val seen = remember { tools.size }
-    LookaheadScope {
+    @Composable
+    fun Discs(boundsModifier: Modifier = Modifier) {
         Row(horizontalArrangement = Arrangement.spacedBy(-TOOL_STACK_OVERLAP)) {
             tools.forEachIndexed { index, tool ->
-                ToolDisc(modifier = Modifier.animateBounds(this@LookaheadScope), isNew = index >= seen) {
+                ToolDisc(modifier = boundsModifier, isNew = animated && index >= seen) {
                     Symbol(
                         symbol = toolSymbol(tool.name),
                         contentDescription = null,
@@ -350,16 +339,14 @@ private fun ToolStack(tools: List<ProcessItem.Tool>, pending: Boolean = false) {
                 }
             }
             if (pending) {
-                ToolDisc(modifier = Modifier.animateBounds(this@LookaheadScope)) {
+                ToolDisc(modifier = boundsModifier) {
                     LoadingIndicator(
                         modifier = Modifier.size(TOOL_DISC_LOADER),
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             } else if (tools.isEmpty()) {
-                // No tools and not pending (a no-tool turn): a fallback assistant icon so the header always
-                // leads with a disc instead of floating text.
-                ToolDisc(modifier = Modifier.animateBounds(this@LookaheadScope)) {
+                ToolDisc(modifier = boundsModifier) {
                     Symbol(
                         symbol = MaterialSymbol.AutoAwesome,
                         contentDescription = null,
@@ -369,6 +356,11 @@ private fun ToolStack(tools: List<ProcessItem.Tool>, pending: Boolean = false) {
                 }
             }
         }
+    }
+    if (animated) {
+        LookaheadScope { Discs(Modifier.animateBounds(this@LookaheadScope)) }
+    } else {
+        Discs()
     }
 }
 

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -88,6 +88,7 @@ sealed interface ThreadRole {
 fun AiThinkingThread(
     thread: AiThreadUi,
     modifier: Modifier = Modifier,
+    deferContent: Boolean = false,
     // Controlled/uncontrolled: when [expanded] is null the disclosure manages its own state (previews,
     // tests); HomeScreen hoists it so the pull gesture can drive it. [expandPx] peeks the timeline open
     // by an absolute pixel height (1:1 with the drag); [onFullHeight] reports its measured full height.
@@ -124,6 +125,7 @@ fun AiThinkingThread(
             expandPx = expandPx,
             onFullHeight = onFullHeight,
             expansionFraction = expansionFraction,
+            deferContent = deferContent,
         )
         // Alpha-only in AND out: any size-changing transition (e.g. shrinkVertically) makes
         // AnimatedVisibility clipToBounds the block, which clips the streaming markdown to its
@@ -134,6 +136,7 @@ fun AiThinkingThread(
             response = thread.response,
             inProgress = inProgress,
             hasProcess = thread.process.isNotEmpty(),
+            deferContent = deferContent,
         )
         if (role is ThreadRole.Latest) {
             val phase = when {
@@ -179,6 +182,7 @@ internal fun ThinkingDisclosure(
     expandPx: () -> Float = { 0f },
     onFullHeight: (Int) -> Unit = {},
     expansionFraction: () -> Float = { 0f },
+    deferContent: Boolean = false,
 ) {
     val canExpand = process.isNotEmpty()
     // Chevron pivot from the live reveal, resolved lazily so the drag only invalidates the draw layer.
@@ -248,7 +252,7 @@ internal fun ThinkingDisclosure(
         val revealing by remember(expanded, inProgress) {
             derivedStateOf { expanded || expandPx() > 0f || !inProgress }
         }
-        if (canExpand && revealing) {
+        if (canExpand && revealing && !deferContent) {
             ExpandReveal(
                 targetPx = { if (expanded) Float.MAX_VALUE else expandPx() },
                 peeking = !expanded,
@@ -400,6 +404,7 @@ private fun AnswerArea(
     response: String?,
     inProgress: Boolean,
     hasProcess: Boolean,
+    deferContent: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     var lastResponse by remember { mutableStateOf("") }
@@ -412,9 +417,16 @@ private fun AnswerArea(
         AnimatedVisibility(visible = hasAnswer, enter = fadeIn(), exit = fadeOut()) {
             Column {
                 Spacer(Modifier.height(Spacing.sm))
-                ResponseBody(response?.takeIf { it.isNotBlank() } ?: lastResponse)
-                // Descender clearance: the serif body's last line extends below its measured line box, so
-                // without this the slot/pager (sized to the measured height) clips it.
+                val text = response?.takeIf { it.isNotBlank() } ?: lastResponse
+                if (deferContent) {
+                    Text(
+                        text = text,
+                        style = CronTypography.bodySerif,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                } else {
+                    ResponseBody(text)
+                }
                 Spacer(Modifier.height(Spacing.sm))
             }
         }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -384,11 +384,12 @@ private fun ToolDisc(modifier: Modifier = Modifier, isNew: Boolean = false, cont
 }
 
 @Composable
-private fun ResponseBody(text: String) {
+private fun ResponseBody(text: String, immediate: Boolean = true) {
     MarkdownBlock(
         text = text,
         bodyStyle = CronTypography.bodySerif.copy(color = MaterialTheme.colorScheme.onSurface),
         serif = true,
+        immediate = immediate,
     )
 }
 
@@ -425,7 +426,7 @@ private fun AnswerArea(
                         color = MaterialTheme.colorScheme.onSurface,
                     )
                 } else {
-                    ResponseBody(text)
+                    ResponseBody(text, immediate = inProgress)
                 }
                 Spacer(Modifier.height(Spacing.sm))
             }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -433,15 +433,7 @@ private fun AnswerArea(
             Column {
                 Spacer(Modifier.height(Spacing.sm))
                 val text = response?.takeIf { it.isNotBlank() } ?: lastResponse
-                if (deferContent) {
-                    Text(
-                        text = text,
-                        style = CronTypography.bodySerif,
-                        color = MaterialTheme.colorScheme.onSurface,
-                    )
-                } else {
-                    ResponseBody(text, immediate = immediateMarkdown)
-                }
+                ResponseBody(text, immediate = immediateMarkdown)
                 Spacer(Modifier.height(Spacing.sm))
             }
         }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ReplanHistoryBar.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ReplanHistoryBar.kt
@@ -242,20 +242,9 @@ private fun ScrollableTabs(
     val padPx = with(LocalDensity.current) { Spacing.md.roundToPx() }
     // Expressive spatial spring so the tap-to-centre scroll glides rather than snapping.
     val scrollSpec = MaterialTheme.motionScheme.defaultSpatialSpec<Float>()
-    // Derived, not a raw read: position() changes every swipe frame, but the ROUNDED nearest tab only
-    // changes at midpoint crossings — so this recomposes the strip at crossings, never per frame.
-    val activeTurn by remember(iterations) {
-        derivedStateOf { iterations[position().roundToInt().coerceIn(0, iterations.lastIndex)].turnIndex }
-    }
-
-    // Centre the active tab (keyed on the rounded position, so it tracks the swipe at each boundary).
-    LaunchedEffect(activeTurn, viewportPx) {
+    LaunchedEffect(selectedTurn, viewportPx) {
         if (viewportPx <= 0) return@LaunchedEffect
-        // Await the (possibly just-added) tab's measured span. A freshly-added tab widens the content via
-        // animateContentSize, so the scroll range (maxValue) ramps up over several frames; clamping
-        // centreTarget to a mid-ramp maxValue leaves the new tab clipped. Wait until the range is wide
-        // enough to reach the desired (unclamped) centre — capped so a full strip can't hang us.
-        val span = snapshotFlow { spans[activeTurn] }.filterNotNull().first()
+        val span = snapshotFlow { spans[selectedTurn] }.filterNotNull().first()
         val wanted = (span.first + span.last) / 2 + padPx - viewportPx / 2
         var frames = 0
         while (scrollState.maxValue < wanted && frames < MAX_SETTLE_FRAMES) {

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ResponseMarkdown.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ResponseMarkdown.kt
@@ -47,6 +47,7 @@ internal fun MarkdownBlock(
     bodyStyle: TextStyle,
     serif: Boolean,
     modifier: Modifier = Modifier,
+    immediate: Boolean = true,
 ) {
     val onSurface = MaterialTheme.colorScheme.onSurface
     val onSurfaceVariant = MaterialTheme.colorScheme.onSurfaceVariant
@@ -89,7 +90,7 @@ internal fun MarkdownBlock(
     // retainState keeps the last successful render on screen while the next parse runs off-thread, and
     // immediate parses the first frame synchronously — together they kill the blank-flash the library
     // otherwise shows on every content change (per streamed token) and on first compose (expand/load).
-    val markdownState = rememberMarkdownState(content = text, retainState = true, immediate = true)
+    val markdownState = rememberMarkdownState(content = text, retainState = true, immediate = immediate)
     Markdown(
         markdownState = markdownState,
         colors = colors,


### PR DESCRIPTION
## Summary

- **Pager swipe performance**: pre-compose the immediate neighbor page (`beyondViewportPageCount = 1`) and defer each page's heavy subtree (markdown parse + `ExpandReveal` SubcomposeLayout + `LookaheadScope` animation) until the pager settles, with a 50ms debounce across the drag→fling gap. During a swipe, neighbors compose cheap placeholders; heavy content appears only after the settle animation completes.
- **Immediate markdown for visible pages**: the settled page and the target page parse markdown synchronously (`immediate = true`) to avoid blank-flash; off-screen neighbors parse off-thread (`immediate = false`)
- **Tab sync on `targetPage`**: `selectedTurn` and `ReplanHistoryBar` scroll now derive from `targetPage` instead of `settledPage`, so tab highlighting starts in parallel with the swipe/click animation
- **`ToolStack` animated flag**: deferred pages render real tool discs without `LookaheadScope`/`animateBounds`, avoiding the double-measure cost while keeping the correct layout. Expansion state resets when a page re-enters composition.

Refs #14

## Test plan

- [x] Navigate to a session with 2+ plan iterations
- [x] Swipe between tabs — verify the gesture frame no longer stutters
- [x] Verify the settled page renders markdown immediately (no blank gap)
- [x] Click a non-adjacent tab — verify highlighting and strip scroll start immediately
- [x] Verify expand/collapse of the thinking thread still works correctly
- [x] Verify streaming responses render without blank flashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)