### PR TITLE
chore: add Roborazzi for agent visual verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,11 +137,20 @@ Co-locate at file bottom by default. Split to a sibling `*Previews.kt` when mock
 ## Workflow
 
 - Concise responses, no celebration paragraphs, no end-of-turn "what I did" recaps — the diff is the recap.
-- Before claiming a UI task is done, build the app and visually confirm on a device or emulator. Type-checking is not feature-checking. Use:
+- **Visually verify UI changes with Roborazzi** — read `docs/screenshot-testing.md` for full details. After modifying a composable, capture a screenshot to confirm it renders correctly:
+  1. If a `*ScreenshotTest.kt` already exists for the component, run it:
+     ```sh
+     JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" \
+       ./gradlew :app:recordRoborazziDebug --tests 'fully.qualified.TestClass'
+     ```
+  2. If not, write a minimal one: call the composable with deterministic data inside `CronTheme`, then `composeTestRule.onRoot().captureRoboImage()`. Follow the pattern in existing `*ScreenshotTest.kt` files.
+  3. Read the generated PNG from `app/build/outputs/roborazzi/` to inspect the result. Iterate until the rendering matches intent.
+
+  Type-checking is not feature-checking — a green build does not mean the UI is correct.
+- Build and lint must also pass before declaring a UI task done. CI fails on lint **errors** (e.g. `UnusedMaterial3ScaffoldPaddingParameter`). An intentionally-ignored Scaffold padding parameter in an edge-to-edge layout needs `@Suppress("UnusedMaterial3ScaffoldPaddingParameter")` on the enclosing function.
   ```sh
-  JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:assembleDebug
+  JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:assembleDebug :app:lintDebug
   ```
-- CI runs `:app:lintDebug` and fails the build on lint **errors** (not warnings) — e.g. `UnusedMaterial3ScaffoldPaddingParameter`. Run `./gradlew :app:lintDebug` alongside `assembleDebug` before declaring a UI task done; `assembleDebug` passing locally is not enough. An intentionally-ignored Scaffold padding parameter in an edge-to-edge layout needs `@Suppress("UnusedMaterial3ScaffoldPaddingParameter")` on the enclosing function.
 - If a task spans 3+ steps, use TaskCreate to track them and mark `completed` as soon as each is done — don't batch.
 - **Branch before touching any file.** At the start of every task, create a fresh branch from `main` (or the appropriate base) and never commit directly to `main`. Name it using the standard prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `style/`, matching the project's commit-message convention.
 - **Commit incrementally.** Commit at each logical milestone — at minimum one commit per completed TaskCreate task — rather than staging everything in a single commit at the end. Each intermediate commit must build (`assembleDebug`) before moving on.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.roborazzi)
 }
 
 // Derive version from git tags so it stays in sync automatically.
