### PR TITLE
Enforce animation labels & preview existence via CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,66 @@ This app targets **Material 3 Expressive**, not static M3. **Read `docs/expressi
 - **Don't put screen description text in `LargeFlexibleTopAppBar`'s `subtitle` slot.** The bar renders `smallSubtitle` in the collapsed bar too (see M3 source: `smallSubtitle = subtitle ?: {}`), so long text crowds the collapsed state and clips the title. The canonical Android pattern (used by Android Settings) is: functional description text is the first item in the scrolling content column, where it naturally scrolls away. In this project that means the `subtitle: String?` parameter on `SettingsDetailScaffold`. The `LargeFlexibleTopAppBar` subtitle slot is reserved for very short complementary labels that should remain visible at all scroll positions — not used in this project.
 - Provide a `@Preview` for any non-trivial or reusable composable — **mandatory for important components** (cards, the nav/FAB, the thinking thread, each screen's key pieces). Keep the preview `private`, wrap it in `CronTheme`, and feed representative sample data so it renders without a device. A component you can't preview without real DB/network data is a sign its rendering should be split from its data-loading.
 
+## Animation previews & inspectability
+
+The primary workflow for testing motion is Android Studio's **Animation Inspector**. Every animated component must be previewable and scrubbable without deploying. CI enforces this via `./gradlew :app:checkAnimationPreviews`.
+
+### Label every animation
+
+Every call to `animate*AsState`, `updateTransition`, `AnimatedVisibility`, `AnimatedContent`, `Crossfade`, and `rememberInfiniteTransition` **must** include a `label` parameter — short kebab-case, scoped to the component, describes the semantic purpose:
+
+```kotlin
+val scale by animateFloatAsState(
+    targetValue = if (pressed) 0.92f else 1f,
+    animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+    label = "card-press-scale",
+)
+```
+
+Without labels the Inspector shows "Float 1", "Float 2" — useless. When touching a file with unlabeled calls, add labels before finishing.
+
+### What requires an animation preview
+
+A `@Preview` is mandatory for any composable that directly uses animation APIs (`animate*AsState`, `AnimatedVisibility`, `AnimatedContent`, `updateTransition`, `Crossfade`, `rememberInfiniteTransition`, `Animatable`). Suppress with `@Suppress("AnimationPreviewNotRequired")` for animations that only run inside a parent's preview.
+
+Do NOT preview: pure layout containers, static wrappers, composables whose only motion is inherited from a parent's enter/exit.
+
+### Preview design for the Inspector
+
+**Interactive previews (preferred).** Internal `remember { mutableStateOf(...) }` toggled by `Modifier.clickable` — the Inspector captures the live transition:
+
+```kotlin
+@Preview(name = "ExpandableCard — interactive")
+@Composable
+private fun ExpandableCardPreview() {
+    CronTheme {
+        var expanded by remember { mutableStateOf(false) }
+        ExpandableCard(
+            expanded = expanded,
+            modifier = Modifier.clickable { expanded = !expanded },
+        )
+    }
+}
+```
+
+For >2 states or gesture-driven animations, add multi-variant static previews instead.
+
+**Infinite animations** are self-driving — one preview, the Inspector picks them up.
+
+### State hoisting for inspectability
+
+Hoist the triggering state as a parameter. Never wire a ViewModel or repository into a Preview — use `private val PREVIEW_*` constants or `private fun preview*(...)` factories.
+
+### Preview file organization
+
+Co-locate at file bottom by default. Split to a sibling `*Previews.kt` when mock data setup exceeds ~20 lines.
+
+### Naming
+
+- Preview functions: `private`, `*Preview` suffix, variant after `—`: `"Card — expanded"`.
+- Labels: kebab-case, semantic: `"reasoning-reveal"`, `"nav-container"`, `"skeleton-pulse"`.
+- Mock data: `private val PREVIEW_<THING>` or `private fun preview<Thing>(...)`.
+
 ## Coroutines & lifecycle
 
 - ViewModels: don't instantiate context-scoped objects (`LocationProvider`, repositories, DAOs) per call. Hold them as `private val` fields constructed once from `application` in the VM's init block.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -223,4 +223,83 @@ tasks.register("checkFileLength") {
     }
 }
 
-tasks.named("check") { dependsOn("checkFileLength") }
+/**
+ * Enforces two animation-quality rules so the Animation Inspector is always usable:
+ * A) Every animation API call has an explicit `label` parameter (named tracks in the timeline).
+ * B) Every file that uses animation APIs ships a @Preview (or a sibling *Previews.kt, or an
+ *    explicit @Suppress("AnimationPreviewNotRequired") for structurally un-previewable code).
+ * Wired into `check` alongside checkFileLength.
+ */
+tasks.register("checkAnimationPreviews") {
+    group = "verification"
+    description = "Fails if animation calls lack labels or animated files lack @Preview."
+    val mainSrc = layout.projectDirectory.dir("src/main")
+    val projectRoot = rootDir
+    doLast {
+        val animationApis = listOf(
+            "animateFloatAsState", "animateColorAsState", "animateDpAsState",
+            "animateIntAsState", "animateValueAsState", "animateIntOffsetAsState",
+            "animateOffsetAsState", "animateSizeAsState", "animateIntSizeAsState",
+            "animateRectAsState", "AnimatedVisibility", "AnimatedContent",
+            "updateTransition", "Crossfade", "rememberInfiniteTransition",
+        )
+        val callPatterns = animationApis.map { it to Regex("""(?<!\w)$it\s*\(""") }
+        val labelPattern = Regex("""label\s*=""")
+        val previewPattern = Regex("""@Preview""")
+        val suppressPattern = Regex("""@(?:file:)?Suppress\([^)]*AnimationPreviewNotRequired[^)]*\)""")
+
+        val ktFiles = mainSrc.asFile.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .toList()
+
+        val unlabeled = mutableListOf<String>()
+        val noPreview = mutableListOf<String>()
+
+        for (file in ktFiles) {
+            val lines = file.readLines()
+            val text = lines.joinToString("\n")
+            val hasAnimations = callPatterns.any { (_, pattern) -> pattern.containsMatchIn(text) }
+            if (!hasAnimations) continue
+
+            for ((i, line) in lines.withIndex()) {
+                val trimmed = line.trimStart()
+                if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("import ")) continue
+                val apiMatch = callPatterns.firstOrNull { (_, p) -> p.containsMatchIn(line) }?.first ?: continue
+                val window = lines.subList(i, minOf(i + 12, lines.size))
+                val hasLabel = window.any { labelPattern.containsMatchIn(it) }
+                if (!hasLabel) {
+                    unlabeled += "  ${file.relativeTo(projectRoot).path}:${i + 1} — $apiMatch"
+                }
+            }
+
+            if (!previewPattern.containsMatchIn(text) && !suppressPattern.containsMatchIn(text)) {
+                val hasSiblingPreviews = file.parentFile.listFiles()
+                    ?.any { it.name.endsWith("Previews.kt") } ?: false
+                if (!hasSiblingPreviews) {
+                    noPreview += "  ${file.relativeTo(projectRoot).path}"
+                }
+            }
+        }
+
+        if (unlabeled.isNotEmpty() || noPreview.isNotEmpty()) {
+            val msg = buildString {
+                if (unlabeled.isNotEmpty()) {
+                    appendLine("Animation calls missing `label` parameter:")
+                    unlabeled.forEach { appendLine(it) }
+                }
+                if (noPreview.isNotEmpty()) {
+                    if (unlabeled.isNotEmpty()) appendLine()
+                    appendLine(
+                        "Files with animations but no @Preview " +
+                            "(add one, or @Suppress(\"AnimationPreviewNotRequired\")):",
+                    )
+                    noPreview.forEach { appendLine(it) }
+                }
+            }
+            throw GradleException(msg)
+        }
+        logger.lifecycle("checkAnimationPreviews: all animation calls labeled, all animated files have previews.")
+    }
+}
+
+tasks.named("check") { dependsOn("checkFileLength", "checkAnimationPreviews") }

--- a/app/src/main/java/fr/bsodium/cron/MainActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/MainActivity.kt
@@ -1,3 +1,5 @@
+@file:Suppress("AnimationPreviewNotRequired")
+
 package fr.bsodium.cron
 
 import android.os.Bundle
@@ -188,6 +190,7 @@ class MainActivity : ComponentActivity() {
                                 enter = slideInVertically(MaterialTheme.motionScheme.defaultSpatialSpec()) { it / 3 } +
                                     fadeIn(MaterialTheme.motionScheme.defaultEffectsSpec()),
                                 exit = fadeOut(MaterialTheme.motionScheme.defaultEffectsSpec()),
+                                label = "bottom-bar",
                             ) {
                                 if (useCompactNav) {
                                     CronFloatingNav(

--- a/app/src/main/java/fr/bsodium/cron/ui/components/CronBottomBar.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/CronBottomBar.kt
@@ -144,6 +144,7 @@ private fun FabSlot(
             visible = visible,
             enter = slideInHorizontally(spatialSpec) { it } + fadeIn(alphaSpec),
             exit = slideOutHorizontally(spatialSpec) { it } + fadeOut(alphaSpec),
+            label = "fab-visibility",
         ) {
             Box(Modifier.onSizeChanged { onWidthMeasured(it.width) }) {
                 if (fabChevron != null) SplitActionFab(lastShown, fabChevron)
@@ -265,6 +266,7 @@ internal fun SplitActionFab(action: FabAction?, fabChevron: FabChevronSlot) {
                                     exit = fadeOut(MaterialTheme.motionScheme.fastEffectsSpec()) +
                                         slideOutVertically(MaterialTheme.motionScheme.fastSpatialSpec()) { it } +
                                         shrinkVertically(animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(), clip = false),
+                                    label = "mock-badge",
                                 ) {
                                     Text(
                                         text = "Mocked",

--- a/app/src/main/java/fr/bsodium/cron/ui/components/NavPill.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/NavPill.kt
@@ -16,6 +16,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -25,9 +28,11 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import fr.bsodium.cron.ROUTE_HISTORY
 import fr.bsodium.cron.ROUTE_HOME
+import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.screens.settings.SETTINGS_ROOT
 import fr.bsodium.cron.ui.theme.CronColors
 import fr.bsodium.cron.ui.theme.MaterialSymbol
@@ -114,5 +119,17 @@ private fun RowScope.NavSlot(
                 )
             }
         }
+    }
+}
+
+@Preview(showBackground = true, name = "NavPill — interactive")
+@Composable
+private fun NavPillPreview() {
+    CronTheme {
+        var route by remember { mutableStateOf(ROUTE_HOME) }
+        NavPill(
+            currentRoute = route,
+            onNavigate = { route = it },
+        )
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
@@ -375,6 +375,7 @@ private fun BoxScope.StickyAlarm(
                         fadeIn(MaterialTheme.motionScheme.defaultEffectsSpec()),
                     exit = shrinkVertically(MaterialTheme.motionScheme.defaultSpatialSpec()) +
                         fadeOut(MaterialTheme.motionScheme.defaultEffectsSpec()),
+                    label = "below-card",
                 ) {
                     Box(Modifier.padding(top = Spacing.sm)) { belowCard() }
                 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -211,6 +211,7 @@ fun HomeScreen(
                 visible = uiState.aiFailure != null,
                 enter = fadeIn() + slideInVertically { it / 2 },
                 exit = fadeOut() + slideOutVertically { it / 2 },
+                label = "failure-banner",
             ) {
                 lastFailure?.let { failure ->
                     AiFailureBanner(
@@ -225,6 +226,7 @@ fun HomeScreen(
                 visible = uiState.settingsChangedSincePlan,
                 enter = fadeIn() + slideInVertically { it / 2 },
                 exit = fadeOut() + slideOutVertically { it / 2 },
+                label = "settings-changed-pill",
             ) {
                 SettingsChangedPill(
                     onRewrite = {

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiThinkingThread.kt
@@ -409,7 +409,7 @@ private fun AnswerArea(
     // Animate the slot size only when settled (the answer↔fallback crossfade). While streaming, the
     // typewriter outpaces the spring, so a lagging container clips the freshest lines — grow instantly.
     Box(modifier = modifier.fillMaxWidth().then(if (inProgress) Modifier else Modifier.animateContentSize())) {
-        AnimatedVisibility(visible = hasAnswer, enter = fadeIn(), exit = fadeOut()) {
+        AnimatedVisibility(visible = hasAnswer, enter = fadeIn(), exit = fadeOut(), label = "response-body") {
             Column {
                 Spacer(Modifier.height(Spacing.sm))
                 ResponseBody(response?.takeIf { it.isNotBlank() } ?: lastResponse)
@@ -418,7 +418,7 @@ private fun AnswerArea(
                 Spacer(Modifier.height(Spacing.sm))
             }
         }
-        AnimatedVisibility(visible = showFallback, enter = fadeIn(), exit = fadeOut()) {
+        AnimatedVisibility(visible = showFallback, enter = fadeIn(), exit = fadeOut(), label = "no-response-fallback") {
             Column {
                 Spacer(Modifier.height(Spacing.sm))
                 Text(

--- a/docs/expressive.md
+++ b/docs/expressive.md
@@ -54,6 +54,7 @@ Rounded, MaterialShapes-based. **Flat**: no `Modifier.shadow`, no `shadowElevati
 - [ ] Used the Expressive variant where one exists (`ButtonGroup` + `animateWidth`, `ToggleButton`, Expressive FAB).
 - [ ] Press/selection has spring feedback.
 - [ ] Uses accent roles (not only `primary`); flat; `Spacing`/`Radius` tokens; ships a `@Preview`.
