### PR TITLE
feat: allow user to edit alarm time via time picker

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
@@ -83,6 +83,7 @@ internal fun HomePlanContent(
     hasNotificationPermission: Boolean,
     onNotifEnable: () -> Unit,
     onAutoAlarmsChange: (Boolean) -> Unit,
+    onAlarmTimeClick: (() -> Unit)? = null,
 ) {
     val iterations = plan.iterations
     val listState = rememberLazyListState()
@@ -307,6 +308,7 @@ internal fun HomePlanContent(
                 sleepSegments = uiState.sleepStats?.segments.orEmpty(),
                 collapseFraction = collapseFraction, // () -> Float, read in the card's measure pass only
                 onFullHeight = { cardFullHeightPx = it },
+                onAlarmTimeClick = onAlarmTimeClick,
             )
         }
     }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -56,6 +56,7 @@ import fr.bsodium.cron.ui.screens.home.components.OnboardingHint
 import fr.bsodium.cron.ui.screens.home.components.SettingsChangedPill
 import fr.bsodium.cron.ui.screens.home.components.StreamingHaptics
 import fr.bsodium.cron.ui.screens.home.components.rememberAlarmTiming
+import fr.bsodium.cron.ui.screens.settings.components.TimePickerDialog
 import fr.bsodium.cron.ui.screens.home.components.rememberRevealedThread
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.Spacing
@@ -130,6 +131,12 @@ fun HomeScreen(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
+    var showTimePicker by remember { mutableStateOf(false) }
+    val alarmEditable = uiState.autoAlarmsEnabled
+        && uiState.sessionDisplay?.alarmTime != null
+        && timing is AlarmTiming.Upcoming
+    val onAlarmTimeClick: (() -> Unit)? = if (alarmEditable) {{ showTimePicker = true }} else null
+
     val navInsetBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val statusInsetTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
     val onNotifEnable = {
@@ -179,6 +186,7 @@ fun HomeScreen(
                         hasNotificationPermission = hasNotificationPermission,
                         onNotifEnable = onNotifEnable,
                         onAutoAlarmsChange = viewModel::setAutoAlarmsEnabled,
+                        onAlarmTimeClick = onAlarmTimeClick,
                     )
                 }
             }
@@ -225,6 +233,17 @@ fun HomeScreen(
                     onDismiss = viewModel::dismissSettingsReminder,
                 )
             }
+        }
+
+        if (showTimePicker) {
+            TimePickerDialog(
+                initial = uiState.sessionDisplay?.alarmTime ?: LocalTime(7, 0),
+                onDismiss = { showTimePicker = false },
+                onConfirm = { newTime ->
+                    viewModel.updateAlarmTime(newTime)
+                    showTimePicker = false
+                },
+            )
         }
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -243,6 +243,7 @@ fun HomeScreen(
                     viewModel.updateAlarmTime(newTime)
                     showTimePicker = false
                 },
+                hardLatest = uiState.sessionDisplay?.hardLatest,
             )
         }
     }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeUiMappers.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeUiMappers.kt
@@ -6,6 +6,7 @@ import fr.bsodium.cron.session.db.SessionEntity
 import fr.bsodium.cron.session.db.SessionEventEntity
 import fr.bsodium.cron.session.db.SessionJson
 import fr.bsodium.cron.session.model.EventData
+import fr.bsodium.cron.session.model.DayPlan
 import fr.bsodium.cron.session.model.Instruction
 import fr.bsodium.cron.session.model.SessionStatus
 import fr.bsodium.cron.session.model.SleepSegment
@@ -34,6 +35,9 @@ internal fun SessionEntity.toDisplayState(): SessionDisplayState? {
     val sessionDate = runCatching { LocalDate.parse(date) }
         .onFailure { Log.w(TAG, "parse session date failed for session $id", it) }
         .getOrNull() ?: return null
+    val plan = runCatching { SessionJson.decodeFromString<DayPlan>(planJson) }
+        .onFailure { Log.w(TAG, "decode plan failed for session $id", it) }
+        .getOrNull()
     return SessionDisplayState(
         status = runCatching { SessionStatus.valueOf(status) }
             .onFailure { Log.w(TAG, "unknown session status '$status' for $id", it) }
@@ -43,6 +47,7 @@ internal fun SessionEntity.toDisplayState(): SessionDisplayState? {
         reason = instruction.reason,
         sessionDate = sessionDate,
         snoozeCount = snoozeCount,
+        hardLatest = plan?.hardLatest,
     )
 }
 

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
@@ -19,6 +19,7 @@ import fr.bsodium.cron.session.db.CronDatabase
 import fr.bsodium.cron.session.db.toModel
 import fr.bsodium.cron.session.model.ActionType
 import fr.bsodium.cron.session.model.EventData
+import fr.bsodium.cron.session.model.Instruction
 import fr.bsodium.cron.session.model.SessionEvent
 import fr.bsodium.cron.session.model.SleepSegment
 import fr.bsodium.cron.session.model.TriggerType
@@ -43,6 +44,7 @@ import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime
 import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
 
 data class HomeUiState(
     val sessionDisplay: SessionDisplayState? = null,
@@ -307,6 +309,32 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                         }
                     }
                 }
