### PR TITLE
feat: default to standard NavigationBar, make compact pill opt-in

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/MainActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/MainActivity.kt
@@ -33,7 +33,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalConfiguration
 import fr.bsodium.cron.ui.screens.settings.LocalSettingsListState
 import fr.bsodium.cron.ui.screens.settings.LocalSettingsTopAppBarState
 import androidx.compose.ui.Modifier
@@ -68,7 +67,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
-private const val COMPACT_NAV_MIN_WIDTH_DP = 360
 private const val FORWARD_MS = 350
 private const val TAB_OUT_MS = 90
 private const val TAB_IN_MS = 160
@@ -163,8 +161,7 @@ class MainActivity : ComponentActivity() {
                 val fabRegistry = remember { FabRegistry() }
                 val fabChevron = rememberFabChevron()
                 val compactNavPref by settings.compactNavEnabled.collectAsState(initial = false)
-                val screenWidthDp = LocalConfiguration.current.screenWidthDp
-                val useCompactNav = compactNavPref && screenWidthDp >= COMPACT_NAV_MIN_WIDTH_DP
+                val useCompactNav = compactNavPref
                 val settingsListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
                 val settingsTopAppBarState = rememberSaveable(saver = TopAppBarState.Saver) { TopAppBarState(0f, 0f, 1f) }
                 val navigate: (String) -> Unit = { route ->

--- a/app/src/main/java/fr/bsodium/cron/MainActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/MainActivity.kt
@@ -26,11 +26,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalConfiguration
 import fr.bsodium.cron.ui.screens.settings.LocalSettingsListState
 import fr.bsodium.cron.ui.screens.settings.LocalSettingsTopAppBarState
 import androidx.compose.ui.Modifier
@@ -44,8 +46,11 @@ import androidx.navigation.compose.rememberNavController
 import fr.bsodium.cron.settings.SecureKeyStore
 import fr.bsodium.cron.settings.SettingsRepository
 import fr.bsodium.cron.ui.components.CronFloatingNav
+import fr.bsodium.cron.ui.components.CronNavigationBar
 import fr.bsodium.cron.ui.components.EdgeFades
 import fr.bsodium.cron.ui.components.FabAction
+import fr.bsodium.cron.ui.components.PrimaryActionFab
+import fr.bsodium.cron.ui.components.SplitActionFab
 import fr.bsodium.cron.ui.components.rememberFabChevron
 import fr.bsodium.cron.ui.screens.history.HistoryScreen
 import fr.bsodium.cron.ui.screens.history.HistoryViewModel
@@ -61,6 +66,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
+private const val COMPACT_NAV_MIN_WIDTH_DP = 360
 private const val FORWARD_MS = 350
 private const val TAB_OUT_MS = 90
 private const val TAB_IN_MS = 160
@@ -154,8 +160,21 @@ class MainActivity : ComponentActivity() {
                     currentRoute?.startsWith("settings") == true
                 val fabRegistry = remember { FabRegistry() }
                 val fabChevron = rememberFabChevron()
+                val compactNavPref by settings.compactNavEnabled.collectAsState(initial = false)
+                val screenWidthDp = LocalConfiguration.current.screenWidthDp
+                val useCompactNav = compactNavPref && screenWidthDp >= COMPACT_NAV_MIN_WIDTH_DP
                 val settingsListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
                 val settingsTopAppBarState = rememberSaveable(saver = TopAppBarState.Saver) { TopAppBarState(0f, 0f, 1f) }
+                val navigate: (String) -> Unit = { route ->
+                    navController.navigate(route) {
+                        popUpTo(ROUTE_HOME) {
+                            saveState = true
+                            inclusive = false
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                }
 
                 CompositionLocalProvider(
                     LocalSettingsListState provides settingsListState,
@@ -170,21 +189,36 @@ class MainActivity : ComponentActivity() {
                                     fadeIn(MaterialTheme.motionScheme.defaultEffectsSpec()),
                                 exit = fadeOut(MaterialTheme.motionScheme.defaultEffectsSpec()),
                             ) {
-                                CronFloatingNav(
-                                    currentRoute = currentRoute,
-                                    onNavigate = { route ->
-                                        navController.navigate(route) {
-                                            popUpTo(ROUTE_HOME) {
-                                                saveState = true
-                                                inclusive = false
-                                            }
-                                            launchSingleTop = true
-                                            restoreState = true
-                                        }
-                                    },
-                                    fabAction = fabRegistry.action,
-                                    fabChevron = fabChevron,
-                                )
+                                if (useCompactNav) {
+                                    CronFloatingNav(
+                                        currentRoute = currentRoute,
+                                        onNavigate = navigate,
+                                        fabAction = fabRegistry.action,
+                                        fabChevron = fabChevron,
+                                    )
+                                } else {
+                                    CronNavigationBar(
+                                        currentRoute = currentRoute,
+                                        onNavigate = navigate,
+                                    )
+                                }
+                            }
+                        },
+                        floatingActionButton = {
+                            if (!useCompactNav) {
+                                val action = fabRegistry.action
+                                var lastShown by remember { mutableStateOf(action) }
+                                if (action != null) lastShown = action
+                                AnimatedVisibility(
+                                    visible = action != null && showBottomBar,
+                                    enter = scaleIn(MaterialTheme.motionScheme.fastSpatialSpec()) +
+                                        fadeIn(MaterialTheme.motionScheme.fastEffectsSpec()),
+                                    exit = scaleOut(MaterialTheme.motionScheme.fastSpatialSpec()) +
+                                        fadeOut(MaterialTheme.motionScheme.fastEffectsSpec()),
+                                ) {
+                                    if (fabChevron != null) SplitActionFab(lastShown, fabChevron)
+                                    else PrimaryActionFab(lastShown)
+                                }
                             }
                         },
                     ) { _ ->

--- a/app/src/main/java/fr/bsodium/cron/MainActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.animation.core.EaseInOutCubic
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
@@ -36,6 +37,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import fr.bsodium.cron.ui.screens.settings.LocalSettingsListState
 import fr.bsodium.cron.ui.screens.settings.LocalSettingsTopAppBarState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
@@ -209,13 +211,17 @@ class MainActivity : ComponentActivity() {
                                 val action = fabRegistry.action
                                 var lastShown by remember { mutableStateOf(action) }
                                 if (action != null) lastShown = action
-                                AnimatedVisibility(
-                                    visible = action != null && showBottomBar,
-                                    enter = fadeIn(MaterialTheme.motionScheme.fastEffectsSpec()),
-                                    exit = fadeOut(MaterialTheme.motionScheme.fastEffectsSpec()),
-                                ) {
-                                    if (fabChevron != null) SplitActionFab(lastShown, fabChevron)
-                                    else PrimaryActionFab(lastShown)
+                                val fabVisible = action != null && showBottomBar
+                                val fabAlpha by animateFloatAsState(
+                                    targetValue = if (fabVisible) 1f else 0f,
+                                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                                    label = "fab-alpha",
+                                )
+                                if (lastShown != null && (fabVisible || fabAlpha > 0f)) {
+                                    Box(modifier = Modifier.graphicsLayer { alpha = fabAlpha }) {
+                                        if (fabChevron != null) SplitActionFab(lastShown, fabChevron)
+                                        else PrimaryActionFab(lastShown)
+                                    }
                                 }
                             }
                         },

--- a/app/src/main/java/fr/bsodium/cron/MainActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/MainActivity.kt
@@ -211,7 +211,7 @@ class MainActivity : ComponentActivity() {
                                 val action = fabRegistry.action
                                 var lastShown by remember { mutableStateOf(action) }
                                 if (action != null) lastShown = action
-                                val fabVisible = action != null && showBottomBar
+                                val fabVisible = currentRoute == ROUTE_HOME && action != null
                                 val fabAlpha by animateFloatAsState(
                                     targetValue = if (fabVisible) 1f else 0f,
                                     animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),

--- a/app/src/main/java/fr/bsodium/cron/MainActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/MainActivity.kt
@@ -211,10 +211,8 @@ class MainActivity : ComponentActivity() {
                                 if (action != null) lastShown = action
                                 AnimatedVisibility(
                                     visible = action != null && showBottomBar,
-                                    enter = scaleIn(MaterialTheme.motionScheme.fastSpatialSpec()) +
-                                        fadeIn(MaterialTheme.motionScheme.fastEffectsSpec()),
-                                    exit = scaleOut(MaterialTheme.motionScheme.fastSpatialSpec()) +
-                                        fadeOut(MaterialTheme.motionScheme.fastEffectsSpec()),
+                                    enter = fadeIn(MaterialTheme.motionScheme.fastEffectsSpec()),
+                                    exit = fadeOut(MaterialTheme.motionScheme.fastEffectsSpec()),
                                 ) {
                                     if (fabChevron != null) SplitActionFab(lastShown, fabChevron)
                                     else PrimaryActionFab(lastShown)

--- a/app/src/main/java/fr/bsodium/cron/settings/SettingsRepository.kt
+++ b/app/src/main/java/fr/bsodium/cron/settings/SettingsRepository.kt
@@ -102,6 +102,10 @@ class SettingsRepository(private val context: Context) {
         prefs[HAPTICS_ENABLED] ?: true
     }
 
+    val compactNavEnabled: Flow<Boolean> = context.dataStore.data.map { prefs ->
+        prefs[COMPACT_NAV_ENABLED] ?: false
+    }
+
     /** Whether the app auto-plans and arms alarms each night. Off cancels every armed alarm. Defaults on. */
     val autoAlarmsEnabled: Flow<Boolean> = context.dataStore.data.map { prefs ->
         prefs[AUTO_ALARMS_ENABLED] ?: true
@@ -175,6 +179,9 @@ class SettingsRepository(private val context: Context) {
     suspend fun setHapticsEnabled(enabled: Boolean) =
         context.dataStore.edit { it[HAPTICS_ENABLED] = enabled }
 
+    suspend fun setCompactNavEnabled(enabled: Boolean) =
+        context.dataStore.edit { it[COMPACT_NAV_ENABLED] = enabled }
+
     /** Plain edit: scheduling is (re)armed/cancelled by the caller, not by the "replan?" pill. */
     suspend fun setAutoAlarmsEnabled(enabled: Boolean) =
         context.dataStore.edit { it[AUTO_ALARMS_ENABLED] = enabled }
@@ -217,6 +224,7 @@ class SettingsRepository(private val context: Context) {
         val HOME_LNG = stringPreferencesKey("home_address_lng")
         val ONBOARDING_COMPLETE = booleanPreferencesKey("onboarding_complete")
         val HAPTICS_ENABLED = booleanPreferencesKey("haptics_enabled")
+        val COMPACT_NAV_ENABLED = booleanPreferencesKey("compact_nav_enabled")
         val AUTO_ALARMS_ENABLED = booleanPreferencesKey("auto_alarms_enabled")
         val DISPLAY_NAME = stringPreferencesKey("display_name")
         val USER_INSTRUCTIONS = stringPreferencesKey("user_instructions")

--- a/app/src/main/java/fr/bsodium/cron/ui/components/CronBottomBar.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/CronBottomBar.kt
@@ -187,7 +187,7 @@ class FabChevronSlot(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun SplitActionFab(action: FabAction?, fabChevron: FabChevronSlot) {
+internal fun SplitActionFab(action: FabAction?, fabChevron: FabChevronSlot) {
     if (action == null) return
     val haptics = rememberCronHaptics()
     val iconAlphaSpec = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
@@ -311,7 +311,7 @@ private fun SplitActionFab(action: FabAction?, fabChevron: FabChevronSlot) {
 }
 
 @Composable
-private fun PrimaryActionFab(action: FabAction?) {
+internal fun PrimaryActionFab(action: FabAction?) {
     if (action == null) return
     val working = action.working
     val haptics = rememberCronHaptics()

--- a/app/src/main/java/fr/bsodium/cron/ui/components/CronNavigationBar.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/CronNavigationBar.kt
@@ -1,13 +1,22 @@
 package fr.bsodium.cron.ui.components
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import fr.bsodium.cron.ROUTE_HISTORY
@@ -16,6 +25,8 @@ import fr.bsodium.cron.ui.screens.settings.SETTINGS_ROOT
 import fr.bsodium.cron.ui.theme.CronColors
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.MaterialSymbol
+import fr.bsodium.cron.ui.theme.Radius
+import fr.bsodium.cron.ui.theme.Spacing
 import fr.bsodium.cron.ui.theme.Symbol
 
 private data class NavDestination(
@@ -48,6 +59,12 @@ fun CronNavigationBar(
                 animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
                 label = "nav-fill-${dest.route}",
             )
+            val indicatorColor by animateColorAsState(
+                targetValue = if (selected) MaterialTheme.colorScheme.secondaryContainer
+                    else Color.Transparent,
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "nav-indicator-${dest.route}",
+            )
             NavigationBarItem(
                 selected = selected,
                 onClick = {
@@ -56,7 +73,20 @@ fun CronNavigationBar(
                         onNavigate(dest.route)
                     }
                 },
-                icon = { Symbol(symbol = dest.symbol, contentDescription = null, fill = fill) },
+                colors = NavigationBarItemDefaults.colors(
+                    indicatorColor = Color.Transparent,
+                ),
+                icon = {
+                    Box(
+                        modifier = Modifier
+                            .clip(Radius.full)
+                            .background(indicatorColor)
+                            .padding(horizontal = Spacing.xl, vertical = Spacing.xs),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Symbol(symbol = dest.symbol, contentDescription = null, fill = fill)
+                    }
+                },
                 label = { Text(dest.label) },
             )
         }

--- a/app/src/main/java/fr/bsodium/cron/ui/components/CronNavigationBar.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/CronNavigationBar.kt
@@ -1,0 +1,73 @@
+package fr.bsodium.cron.ui.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import fr.bsodium.cron.ROUTE_HISTORY
+import fr.bsodium.cron.ROUTE_HOME
+import fr.bsodium.cron.ui.screens.settings.SETTINGS_ROOT
+import fr.bsodium.cron.ui.theme.CronColors
+import fr.bsodium.cron.ui.theme.CronTheme
+import fr.bsodium.cron.ui.theme.MaterialSymbol
+import fr.bsodium.cron.ui.theme.Symbol
+
+private data class NavDestination(
+    val route: String,
+    val symbol: MaterialSymbol,
+    val label: String,
+)
+
+private val DESTINATIONS = listOf(
+    NavDestination(ROUTE_HOME, MaterialSymbol.Alarm, "Home"),
+    NavDestination(ROUTE_HISTORY, MaterialSymbol.History, "History"),
+    NavDestination(SETTINGS_ROOT, MaterialSymbol.Settings, "Settings"),
+)
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun CronNavigationBar(
+    currentRoute: String?,
+    onNavigate: (String) -> Unit,
+) {
+    val haptics = rememberCronHaptics()
+    NavigationBar(
+        containerColor = CronColors.elementSurface,
+        tonalElevation = 0.dp,
+    ) {
+        for (dest in DESTINATIONS) {
+            val selected = currentRoute == dest.route
+            val fill by animateFloatAsState(
+                targetValue = if (selected) 1f else 0f,
+                animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+                label = "nav-fill-${dest.route}",
+            )
+            NavigationBarItem(
+                selected = selected,
+                onClick = {
+                    if (!selected) {
+                        haptics.contextClick()
+                        onNavigate(dest.route)
+                    }
+                },
+                icon = { Symbol(symbol = dest.symbol, contentDescription = null, fill = fill) },
+                label = { Text(dest.label) },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Preview(showBackground = true)
+@Composable
+private fun CronNavigationBarPreview() {
+    CronTheme {
+        CronNavigationBar(currentRoute = ROUTE_HOME, onNavigate = {})
+    }
+}

--- a/app/src/main/java/fr/bsodium/cron/ui/components/CronNavigationBar.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/CronNavigationBar.kt
@@ -1,22 +1,13 @@
 package fr.bsodium.cron.ui.components
 
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import fr.bsodium.cron.ROUTE_HISTORY
@@ -25,8 +16,6 @@ import fr.bsodium.cron.ui.screens.settings.SETTINGS_ROOT
 import fr.bsodium.cron.ui.theme.CronColors
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.MaterialSymbol
-import fr.bsodium.cron.ui.theme.Radius
-import fr.bsodium.cron.ui.theme.Spacing
 import fr.bsodium.cron.ui.theme.Symbol
 
 private data class NavDestination(
@@ -59,12 +48,6 @@ fun CronNavigationBar(
                 animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
                 label = "nav-fill-${dest.route}",
             )
-            val indicatorColor by animateColorAsState(
-                targetValue = if (selected) MaterialTheme.colorScheme.secondaryContainer
-                    else Color.Transparent,
-                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                label = "nav-indicator-${dest.route}",
-            )
             NavigationBarItem(
                 selected = selected,
                 onClick = {
@@ -73,20 +56,7 @@ fun CronNavigationBar(
                         onNavigate(dest.route)
                     }
                 },
-                colors = NavigationBarItemDefaults.colors(
-                    indicatorColor = Color.Transparent,
-                ),
-                icon = {
-                    Box(
-                        modifier = Modifier
-                            .clip(Radius.full)
-                            .background(indicatorColor)
-                            .padding(horizontal = Spacing.xl, vertical = Spacing.xs),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Symbol(symbol = dest.symbol, contentDescription = null, fill = fill)
-                    }
-                },
+                icon = { Symbol(symbol = dest.symbol, contentDescription = null, fill = fill) },
                 label = { Text(dest.label) },
             )
         }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsNavGraph.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsNavGraph.kt
@@ -169,7 +169,9 @@ fun NavGraphBuilder.settingsGraph(
             val state by vm.uiState.collectAsState()
             AppSettingsScreen(
                 hapticsEnabled = state.hapticsEnabled,
+                compactNavEnabled = state.compactNavEnabled,
                 onHapticsEnabled = vm::setHapticsEnabled,
+                onCompactNavEnabled = vm::setCompactNavEnabled,
                 onBack = { navController.popBackStack() },
             )
         }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsViewModel.kt
@@ -33,6 +33,7 @@ data class SettingsUiState(
     val dailyTokenLimit: Int = BudgetStore.DEFAULT_DAILY_TOKEN_LIMIT,
     val tokensUsedToday: Int = 0,
     val hapticsEnabled: Boolean = true,
+    val compactNavEnabled: Boolean = false,
 )
 
 class SettingsViewModel @JvmOverloads constructor(
@@ -81,6 +82,8 @@ class SettingsViewModel @JvmOverloads constructor(
         state.copy(tokensUsedToday = used)
     }.combine(repo.hapticsEnabled) { state, haptics ->
         state.copy(hapticsEnabled = haptics)
+    }.combine(repo.compactNavEnabled) { state, compact ->
+        state.copy(compactNavEnabled = compact)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState())
 
     fun setEveningTrigger(time: LocalTime) {
@@ -132,6 +135,10 @@ class SettingsViewModel @JvmOverloads constructor(
 
     fun setHapticsEnabled(enabled: Boolean) {
         viewModelScope.launch { repo.setHapticsEnabled(enabled) }
+    }
+
+    fun setCompactNavEnabled(enabled: Boolean) {
+        viewModelScope.launch { repo.setCompactNavEnabled(enabled) }
     }
 
     /** Re-reads today's token spend; called when the Settings screen resumes. */

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/categories/AppSettingsScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/categories/AppSettingsScreen.kt
@@ -9,7 +9,9 @@ import fr.bsodium.cron.ui.theme.CronTheme
 @Composable
 fun AppSettingsScreen(
     hapticsEnabled: Boolean,
+    compactNavEnabled: Boolean,
     onHapticsEnabled: (Boolean) -> Unit,
+    onCompactNavEnabled: (Boolean) -> Unit,
     onBack: () -> Unit,
 ) {
     SettingsDetailScaffold(title = "Preferences", onBack = onBack) {
@@ -20,6 +22,13 @@ fun AppSettingsScreen(
             onCheckedChange = onHapticsEnabled,
             hapticsEnabled = hapticsEnabled,
         )
+        SwitchRow(
+            title = "Compact navigation",
+            subtitle = "Use a floating pill instead of the standard navigation bar",
+            checked = compactNavEnabled,
+            onCheckedChange = onCompactNavEnabled,
+            hapticsEnabled = hapticsEnabled,
+        )
     }
 }
 
@@ -27,6 +36,12 @@ fun AppSettingsScreen(
 @Composable
 private fun AppSettingsScreenPreview() {
     CronTheme {
-        AppSettingsScreen(hapticsEnabled = true, onHapticsEnabled = {}, onBack = {})
+        AppSettingsScreen(
+            hapticsEnabled = true,
+            compactNavEnabled = false,
+            onHapticsEnabled = {},
+            onCompactNavEnabled = {},
+            onBack = {},
+        )
     }
 }


### PR DESCRIPTION
## Summary

- Standard M3 `NavigationBar` is now the default bottom navigation — full-width, icon+label, stable item positions regardless of FAB presence.
- FAB floats above the bar via Scaffold's `floatingActionButton` slot with fade animation.
- New "Compact navigation" toggle in Settings → Preferences re-enables the floating pill.
- Compact pill behavior unchanged when enabled.

Closes #120

## Test plan

- [x] Default experience shows standard NavigationBar with 3 tabs
- [x] FAB floats above the bar on the Home tab, fades in/out smoothly
- [x] Toggle "Compact navigation" in Settings → Preferences → floating pill reappears
- [x] Compact pill behavior unchanged (FAB docks right, pill shifts left)
- [x] Navigation transitions (tab fade-through, settings drill-down) work in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)