+- [ ] Every animation call has a `label`; animated components ship an interactive `@Preview` (enforced by `checkAnimationPreviews`).
 
 ## Sanctioned exceptions to the motionScheme rule
 


### PR DESCRIPTION
## Summary
- Adds `checkAnimationPreviews` Gradle task (wired into `check`) that fails the build when:
  - Animation API calls (`animate*AsState`, `AnimatedVisibility`, `AnimatedContent`, `Crossfade`, `updateTransition`, `rememberInfiniteTransition`) lack a `label` parameter
  - Files with animation APIs lack a `@Preview` (or sibling `*Previews.kt`, or explicit `@Suppress("AnimationPreviewNotRequired")`)
- Labels 8 previously-unlabeled `AnimatedVisibility` calls across the codebase
- Adds an interactive preview to `NavPill`
- Documents the animation inspectability rules in AGENTS.md and adds a checklist item to `docs/expressive.md`

## Motivation
The Animation Inspector timeline is useless without labels (shows "Float 1", "Float 2") and without previews there's nothing to scrub. This CI gate survives context compaction — the agent self-corrects on build failure without needing to remember the rules.

## Test plan
- [x] `./gradlew :app:checkAnimationPreviews` passes
- [x] `./gradlew :app:assembleDebug` passes
- [x] `./gradlew :app:lintDebug` passes
- [x] Open NavPill preview in Android Studio → Animation Inspector shows `nav-container`, `nav-tint`, `nav-fill` tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)