### PR TITLE
fix: pin debug versionCode to avoid downgrade errors on branch switch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,9 @@ fun gitVersionCode(): Int {
     }
 }
 
+// Fixed debug versionCode so switching branches never triggers a version-downgrade error on device.
+val isReleaseBuild = gradle.startParameter.taskNames.any { it.contains("Release", ignoreCase = true) }
+
 // Read local.properties for sensitive config (file is gitignored)
 val localProps = Properties().apply {
     rootProject.file("local.properties")
@@ -54,7 +57,7 @@ android {
         applicationId = "fr.bsodium.cron"
         minSdk = 26
         targetSdk = 36
-        versionCode = gitVersionCode()
+        versionCode = if (isReleaseBuild) gitVersionCode() else Int.MAX_VALUE
         versionName = gitVersionName()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Summary

- Debug builds use `Int.MAX_VALUE` as `versionCode` so installing from any branch never triggers `INSTALL_FAILED_VERSION_DOWNGRADE`. Release builds still use the git commit count.

## Test plan

- [x] Install a debug build from branch A, then from branch B — verify no downgrade error
- [x] Run a release build — verify `versionCode` still derives from `gitVersionCode()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)