+        }
+    }
+
+    fun updateAlarmTime(newTime: LocalTime) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val session = repository.findCurrent() ?: return@launch
+            val tz = TimeZone.of(session.timezone)
+            val requested = session.date.atTime(newTime).toInstant(tz)
+            val plan = alarmScheduler.schedule(
+                requested = requested,
+                hardLatest = session.plan.hardLatest,
+                sessionDate = session.date,
+                timezone = tz,
+                label = session.currentInstruction.reason.ifBlank { "Cron Alarm" },
+                sessionId = session.id,
+            )
+            val actualTime = plan.actualInstant.toLocalDateTime(tz).time
+            repository.updateInstruction(
+                session.id,
+                Instruction(
+                    action = ActionType.SetAlarm,
+                    alarmTime = actualTime,
+                    reason = session.currentInstruction.reason,
+                    issuedAt = Clock.System.now(),
+                ),
+            )
         }
     }
 

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/SessionDisplayState.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/SessionDisplayState.kt
@@ -13,4 +13,5 @@ data class SessionDisplayState(
     val reason: String,
     val sessionDate: LocalDate,
     val snoozeCount: Int,
+    val hardLatest: LocalTime? = null,
 )

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/CollapsibleAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/CollapsibleAlarmCard.kt
@@ -53,6 +53,7 @@ internal fun CollapsibleAlarmCard(
     collapseFraction: () -> Float,
     onFullHeight: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    onAlarmTimeClick: (() -> Unit)? = null,
 ) {
     val timing = rememberAlarmTiming(alarmTime, sessionDate)
     val onCard = MaterialTheme.colorScheme.onPrimary
@@ -69,6 +70,7 @@ internal fun CollapsibleAlarmCard(
     AlarmShell(
         modifier = modifier,
         shape = RoundedCornerShape(Radius.xl),
+        onClick = onAlarmTimeClick,
     ) {
         SubcomposeLayout(modifier = Modifier.clipToBounds()) { constraints ->
             val f = collapseFraction().coerceIn(0f, 1f)

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/CollapsibleAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/CollapsibleAlarmCard.kt
@@ -63,7 +63,7 @@ internal fun CollapsibleAlarmCard(
     val countdownColor = if (upcoming) onCard.copy(alpha = 0.7f) else onCard.copy(alpha = 0.30f)
     // One reveal, shared by the moving clock + countdown (the hidden time row in extras keeps its own
     // deterministic copy, never drawn).
-    val progress = rememberLcdRevealProgress(alarmTime)
+    val reveal = rememberLcdReveal(alarmTime)
     val ink = rememberLcdInkMetrics()
     val dateStyle = CronTypography.dateLabel.copy(fontSize = 28.sp, lineHeight = 28.sp)
 
@@ -105,12 +105,12 @@ internal fun CollapsibleAlarmCard(
             // glyph scale cancels the dilution from shrinking, so the RENDERED stroke tracks f directly.
             val strokePx = MAX_CLOCK_STROKE.toPx() * f / clockScale
             val clock = subcompose("clock") {
-                LcdClock(alarmTime, progress, digitColor, strokeWidthPx = strokePx)
+                LcdClock(alarmTime, reveal, digitColor, strokeWidthPx = strokePx)
             }.first().measure(cWrap)
             // The remaining is the SAME CountdownStack as expanded (identical font/size/weight) — it just
             // moves and re-aligns its lines (left→right) via alignFraction; it never fades or resizes.
             val countdown = subcompose("countdown") {
-                RemainingOrStatus(timing = timing, progress = progress, color = countdownColor, alignFraction = f)
+                RemainingOrStatus(timing = timing, progress = reveal.progress, color = countdownColor, alignFraction = f)
             }.first().measure(cWrap)
 
             val w = extras.width

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/Countdown.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/Countdown.kt
@@ -6,8 +6,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.AlignmentLine
@@ -30,6 +33,7 @@ import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import java.util.Locale
 import kotlin.math.roundToInt
+import androidx.compose.ui.util.lerp
 import kotlin.time.Duration
 
 internal data class HoursMinutes(val hours: Long, val minutes: Long)
@@ -47,10 +51,16 @@ internal fun CountdownStack(
     modifier: Modifier = Modifier,
     alignFraction: Float = 0f,
 ) {
+    val prevCountdown = remember { mutableStateOf(countdown) }
+    val fromH = prevCountdown.value?.hours ?: 0L
+    val fromM = prevCountdown.value?.minutes ?: 0L
+    val targetH = countdown?.hours ?: 0L
+    val targetM = countdown?.minutes ?: 0L
+    if (progress >= 1f) SideEffect { prevCountdown.value = countdown }
     // No alarm → a grayed "00H/00M" placeholder, mirroring the dimmed "00:00" digits.
     val (top, bottom) = if (countdown == null) "00H" to "00M"
-    else String.format(Locale.US, "%dH", (countdown.hours * progress).roundToInt()) to
-        String.format(Locale.US, "%dM", (countdown.minutes * progress).roundToInt())
+    else String.format(Locale.US, "%dH", lerp(fromH.toFloat(), targetH.toFloat(), progress).roundToInt()) to
+        String.format(Locale.US, "%dM", lerp(fromM.toFloat(), targetM.toFloat(), progress).roundToInt())
     TwoLineLcdStack(top = top, bottom = bottom, color = color, modifier = modifier, alignFraction = alignFraction)
 }
 

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/Countdown.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/Countdown.kt
@@ -6,11 +6,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.AlignmentLine
@@ -33,7 +30,6 @@ import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import java.util.Locale
 import kotlin.math.roundToInt
-import androidx.compose.ui.util.lerp
 import kotlin.time.Duration
 
 internal data class HoursMinutes(val hours: Long, val minutes: Long)
@@ -51,16 +47,10 @@ internal fun CountdownStack(
     modifier: Modifier = Modifier,
     alignFraction: Float = 0f,
 ) {
-    val prevCountdown = remember { mutableStateOf(countdown) }
-    val fromH = prevCountdown.value?.hours ?: 0L
-    val fromM = prevCountdown.value?.minutes ?: 0L
-    val targetH = countdown?.hours ?: 0L
-    val targetM = countdown?.minutes ?: 0L
-    if (progress >= 1f) SideEffect { prevCountdown.value = countdown }
     // No alarm → a grayed "00H/00M" placeholder, mirroring the dimmed "00:00" digits.
     val (top, bottom) = if (countdown == null) "00H" to "00M"
-    else String.format(Locale.US, "%dH", lerp(fromH.toFloat(), targetH.toFloat(), progress).roundToInt()) to
-        String.format(Locale.US, "%dM", lerp(fromM.toFloat(), targetM.toFloat(), progress).roundToInt())
+    else String.format(Locale.US, "%dH", (countdown.hours * progress).roundToInt()) to
+        String.format(Locale.US, "%dM", (countdown.minutes * progress).roundToInt())
     TwoLineLcdStack(top = top, bottom = bottom, color = color, modifier = modifier, alignFraction = alignFraction)
 }
 

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -55,6 +56,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import java.util.Locale
 import kotlin.math.roundToInt
+import androidx.compose.ui.util.lerp
 
 @Composable
 fun NextAlarmCard(
@@ -252,9 +254,15 @@ internal fun LcdClock(
     strokeWidthPx: Float = 0f,
 ) {
     val pending = alarmTime == null
+    val prevAlarmTime = remember { mutableStateOf(alarmTime) }
+    val fromH = prevAlarmTime.value?.hour ?: 0
+    val fromM = prevAlarmTime.value?.minute ?: 0
+    val targetH = alarmTime?.hour ?: 0
+    val targetM = alarmTime?.minute ?: 0
+    SideEffect { prevAlarmTime.value = alarmTime }
     // Locale.US so the digits render as ASCII 0-9 on Arabic/Farsi/Bengali devices.
-    val hh = if (pending) "00" else String.format(Locale.US, "%02d", (alarmTime.hour * progress).roundToInt())
-    val mm = if (pending) "00" else String.format(Locale.US, "%02d", (alarmTime.minute * progress).roundToInt())
+    val hh = if (pending) "00" else String.format(Locale.US, "%02d", lerp(fromH.toFloat(), targetH.toFloat(), progress).roundToInt())
+    val mm = if (pending) "00" else String.format(Locale.US, "%02d", lerp(fromM.toFloat(), targetM.toFloat(), progress).roundToInt())
     val lcdStyle = CronTypography.lcdHero
     val ink = rememberLcdInkMetrics()
     // IntrinsicSize.Min so the colon's fillMaxHeight matches the digit line box, not the viewport.
@@ -310,7 +318,10 @@ internal fun rememberLcdRevealProgress(alarmTime: LocalTime?): Float {
     val progressAnim = remember { Animatable(if (valueKey == null || valueKey == animatedKey) 1f else 0f) }
     LaunchedEffect(valueKey) {
         if (valueKey == null) return@LaunchedEffect
-        if (valueKey != animatedKey) {
+        if (animatedKey == null) {
+            progressAnim.snapTo(1f)
+            animatedKey = valueKey
+        } else if (valueKey != animatedKey) {
             progressAnim.snapTo(0f)
             // Sanctioned motionScheme exception (docs/expressive.md § Sanctioned exceptions): the reveal
             // gates digit rolling on a 0→1 progress; a spring's overshoot past 1 would re-roll the digits.

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
@@ -259,7 +259,7 @@ internal fun LcdClock(
     val fromM = prevAlarmTime.value?.minute ?: 0
     val targetH = alarmTime?.hour ?: 0
     val targetM = alarmTime?.minute ?: 0
-    SideEffect { prevAlarmTime.value = alarmTime }
+    if (progress >= 1f) SideEffect { prevAlarmTime.value = alarmTime }
     // Locale.US so the digits render as ASCII 0-9 on Arabic/Farsi/Bengali devices.
     val hh = if (pending) "00" else String.format(Locale.US, "%02d", lerp(fromH.toFloat(), targetH.toFloat(), progress).roundToInt())
     val mm = if (pending) "00" else String.format(Locale.US, "%02d", lerp(fromM.toFloat(), targetM.toFloat(), progress).roundToInt())

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -75,19 +76,34 @@ fun NextAlarmCard(
  * collapsing variant can lerp its corner radius. Content renders in `onPrimary`.
  */
 @Composable
+@OptIn(ExperimentalMaterial3Api::class)
 internal fun AlarmShell(
     modifier: Modifier = Modifier,
     shape: Shape = RoundedCornerShape(Radius.xl),
+    onClick: (() -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
-    Surface(
-        modifier = modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.primary,
-        shape = shape,
-        tonalElevation = 0.dp,
-        shadowElevation = 0.dp,
-        content = content,
-    )
+    val mod = modifier.fillMaxWidth()
+    if (onClick != null) {
+        Surface(
+            onClick = onClick,
+            modifier = mod,
+            color = MaterialTheme.colorScheme.primary,
+            shape = shape,
+            tonalElevation = 0.dp,
+            shadowElevation = 0.dp,
+            content = content,
+        )
+    } else {
+        Surface(
+            modifier = mod,
+            color = MaterialTheme.colorScheme.primary,
+            shape = shape,
+            tonalElevation = 0.dp,
+            shadowElevation = 0.dp,
+            content = content,
+        )
+    }
 }
 
 /** The expanded card body: bold date, hero LCD time, and the sleep block. Renders in `onPrimary`. */

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -219,7 +218,7 @@ private fun LcdTimeDisplay(
     modifier: Modifier = Modifier,
     timeRowAlpha: Float = 1f,
 ) {
-    val progress = rememberLcdRevealProgress(alarmTime)
+    val reveal = rememberLcdReveal(alarmTime)
     // Only an upcoming alarm reads in full; no alarm and a passed alarm both render the grayed onset look.
     val upcoming = timing is AlarmTiming.Upcoming
     val digitColor = if (upcoming) base else base.copy(alpha = 0.30f)
@@ -229,10 +228,10 @@ private fun LcdTimeDisplay(
         modifier = modifier.alpha(timeRowAlpha),
         verticalAlignment = Alignment.Top,
     ) {
-        LcdClock(alarmTime = alarmTime, progress = progress, color = digitColor)
+        LcdClock(alarmTime = alarmTime, reveal = reveal, color = digitColor)
         RemainingOrStatus(
             timing = timing,
-            progress = progress,
+            progress = reveal.progress,
             color = statusColor,
             modifier = Modifier.padding(start = Spacing.xs + Spacing.xxs, top = Spacing.xs + Spacing.xxs),
         )
@@ -246,7 +245,7 @@ private fun LcdTimeDisplay(
 @Composable
 internal fun LcdClock(
     alarmTime: LocalTime?,
-    progress: Float,
+    reveal: LcdReveal,
     color: Color,
     modifier: Modifier = Modifier,
     // The single-weight LCD face has no bold; [strokeWidthPx] (local px) overlays a stroke that
@@ -254,15 +253,9 @@ internal fun LcdClock(
     strokeWidthPx: Float = 0f,
 ) {
     val pending = alarmTime == null
-    val prevAlarmTime = remember { mutableStateOf(alarmTime) }
-    val fromH = prevAlarmTime.value?.hour ?: 0
-    val fromM = prevAlarmTime.value?.minute ?: 0
-    val targetH = alarmTime?.hour ?: 0
-    val targetM = alarmTime?.minute ?: 0
-    if (progress >= 1f) SideEffect { prevAlarmTime.value = alarmTime }
     // Locale.US so the digits render as ASCII 0-9 on Arabic/Farsi/Bengali devices.
-    val hh = if (pending) "00" else String.format(Locale.US, "%02d", lerp(fromH.toFloat(), targetH.toFloat(), progress).roundToInt())
-    val mm = if (pending) "00" else String.format(Locale.US, "%02d", lerp(fromM.toFloat(), targetM.toFloat(), progress).roundToInt())
+    val hh = if (pending) "00" else String.format(Locale.US, "%02d", lerp(reveal.fromHour.toFloat(), alarmTime.hour.toFloat(), reveal.progress).roundToInt())
+    val mm = if (pending) "00" else String.format(Locale.US, "%02d", lerp(reveal.fromMinute.toFloat(), alarmTime.minute.toFloat(), reveal.progress).roundToInt())
     val lcdStyle = CronTypography.lcdHero
     val ink = rememberLcdInkMetrics()
     // IntrinsicSize.Min so the colon's fillMaxHeight matches the digit line box, not the viewport.
@@ -307,31 +300,41 @@ private fun StrokeableLcdDigits(
     }
 }
 
-/**
- * The 700ms "roll up from 0" reveal progress, fired only when the alarm VALUE changes. The animated
- * key is [rememberSaveable], so reopening or switching tabs with an unchanged value shows it at rest.
- */
+internal data class LcdReveal(
+    val fromHour: Int,
+    val fromMinute: Int,
+    val progress: Float,
+)
+
 @Composable
-internal fun rememberLcdRevealProgress(alarmTime: LocalTime?): Float {
+internal fun rememberLcdReveal(alarmTime: LocalTime?): LcdReveal {
     val valueKey = alarmTime?.let { it.hour * 60 + it.minute }
     var animatedKey by rememberSaveable { mutableStateOf<Int?>(null) }
+    var fromKey by rememberSaveable { mutableStateOf(valueKey ?: 0) }
     val progressAnim = remember { Animatable(if (valueKey == null || valueKey == animatedKey) 1f else 0f) }
     LaunchedEffect(valueKey) {
         if (valueKey == null) return@LaunchedEffect
         if (animatedKey == null) {
+            fromKey = valueKey
             progressAnim.snapTo(1f)
             animatedKey = valueKey
         } else if (valueKey != animatedKey) {
+            fromKey = animatedKey!!
             progressAnim.snapTo(0f)
             // Sanctioned motionScheme exception (docs/expressive.md § Sanctioned exceptions): the reveal
             // gates digit rolling on a 0→1 progress; a spring's overshoot past 1 would re-roll the digits.
             progressAnim.animateTo(1f, tween(durationMillis = LCD_REVEAL_MILLIS, easing = EaseOutCubic))
+            fromKey = valueKey
             animatedKey = valueKey
         } else {
             progressAnim.snapTo(1f)
         }
     }
-    return progressAnim.value
+    return LcdReveal(
+        fromHour = fromKey / 60,
+        fromMinute = fromKey % 60,
+        progress = progressAnim.value,
+    )
 }
 
 private const val LCD_REVEAL_MILLIS = 700

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/components/TimePickerRow.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/components/TimePickerRow.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -85,12 +86,19 @@ internal fun TimePickerDialog(
     initial: LocalTime,
     onDismiss: () -> Unit,
     onConfirm: (LocalTime) -> Unit,
+    hardLatest: LocalTime? = null,
 ) {
     val pickerState = rememberTimePickerState(
         initialHour = initial.hour,
         initialMinute = initial.minute,
         is24Hour = true,
     )
+    val overLimit by remember(hardLatest) {
+        derivedStateOf {
+            hardLatest != null && (pickerState.hour > hardLatest.hour ||
+                (pickerState.hour == hardLatest.hour && pickerState.minute > hardLatest.minute))
+        }
+    }
     val lighterTypography = MaterialTheme.typography.copy(
         displayLarge = MaterialTheme.typography.displayLarge.copy(fontWeight = FontWeight.Normal),
     )
@@ -107,6 +115,14 @@ internal fun TimePickerDialog(
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                if (hardLatest != null) {
+                    Text(
+                        text = String.format(Locale.US, "Latest: %02d:%02d", hardLatest.hour, hardLatest.minute),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = if (overLimit) MaterialTheme.colorScheme.error
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
                 Spacer(Modifier.height(Spacing.lg))
                 MaterialTheme(typography = lighterTypography) {
                     TimePicker(state = pickerState)
@@ -116,7 +132,10 @@ internal fun TimePickerDialog(
                     horizontalArrangement = Arrangement.End,
                 ) {
                     TextButton(onClick = onDismiss) { Text("Cancel") }
-                    TextButton(onClick = { onConfirm(LocalTime(pickerState.hour, pickerState.minute)) }) {
+                    TextButton(
+                        onClick = { onConfirm(LocalTime(pickerState.hour, pickerState.minute)) },
+                        enabled = !overLimit,
+                    ) {
                         Text("OK")
                     }
                 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/components/TimePickerRow.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/components/TimePickerRow.kt
@@ -1,12 +1,17 @@
 package fr.bsodium.cron.ui.screens.settings.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.AlertDialog
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
@@ -19,6 +24,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import fr.bsodium.cron.ui.theme.Radius
+import fr.bsodium.cron.ui.theme.Spacing
 import java.util.Locale
 import kotlinx.datetime.LocalTime
 
@@ -82,17 +91,36 @@ internal fun TimePickerDialog(
         initialMinute = initial.minute,
         is24Hour = true,
     )
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Select time") },
-        text = { TimePicker(state = pickerState) },
-        confirmButton = {
-            TextButton(onClick = { onConfirm(LocalTime(pickerState.hour, pickerState.minute)) }) {
-                Text("OK")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
-        },
+    val lighterTypography = MaterialTheme.typography.copy(
+        displayLarge = MaterialTheme.typography.displayLarge.copy(fontWeight = FontWeight.Normal),
     )
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = RoundedCornerShape(Radius.xl),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            tonalElevation = 0.dp,
+            shadowElevation = 0.dp,
+        ) {
+            Column(modifier = Modifier.padding(Spacing.xl)) {
+                Text(
+                    text = "Select time",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(Spacing.lg))
+                MaterialTheme(typography = lighterTypography) {
+                    TimePicker(state = pickerState)
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                    TextButton(onClick = { onConfirm(LocalTime(pickerState.hour, pickerState.minute)) }) {
+                        Text("OK")
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/components/TimePickerRow.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/components/TimePickerRow.kt
@@ -72,7 +72,7 @@ internal fun TimePickerRow(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun TimePickerDialog(
+internal fun TimePickerDialog(
     initial: LocalTime,
     onDismiss: () -> Unit,
     onConfirm: (LocalTime) -> Unit,


### PR DESCRIPTION
## Summary

- Tapping the alarm card on the home screen opens a Material 3 `TimePicker` dialog to adjust the alarm time without re-running the AI plan
- The alarm is rescheduled via `AlarmScheduler` (with clamping) and the instruction is persisted; the UI updates immediately via Room observation
- The card is only tappable when an alarm is set, upcoming, and auto-alarms are enabled

Closes #117

## Test plan

- [x] Set an alarm via the AI plan, tap the alarm card → time picker opens
- [x] Pick a new time and confirm → alarm reschedules, LCD display updates
- [x] Dismiss the picker → alarm unchanged
- [x] When alarm has passed (resting state) → card is not tappable
- [x] When auto-alarms disabled → card is not tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)