### PR TITLE
Fix homepage going blank after alarm dismissal

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -228,8 +228,8 @@ private fun HomeRootContent(
         LaunchedEffect(displayPlan) { displayPlan?.let { lastPlan = it } }
         val homePhase = when {
             !uiState.initialized -> HomePhase.Loading
-            displayPlan != null && !resting -> HomePhase.Plan
-            lastPlan != null && uiState.isRetrying && !resting -> HomePhase.Plan
+            displayPlan != null -> HomePhase.Plan
+            lastPlan != null && uiState.isRetrying -> HomePhase.Plan
             else -> HomePhase.Idle
         }
         Crossfade(

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
@@ -17,6 +17,7 @@ import fr.bsodium.cron.session.SessionRepository
 import fr.bsodium.cron.session.db.CronDatabase
 import fr.bsodium.cron.session.db.toModel
 import fr.bsodium.cron.session.model.ActionType
+import fr.bsodium.cron.session.model.SessionStatus
 import fr.bsodium.cron.session.model.EventData
 import fr.bsodium.cron.session.model.Instruction
 import fr.bsodium.cron.session.model.SessionEvent
@@ -192,7 +193,10 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                 streamingTurnIndex = streaming?.takeIf { it.sessionId == sessionId }?.turnIndex,
             )
         } else null
-        val allSessions = listOfNotNull(currentSession) + history
+        val dedupedHistory = if (currentSession != null) {
+            history.filter { it.sessionId != currentSession.sessionId }
+        } else history
+        val allSessions = listOfNotNull(currentSession) + dedupedHistory
         buildTimeline(allSessions)
     }.flowOn(Dispatchers.Default)
 
@@ -250,7 +254,6 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     private fun loadRecentHistory() {
         viewModelScope.launch(Dispatchers.IO) {
             val currentId = db.sessionDao().findCurrent()?.id
-                ?: db.sessionDao().findPaginated(1, 0).firstOrNull()?.id
             val page = timelineRepo.loadHistory(
                 excludeSessionId = currentId,
                 limit = HISTORY_LOAD_SIZE,
@@ -316,6 +319,15 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
     init {
         loadRecentHistory()
+
+        viewModelScope.launch {
+            sessionFlow
+                .map { it?.status }
+                .distinctUntilChanged()
+                .collect { status ->
+                    if (status == SessionStatus.Complete.name) loadRecentHistory()
+                }
+        }
 
         // Drive the "working" flag and the failure banner off the real WorkManager turn, not a fixed
         // delay: a tap sets isRetrying true optimistically; this clears it when the turn reaches a

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -192,6 +192,58 @@ A detail screen wanting the card effect wraps its scaffold in `PredictiveBackCar
 `SettingsDetailScaffold`), and its parent screen should be cheap to render a second time (see §3's
 stateless-screen note).
 
+## 6. Stateful screens — the Home pattern
+
+When the parent screen is **stateful** (ViewModel-backed flows, markdown parsing, SubcomposeLayout probes,
+font resolution), rendering a second instance as `parentContent` — like Settings does — is not viable: you'd
+need to hoist all state or snapshot the composition, and the cost is not "free" the way a static category
+list is. Home's plan-detail navigation solves this differently:
+
+**Local state, not NavHost.** Plan detail is managed via `detailKey: PlanDetailKey?` in `HomeScreen`.
+`HomeRootContent` is always composed in a `Box` behind the detail. When `detailKey` is set,
+`PredictiveBackCard` overlays on top — its scrim naturally dims the live home during the gesture. No
+snapshot, no second instance needed.
+
+```kotlin
+Box(Modifier.fillMaxSize()) {
+    HomeRootContent(…)                                  // always composed
+
+    detailKey?.let { key ->
+        Box(Modifier.graphicsLayer { translationX = enterOffset * size.width }) {
+            PredictiveBackCard(onBack = { detailKey = null }) { animatedBack ->
+                PlanDetailScreen(…, onBack = animatedBack)
+            }
+        }
+    }
+}
+```
+
+**Forward entrance** uses `animateFloatAsState` with `motionScheme.defaultSpatialSpec()` to slide the detail
+in from the right — the same visual direction as the Settings push, but driven by Compose state rather than
+NavHost transitions (because NavHost isn't involved).
+
+**Why the `PredictiveBackCard` has no `parentContent` here:** with the home always composed behind, the
+card's scrim reveals the live home directly. `parentContent` would add a second stateful instance.
+
+### What was tried and why it failed
+
+Three approaches were attempted before arriving at the always-composed solution:
+
+1. **Navigation 3 `NavDisplay`** — registers a `NavigationBackHandler` (from `androidx.navigationevent`)
+   that intercepts the back gesture even with `None togetherWith None` transitions. It also corrupts
+   GraphicsLayer snapshots via its exit animation. Abandoned entirely.
+
+2. **`rememberGraphicsLayer()` snapshot** — `drawWithContent { record(); drawLayer() }` to capture the home
+   screen as a bitmap during the back gesture. Child render nodes are destroyed when the composable leaves
+   composition, making the display list stale — `drawLayer()` renders nothing.
+
+3. **Conditional composition** — `if (detailKey == null) { HomeRootContent(…) }`. Causes a layout flash on
+   return: `mutableIntStateOf(0)` values (`cardFullHeightPx`, `greetingHeightPx`) reset when the composable
+   re-enters composition, so the alarm card jumps for a frame.
+
+The working solution is the simplest. First-composition is expensive but ongoing recomposition is cheap, so
+keeping the home composed behind the detail costs nothing.
+
 ## Verifying
 
 Predictive back's *in-progress* (drag) animation needs **API 34+**; on older devices and the system back


### PR DESCRIPTION
## Summary

- Drop `!resting` guards on `homePhase` so the timeline stays visible after the alarm is dismissed (session Complete) — `HomeIdleContent` only shows when there's genuinely no plan
- Fix `loadRecentHistory()`: remove fallback that excluded the just-completed session, add reactive reload when session status changes to Complete, deduplicate sessions in `timelineFlow`
- Document the Home stateful-screen pattern in `docs/navigation.md` §6: why local state + always-composed `PredictiveBackCard` (not NavHost), and the three failed approaches (Nav 3, GraphicsLayer snapshot, conditional composition)

Refs #136

## Test plan

- [ ] Dismiss alarm → homepage should still show the timeline with all iterations/events
- [ ] Idle screen should only appear before the first evening plan trigger (no prior session)
- [ ] FAB label/icon correct in both resting and active states
- [ ] History tab still works, no duplicate items in the timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)