@@ -178,6 +179,9 @@ dependencies {
     testImplementation(libs.androidx.work.testing)
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(libs.roborazzi)
+    testImplementation(libs.roborazzi.compose)
+    testImplementation(libs.roborazzi.junit.rule)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/test/java/fr/bsodium/cron/ui/components/CronFloatingNavScreenshotTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/components/CronFloatingNavScreenshotTest.kt
@@ -1,0 +1,48 @@
+package fr.bsodium.cron.ui.components
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.bsodium.cron.ui.theme.CronTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+@Suppress("DEPRECATION")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@RunWith(RobolectricTestRunner::class)
+class CronFloatingNavScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun home_tab_selected_with_fab() {
+        composeTestRule.setContent {
+            CronTheme {
+                CronFloatingNav(
+                    currentRoute = "home",
+                    onNavigate = {},
+                    fabAction = FabAction(onClick = {}),
+                )
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Test
+    fun history_tab_selected_no_fab() {
+        composeTestRule.setContent {
+            CronTheme {
+                CronFloatingNav(
+                    currentRoute = "history",
+                    onNavigate = {},
+                    fabAction = null,
+                )
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCardScreenshotTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCardScreenshotTest.kt
@@ -1,0 +1,38 @@
+package fr.bsodium.cron.ui.screens.home.components
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.bsodium.cron.ui.theme.CronTheme
+import kotlinx.datetime.LocalTime
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+@Suppress("DEPRECATION")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@RunWith(RobolectricTestRunner::class)
+class NextAlarmCardScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun alarm_set() {
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            CronTheme {
+                NextAlarmCard(
+                    dateLabel = "Friday 22",
+                    alarmTime = LocalTime(6, 40),
+                    sessionDate = null,
+                    sleepDurationLabel = null,
+                    sleepSegments = emptyList(),
+                )
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/settings/components/SwitchRowScreenshotTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/settings/components/SwitchRowScreenshotTest.kt
@@ -1,0 +1,50 @@
+package fr.bsodium.cron.ui.screens.settings.components
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.bsodium.cron.ui.theme.CronTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+@Suppress("DEPRECATION")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@RunWith(RobolectricTestRunner::class)
+class SwitchRowScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun switch_on() {
+        composeTestRule.setContent {
+            CronTheme {
+                SwitchRow(
+                    title = "Haptic feedback",
+                    subtitle = "Subtle ticks while the assistant writes",
+                    checked = true,
+                    onCheckedChange = {},
+                )
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Test
+    fun switch_off() {
+        composeTestRule.setContent {
+            CronTheme {
+                SwitchRow(
+                    title = "Haptic feedback",
+                    subtitle = "Subtle ticks while the assistant writes",
+                    checked = false,
+                    onCheckedChange = {},
+                )
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.roborazzi) apply false
 }

--- a/docs/screenshot-testing.md
+++ b/docs/screenshot-testing.md
@@ -1,0 +1,69 @@
+# Screenshot testing with Roborazzi
+
+Roborazzi renders `@Composable` functions to PNG on the host JVM via Robolectric — no emulator or device needed. Agents use it to visually verify UI changes from the CLI.
+
+## Why Roborazzi (and when to migrate)
+
+The project already runs Robolectric with `@GraphicsMode(NATIVE)`. Roborazzi hooks into that same pipeline, so there's no second graphics renderer to maintain (unlike Paparazzi's standalone Layoutlib). Google's official Compose Screenshot Testing plugin is the planned long-term replacement once it exits experimental status and supports `private` previews.
+
+## Agent workflow
+
+**Record baselines** (after accepting a UI change):
+
+```sh
+JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" \
+  ./gradlew :app:recordRoborazziDebug
+```
+
+**Compare against baselines** (check for regressions):
+
+```sh
+JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" \
+  ./gradlew :app:compareRoborazziDebug
+```
+
+**Verify** (CI — same as compare, fails on diff):
+
+```sh
+./gradlew :app:verifyRoborazziDebug
+```
+
+## Where PNGs land
+
+All output goes to `app/build/outputs/roborazzi/` (gitignored). The agent workflow is record-on-demand: capture before a change, make the change, compare, read diffs. No committed baselines needed for this workflow.
+
+If CI regression testing is added later, configure `roborazzi.output.dir` to a source-tracked directory and commit the baselines.
+
+## Adding a screenshot test
+
+1. Create a test in the same package as the composable under test.
+2. Use the standard test annotations and `createComposeRule()`.
+3. Call the composable directly with deterministic data — don't call the `@Preview` function (they're `private`).
+4. Capture with `composeTestRule.onRoot().captureRoboImage()`.
+
+```kotlin
+@Suppress("DEPRECATION")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@RunWith(RobolectricTestRunner::class)
+class MyComponentScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun default_state() {
+        composeTestRule.setContent {
+            CronTheme {
+                MyComponent(/* deterministic args */)
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}
+```
+
+For composables with live timers or animations, set `composeTestRule.mainClock.autoAdvance = false` before `setContent` to prevent the test rule from waiting forever for idle.
+
+## JDK consistency
+
+Robolectric renders fonts differently across JDK versions. Record reference images on the same JDK that CI uses to avoid spurious diffs. The project uses the Android Studio bundled JBR.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ robolectric = "4.14.1"
 mockk = "1.13.13"
 turbine = "1.2.0"
 androidxTestCore = "1.6.1"
+roborazzi = "1.62.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -76,9 +77,13 @@ mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "workRuntimeKtx" }
+roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", version.ref = "roborazzi" }
+roborazzi-compose = { group = "io.github.takahirom.roborazzi", name = "roborazzi-compose", version.ref = "roborazzi" }
+roborazzi-junit-rule = { group = "io.github.takahirom.roborazzi", name = "roborazzi-junit-rule", version.ref = "roborazzi" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }


### PR DESCRIPTION
## Summary

- Integrate [Roborazzi](https://github.com/takahirom/roborazzi) for headless screenshot testing on the host JVM (no emulator needed)
- Add 3 sample screenshot tests covering `SwitchRow`, `CronFloatingNav`, and `NextAlarmCard`
- Add `docs/screenshot-testing.md` with agent workflow and test authoring guide

Chosen over Paparazzi (reuses existing Robolectric pipeline), Google's official plugin (still experimental), and compose-ai-tools (too young). Migration to Google's plugin planned once it hits stable.

## Test plan

- [x] `./gradlew :app:assembleDebug` passes
- [x] `./gradlew :app:testDebugUnitTest` passes (existing + new tests)
- [x] `./gradlew :app:lintDebug` passes
- [x] `./gradlew :app:recordRoborazziDebug` generates 5 PNGs
- [x] Visual inspection of generated PNGs confirms correct rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)