### PR TITLE
fix: sleep-detection & toggle audit (card contradiction, false sleep, plan storm, dead toggle)

### DIFF
--- a/app/src/debug/java/fr/bsodium/cron/debug/SleepTestPrefs.kt
+++ b/app/src/debug/java/fr/bsodium/cron/debug/SleepTestPrefs.kt
@@ -1,0 +1,19 @@
+package fr.bsodium.cron.debug
+
+import android.content.Context
+
+/** DEBUG-ONLY. Persists sleep-detection test toggles across process restarts. */
+class SleepTestPrefs(context: Context) {
+
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /** When on, the onset/rearm thresholds collapse to seconds so the chain is testable instantly. */
+    var fastOnset: Boolean
+        get() = prefs.getBoolean(KEY_FAST_ONSET, false)
+        set(value) { prefs.edit().putBoolean(KEY_FAST_ONSET, value).apply() }
+
+    companion object {
+        private const val PREFS_NAME = "sleep_test"
+        private const val KEY_FAST_ONSET = "fast_onset"
+    }
+}

--- a/app/src/debug/java/fr/bsodium/cron/sensors/SleepTuning.kt
+++ b/app/src/debug/java/fr/bsodium/cron/sensors/SleepTuning.kt
@@ -1,0 +1,19 @@
+package fr.bsodium.cron.sensors
+
+import android.content.Context
+import fr.bsodium.cron.debug.SleepTestPrefs
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * DEBUG variant — collapses the sleep-onset/rearm thresholds to seconds when the developer
+ * "fast onset" toggle is on, so the detection chain is testable without waiting 20 minutes.
+ */
+object SleepTuning {
+    fun onsetThreshold(context: Context): Duration =
+        if (SleepTestPrefs(context).fastOnset) 10.seconds else 20.minutes
+
+    fun rearmThreshold(context: Context): Duration =
+        if (SleepTestPrefs(context).fastOnset) 5.seconds else 15.minutes
+}

--- a/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
@@ -23,7 +23,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import fr.bsodium.cron.debug.MockApiPrefs
+import fr.bsodium.cron.debug.SleepTestPrefs
+import fr.bsodium.cron.service.SleepSessionService
+import fr.bsodium.cron.session.SessionFsm
 import fr.bsodium.cron.session.SessionRepository
+import fr.bsodium.cron.session.model.ActivityType
 import fr.bsodium.cron.session.model.EventData
 import fr.bsodium.cron.session.model.SessionEvent
 import fr.bsodium.cron.session.model.SignalConfidence
@@ -34,6 +38,7 @@ import fr.bsodium.cron.ui.screens.settings.components.SwitchRow
 import fr.bsodium.cron.ui.theme.Spacing
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
 import kotlin.time.Duration.Companion.minutes
 
 @Composable
@@ -41,6 +46,8 @@ fun DeveloperSettingsScreen(onBack: () -> Unit) {
     val context = LocalContext.current
     val prefs = remember { MockApiPrefs(context) }
     var mockEnabled by remember { mutableStateOf(prefs.isEnabled) }
+    val sleepPrefs = remember { SleepTestPrefs(context) }
+    var fastOnset by remember { mutableStateOf(sleepPrefs.fastOnset) }
     var showClearDialog by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
@@ -54,6 +61,39 @@ fun DeveloperSettingsScreen(onBack: () -> Unit) {
                 mockEnabled = enabled
             },
         )
+        SwitchRow(
+            title = "Fast sleep onset (10s)",
+            subtitle = "Collapse onset/rearm thresholds to seconds (restart the session to apply)",
+            checked = fastOnset,
+            onCheckedChange = { on ->
+                sleepPrefs.fastOnset = on
+                fastOnset = on
+            },
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Start sleep session",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                Text(
+                    text = "Bootstrap a session and start the sensor monitor now",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            TextButton(onClick = {
+                context.startService(
+                    SleepSessionService.eveningPlanIntent(context, TimeZone.currentSystemDefault().id),
+                )
+            }) {
+                Text("Start")
+            }
+        }
         FsmEventInjector(context, scope)
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -166,6 +206,18 @@ private fun FsmEventInjector(
     scope: kotlinx.coroutines.CoroutineScope,
 ) {
     val repo = remember { SessionRepository(context) }
+    var driveFsm by remember { mutableStateOf(false) }
+
+    // Append-only records the event; FSM mode routes through SessionFsm.onEvent so transitions,
+    // the auto-plan gate (Bug 4) and the AI cooldown (Bug 3) actually run.
+    val inject: suspend (SessionEvent) -> Boolean = { event ->
+        if (driveFsm) {
+            SessionFsm(context, repo).onEvent(event) != null
+        } else {
+            val session = repo.findCurrent()
+            if (session == null) false else { repo.appendEvent(session.id, event); true }
+        }
+    }
 
     Column {
         Text(
@@ -173,10 +225,11 @@ private fun FsmEventInjector(
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onBackground,
         )
-        Text(
-            text = "Record events in the current session without FSM transitions",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        SwitchRow(
+            title = "Drive through FSM (transitions + AI)",
+            subtitle = "Route injected events through SessionFsm.onEvent — exercises cooldown + auto-plan gating",
+            checked = driveFsm,
+            onCheckedChange = { driveFsm = it },
         )
         FlowRow(
             modifier = Modifier.padding(top = Spacing.sm),
@@ -184,40 +237,43 @@ private fun FsmEventInjector(
             verticalArrangement = Arrangement.spacedBy(Spacing.sm),
         ) {
             InjectButton("Sleep Onset", scope) {
-                val session = repo.findCurrent() ?: return@InjectButton false
-                repo.appendEvent(session.id, SessionEvent(
+                inject(SessionEvent(
                     trigger = TriggerType.SleepOnset,
                     timestamp = Clock.System.now(),
                     data = EventData.SleepOnset(screenOffSince = Clock.System.now(), rearm = false),
                 ))
-                true
+            }
+            InjectButton("Mid Sleep Activity", scope) {
+                inject(SessionEvent(
+                    trigger = TriggerType.MidSleepActivity,
+                    timestamp = Clock.System.now(),
+                    data = EventData.MidSleepActivity(
+                        activityType = ActivityType.Still,
+                        screenOn = false,
+                        durationSeconds = 0,
+                    ),
+                ))
             }
             InjectButton("Alarm Dismissed", scope) {
-                val session = repo.findCurrent() ?: return@InjectButton false
-                repo.appendEvent(session.id, SessionEvent(
+                inject(SessionEvent(
                     trigger = TriggerType.AlarmDismissed,
                     timestamp = Clock.System.now(),
                     data = EventData.Empty,
                 ))
-                true
             }
             InjectButton("Alarm Snoozed", scope) {
-                val session = repo.findCurrent() ?: return@InjectButton false
-                repo.appendEvent(session.id, SessionEvent(
+                inject(SessionEvent(
                     trigger = TriggerType.AlarmSnoozed,
                     timestamp = Clock.System.now(),
                     data = EventData.Empty,
                 ))
-                true
             }
             InjectButton("Out Of Bed", scope) {
-                val session = repo.findCurrent() ?: return@InjectButton false
-                repo.appendEvent(session.id, SessionEvent(
+                inject(SessionEvent(
                     trigger = TriggerType.OutOfBedConfirmed,
                     timestamp = Clock.System.now(),
                     data = EventData.OutOfBedConfirmed(evidence = listOf("debug injection")),
                 ))
-                true
             }
         }
     }

--- a/app/src/main/java/fr/bsodium/cron/sensors/AmbientLightReader.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/AmbientLightReader.kt
@@ -1,0 +1,52 @@
+package fr.bsodium.cron.sensors
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.util.Log
+
+/**
+ * Keeps the latest ambient-light reading so sleep-onset detection can require a *dark* room — the
+ * signal that tells a phone idle on a lit couch apart from one on a bedside table (see Google Clock's
+ * "motionless in a dark room"). Push-based: registers a low-power [Sensor.TYPE_LIGHT] listener for the
+ * service's lifetime.
+ */
+class AmbientLightReader(context: Context) {
+
+    private val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    private val lightSensor: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
+
+    @Volatile
+    private var latestLux: Float? = null
+
+    private val listener = object : SensorEventListener {
+        override fun onSensorChanged(event: SensorEvent) {
+            latestLux = event.values.firstOrNull()
+        }
+
+        override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+    }
+
+    fun start() {
+        if (lightSensor == null) {
+            Log.w(TAG, "No ambient-light sensor — dark gate will pass by default")
+            return
+        }
+        sensorManager.registerListener(listener, lightSensor, SensorManager.SENSOR_DELAY_NORMAL)
+    }
+
+    fun stop() {
+        sensorManager.unregisterListener(listener)
+    }
+
+    /** True when the room is dark — or when there's no light sensor (don't block onset on missing hardware). */
+    fun isDark(): Boolean = (latestLux ?: return true) < DARK_LUX_THRESHOLD
+
+    companion object {
+        private const val TAG = "AmbientLightReader"
+        /** A dark bedroom reads only a few lux; dim indoor lighting is tens+. Calibration knob. */
+        private const val DARK_LUX_THRESHOLD = 10f
+    }
+}

--- a/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
@@ -38,6 +38,7 @@ class ScreenStateMonitor(
     private val sink: SensorEventSink,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob()),
     private val sleepOnsetThreshold: Duration = 20.minutes,
+    private val rearmThreshold: Duration = REARM_ONSET_THRESHOLD,
     private val lightReader: AmbientLightReader = AmbientLightReader(context),
 ) {
 
@@ -88,7 +89,7 @@ class ScreenStateMonitor(
      * the user has already proven they can fall asleep tonight, and we want to catch a second sleep
      * onset quickly so the AI can re-arm the alarm without losing too much window.
      */
-    fun rearm(threshold: Duration = REARM_ONSET_THRESHOLD) {
+    fun rearm(threshold: Duration = rearmThreshold) {
         sleepOnsetEmitted = false
         isRearm = true
         screenOffSince = if (!powerManager.isInteractive) Clock.System.now() else null

--- a/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
@@ -4,38 +4,41 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.BatteryManager
 import android.os.PowerManager
 import android.util.Log
-import fr.bsodium.cron.session.model.ActivityType
 import fr.bsodium.cron.session.model.EventData
 import fr.bsodium.cron.session.model.SessionEvent
 import fr.bsodium.cron.session.model.TriggerType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 /**
- * Listens to ACTION_SCREEN_OFF / SCREEN_ON / USER_PRESENT broadcasts and
- * synthesizes two derived events:
+ * Listens to ACTION_SCREEN_OFF / SCREEN_ON / USER_PRESENT broadcasts and synthesizes:
  *
- *  - [TriggerType.SleepOnset] when the screen has been off continuously
- *    for [sleepOnsetThreshold].
- *  - [TriggerType.MidSleepActivity] when the screen turns on mid-session
- *    (during MONITORING_SLEEP).
+ *  - [TriggerType.SleepOnset] when the screen has been off long enough **and** the room is dark
+ *    (Google Clock's "motionless in a dark room"). Uncharged devices need a longer sustained window,
+ *    since a phone set down somewhere is more likely than one charging at a bedside. Conditions are
+ *    re-checked while the screen stays off, so onset still fires once the lights go out.
+ *  - [TriggerType.OutOfBedConfirmed] on a genuine unlock mid-session — the strongest "awake" signal
+ *    we have, so a pickup wakes the session instead of firing a plan on every handle.
  *
- * Receivers MUST be registered dynamically — static registration of
- * ACTION_SCREEN_ON / OFF has been blocked since Android 8.
+ * Receivers MUST be registered dynamically — static registration of ACTION_SCREEN_ON / OFF has been
+ * blocked since Android 8.
  */
 class ScreenStateMonitor(
     private val context: Context,
     private val sink: SensorEventSink,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob()),
-    private val sleepOnsetThreshold: kotlin.time.Duration = 20.minutes,
+    private val sleepOnsetThreshold: Duration = 20.minutes,
+    private val lightReader: AmbientLightReader = AmbientLightReader(context),
 ) {
 
     private var screenOffSince: Instant? = null
@@ -43,20 +46,21 @@ class ScreenStateMonitor(
     private var pendingOnset: Job? = null
     /** True after [rearm] has been called; consumed by the next SleepOnset emission. */
     private var isRearm: Boolean = false
-    private var currentOnsetThreshold: kotlin.time.Duration = sleepOnsetThreshold
     private val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    private val batteryManager = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
 
     private val receiver = object : BroadcastReceiver() {
         override fun onReceive(ctx: Context, intent: Intent) {
             when (intent.action) {
                 Intent.ACTION_SCREEN_OFF -> onScreenOff()
                 Intent.ACTION_SCREEN_ON -> onScreenOn()
-                Intent.ACTION_USER_PRESENT -> Unit // unlock; treat like SCREEN_ON
+                Intent.ACTION_USER_PRESENT -> onUserPresent()
             }
         }
     }
 
     fun start() {
+        lightReader.start()
         // Seed from the current state — service might start with the screen already off.
         if (!powerManager.isInteractive) {
             screenOffSince = Clock.System.now()
@@ -74,20 +78,19 @@ class ScreenStateMonitor(
     fun stop() {
         runCatching { context.unregisterReceiver(receiver) }
             .onFailure { Log.w(TAG, "unregisterReceiver failed", it) }
+        lightReader.stop()
         pendingOnset?.cancel()
         Log.i(TAG, "ScreenStateMonitor stopped")
     }
 
     /**
-     * Resets sleep-onset latch after the FSM moves to AWAKE. Uses a shorter
-     * threshold by default since the user has already proven they can fall
-     * asleep tonight, and we want to catch a second sleep onset quickly so
-     * the AI can re-arm the alarm without losing too much window.
+     * Resets sleep-onset latch after the FSM moves to AWAKE. Uses a shorter threshold by default since
+     * the user has already proven they can fall asleep tonight, and we want to catch a second sleep
+     * onset quickly so the AI can re-arm the alarm without losing too much window.
      */
-    fun rearm(threshold: kotlin.time.Duration = REARM_ONSET_THRESHOLD) {
+    fun rearm(threshold: Duration = REARM_ONSET_THRESHOLD) {
         sleepOnsetEmitted = false
         isRearm = true
-        currentOnsetThreshold = threshold
         screenOffSince = if (!powerManager.isInteractive) Clock.System.now() else null
         scheduleOnsetCheck(threshold)
     }
@@ -102,55 +105,83 @@ class ScreenStateMonitor(
         val offDuration = Clock.System.now() - offSince
         screenOffSince = null
         pendingOnset?.cancel()
-
-        if (sleepOnsetEmitted) {
-            // Already-sleeping → screen on means activity. Emit MidSleepActivity.
-            scope.launch {
-                sink.emit(
-                    SessionEvent(
-                        trigger = TriggerType.MidSleepActivity,
-                        timestamp = Clock.System.now(),
-                        data = EventData.MidSleepActivity(
-                            activityType = ActivityType.Still,
-                            screenOn = true,
-                            durationSeconds = 0, // populated when screen turns off again
-                        ),
-                    )
-                )
-            }
-        }
         Log.d(TAG, "Screen on after ${offDuration.inWholeSeconds}s off")
     }
 
-    private fun scheduleOnsetCheck(threshold: kotlin.time.Duration = sleepOnsetThreshold) {
+    /**
+     * A genuine unlock is our strongest "awake" signal — the user is handling the phone, not stirring
+     * in their sleep. If we'd latched sleep, treat it as getting out of bed (one event → FSM Awake →
+     * [rearm]) rather than firing a plan on every pickup.
+     */
+    private fun onUserPresent() {
+        screenOffSince = null
+        pendingOnset?.cancel()
+        if (!sleepOnsetEmitted) return
+        sleepOnsetEmitted = false
+        scope.launch {
+            sink.emit(
+                SessionEvent(
+                    trigger = TriggerType.OutOfBedConfirmed,
+                    timestamp = Clock.System.now(),
+                    data = EventData.OutOfBedConfirmed(evidence = listOf("device_unlocked")),
+                )
+            )
+        }
+        Log.i(TAG, "User present while asleep — out of bed")
+    }
+
+    private fun scheduleOnsetCheck(threshold: Duration = sleepOnsetThreshold) {
         pendingOnset?.cancel()
         pendingOnset = scope.launch {
             kotlinx.coroutines.delay(threshold)
-            val since = screenOffSince ?: return@launch
-            if (sleepOnsetEmitted) return@launch
-            val onsetThresholdMet = (Clock.System.now() - since) >= threshold
-            if (onsetThresholdMet) {
-                sleepOnsetEmitted = true
-                val wasRearm = isRearm
-                isRearm = false
-                sink.emit(
-                    SessionEvent(
-                        trigger = TriggerType.SleepOnset,
-                        timestamp = Clock.System.now(),
-                        data = EventData.SleepOnset(
-                            screenOffSince = since,
-                            rearm = wasRearm,
-                        ),
-                    )
-                )
-                Log.i(TAG, "Sleep onset emitted at ${Clock.System.now()} (rearm=$wasRearm)")
+            while (isActive) {
+                val since = screenOffSince ?: return@launch
+                if (sleepOnsetEmitted) return@launch
+                val screenOff = Clock.System.now() - since
+                if (shouldEmitOnset(screenOff, threshold, lightReader.isDark(), batteryManager.isCharging)) {
+                    emitOnset(since)
+                    return@launch
+                }
+                kotlinx.coroutines.delay(ONSET_RECHECK_INTERVAL)
             }
         }
+    }
+
+    private suspend fun emitOnset(since: Instant) {
+        sleepOnsetEmitted = true
+        val wasRearm = isRearm
+        isRearm = false
+        sink.emit(
+            SessionEvent(
+                trigger = TriggerType.SleepOnset,
+                timestamp = Clock.System.now(),
+                data = EventData.SleepOnset(screenOffSince = since, rearm = wasRearm),
+            )
+        )
+        Log.i(TAG, "Sleep onset emitted at ${Clock.System.now()} (rearm=$wasRearm)")
     }
 
     companion object {
         private const val TAG = "ScreenStateMonitor"
         /** Shorter threshold for re-arm; user has already proven they sleep tonight. */
         private val REARM_ONSET_THRESHOLD = 15.minutes
+        /** How often to re-test the dark/charging gate while the screen stays off. */
+        private val ONSET_RECHECK_INTERVAL = 5.minutes
+
+        /**
+         * Pure onset decision — unit-testable. Sleep onset requires a dark room; an uncharged device
+         * (more likely just set down than in bed) must stay dark + idle for twice as long. Conservative
+         * by design: missing an onset only delays an auto-replan, a false one risks a wrong wake + cost.
+         */
+        internal fun shouldEmitOnset(
+            screenOff: Duration,
+            baseThreshold: Duration,
+            isDark: Boolean,
+            isCharging: Boolean,
+        ): Boolean {
+            if (!isDark) return false
+            val required = if (isCharging) baseThreshold else baseThreshold * 2
+            return screenOff >= required
+        }
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
@@ -98,6 +98,7 @@ class ScreenStateMonitor(
 
     private fun onScreenOff() {
         screenOffSince = Clock.System.now()
+        Log.d(TAG, "Screen off — onset check scheduled (threshold=$sleepOnsetThreshold)")
         scheduleOnsetCheck()
     }
 

--- a/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
+++ b/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
@@ -23,6 +23,7 @@ import fr.bsodium.cron.sensors.ActivityRecognitionMonitor
 import fr.bsodium.cron.sensors.DebugSensorEventSink
 import fr.bsodium.cron.sensors.SensorEventSink
 import fr.bsodium.cron.sensors.ScreenStateMonitor
+import fr.bsodium.cron.sensors.SleepTuning
 import fr.bsodium.cron.session.SessionFsm
 import fr.bsodium.cron.session.SessionRepository
 import fr.bsodium.cron.session.model.EventData
@@ -91,7 +92,13 @@ class SleepSessionService : Service() {
         startForegroundService(includeLocation = eveningPlan)
 
         if (screenStateMonitor == null) {
-            screenStateMonitor = ScreenStateMonitor(applicationContext, fsmSink, serviceScope).also { it.start() }
+            screenStateMonitor = ScreenStateMonitor(
+                applicationContext,
+                fsmSink,
+                serviceScope,
+                sleepOnsetThreshold = SleepTuning.onsetThreshold(applicationContext),
+                rearmThreshold = SleepTuning.rearmThreshold(applicationContext),
+            ).also { it.start() }
         }
         if (activityRecognitionMonitor == null) {
             activityRecognitionMonitor = ActivityRecognitionMonitor(applicationContext, fsmSink, serviceScope).also { it.start() }

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -80,6 +80,9 @@ class SessionFsm(
         }
 
         if (shouldTriggerAi(event.trigger, nextStatus, session.lastAiCallAt)) {
+            // Stamp the trigger time before enqueueing so the cooldown is effective immediately —
+            // a burst of noisy events otherwise each slip through before the worker's tool sets it.
+            repository.markAiTriggered(session.id)
             repository.triggerAiTurn(session.id)
         }
 

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlin.time.Duration.Companion.minutes
 
@@ -78,7 +79,7 @@ class SessionFsm(
             onStatusChange(session, nextStatus)
         }
 
-        if (shouldTriggerAi(event.trigger, nextStatus)) {
+        if (shouldTriggerAi(event.trigger, nextStatus, session.lastAiCallAt)) {
             repository.triggerAiTurn(session.id)
         }
 
@@ -199,11 +200,6 @@ class SessionFsm(
         }
     }
 
-    private fun shouldTriggerAi(trigger: TriggerType, newStatus: SessionStatus): Boolean {
-        if (newStatus == SessionStatus.Complete) return false
-        return trigger in AI_TRIGGERS
-    }
-
     /**
      * Handle an alarm snooze, called from AlarmReceiver and bypassing the main
      * onEvent path. Returns true if AI was triggered for a replan, false if
@@ -246,5 +242,34 @@ class SessionFsm(
             TriggerType.CalendarChange,
             TriggerType.AlarmSnoozed,
         )
+
+        /** Triggers that recur on noise (screen-on, HC polls) and so are rate-limited by [AI_COOLDOWN]. */
+        private val THROTTLEABLE_TRIGGERS = setOf(
+            TriggerType.MidSleepActivity,
+            TriggerType.HcStageUpdate,
+        )
+
+        private val AI_COOLDOWN = 15.minutes
+
+        /**
+         * Whether an event should fire an AI turn. Pure (no IO) so it's unit-testable: a completed
+         * session never fires; only [AI_TRIGGERS] fire; and [THROTTLEABLE_TRIGGERS] are suppressed
+         * within [AI_COOLDOWN] of the last AI turn so noisy sensors can't storm paid calls.
+         */
+        internal fun shouldTriggerAi(
+            trigger: TriggerType,
+            newStatus: SessionStatus,
+            lastAiCallAt: Instant?,
+            now: Instant = Clock.System.now(),
+        ): Boolean {
+            if (newStatus == SessionStatus.Complete) return false
+            if (trigger !in AI_TRIGGERS) return false
+            if (trigger in THROTTLEABLE_TRIGGERS && lastAiCallAt != null &&
+                now - lastAiCallAt < AI_COOLDOWN
+            ) {
+                return false
+            }
+            return true
+        }
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -44,6 +44,14 @@ class SessionFsm(
      * session exists and the event cannot bootstrap one.
      */
     suspend fun onEvent(event: SessionEvent): String? = withContext(Dispatchers.IO) {
+        // Auto-plan off = full stand-down: drop every automatic event. A manual run (the "run one
+        // yourself" CTA) carries isManual and is exempt, so it still works with the toggle off.
+        if (!SettingsRepository(context).autoAlarmsEnabledNow() &&
+            (event.data as? EventData.EveningPlan)?.isManual != true
+        ) {
+            Log.d(TAG, "Auto-plan disabled — ignoring ${event.trigger}")
+            return@withContext null
+        }
         var current = repository.findCurrent()
         // A fresh evening plan for a new morning supersedes any session left unfinished from a prior day.
         if (event.trigger == TriggerType.EveningPlan && current != null && supersedeIfStale(current, event)) {

--- a/app/src/main/java/fr/bsodium/cron/session/SessionRepository.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionRepository.kt
@@ -125,6 +125,17 @@ class SessionRepository(private val context: Context) {
         ))
     }
 
+    /**
+     * Stamps [lastAiCallAt] at the moment an AI turn is *triggered* (not when a tool later runs), so the
+     * cooldown gate sees it synchronously and a burst of noisy events can't each enqueue a turn before the
+     * first one's tool writes the timestamp. Also clears the "settings changed since plan" reminder.
+     */
+    suspend fun markAiTriggered(sessionId: String) {
+        val entity = db.sessionDao().findById(sessionId) ?: return
+        val now = Clock.System.now().toEpochMilliseconds()
+        db.sessionDao().update(entity.copy(lastAiCallAt = now, updatedAt = now))
+    }
+
     suspend fun updateInstruction(sessionId: String, instruction: Instruction) {
         val entity = db.sessionDao().findById(sessionId) ?: return
         val now = Clock.System.now().toEpochMilliseconds()

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/AutoAlarmArming.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/AutoAlarmArming.kt
@@ -1,0 +1,43 @@
+package fr.bsodium.cron.ui.screens.home
+
+import fr.bsodium.cron.alarm.AlarmScheduler
+import fr.bsodium.cron.alarm.HardLatestScheduler
+import fr.bsodium.cron.session.model.ActionType
+import fr.bsodium.cron.session.model.SleepSession
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atTime
+import kotlinx.datetime.toInstant
+
+/**
+ * Re-applies a session's already-decided alarm + hard-latest floor to AlarmManager when auto-plan is
+ * toggled back on (symmetry with the OFF teardown). Each target is gated on still being AHEAD of now,
+ * so re-enabling after the wake window never rings instantly (a past setAlarmClock fires at once, and
+ * the AI alarm would clamp to now + a minute).
+ */
+internal fun rearmSessionAlarms(
+    session: SleepSession,
+    alarmScheduler: AlarmScheduler,
+    hardLatestScheduler: HardLatestScheduler,
+) {
+    val tz = TimeZone.of(session.timezone)
+    val now = Clock.System.now()
+    if (session.date.atTime(session.plan.hardLatest).toInstant(tz) > now) {
+        hardLatestScheduler.arm(session.plan.hardLatest, session.date, tz, session.id)
+    }
+    val instr = session.currentInstruction
+    val alarmTime = instr.alarmTime
+    if (instr.action == ActionType.SetAlarm && alarmTime != null) {
+        val requested = session.date.atTime(alarmTime).toInstant(tz)
+        if (requested > now) {
+            alarmScheduler.schedule(
+                requested = requested,
+                hardLatest = session.plan.hardLatest,
+                sessionDate = session.date,
+                timezone = tz,
+                label = instr.reason.ifBlank { "Cron Alarm" },
+                sessionId = session.id,
+            )
+        }
+    }
+}

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -228,10 +228,8 @@ private fun HomeRootContent(
         LaunchedEffect(displayPlan) { displayPlan?.let { lastPlan = it } }
         val homePhase = when {
             !uiState.initialized -> HomePhase.Loading
-            lastPlan != null && uiState.isRetrying -> HomePhase.Plan
-            // Spent alarm (passed/dismissed): rest on the onset card + next-plan line, not the stale thread.
-            resting -> HomePhase.Idle
             displayPlan != null -> HomePhase.Plan
+            lastPlan != null && uiState.isRetrying -> HomePhase.Plan
             else -> HomePhase.Idle
         }
         Crossfade(

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -228,8 +228,10 @@ private fun HomeRootContent(
         LaunchedEffect(displayPlan) { displayPlan?.let { lastPlan = it } }
         val homePhase = when {
             !uiState.initialized -> HomePhase.Loading
-            displayPlan != null -> HomePhase.Plan
             lastPlan != null && uiState.isRetrying -> HomePhase.Plan
+            // Spent alarm (passed/dismissed): rest on the onset card + next-plan line, not the stale thread.
+            resting -> HomePhase.Idle
+            displayPlan != null -> HomePhase.Plan
             else -> HomePhase.Idle
         }
         Crossfade(

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
@@ -16,6 +16,7 @@ import fr.bsodium.cron.session.SessionFsm
 import fr.bsodium.cron.session.SessionRepository
 import fr.bsodium.cron.session.db.CronDatabase
 import fr.bsodium.cron.session.db.toModel
+import fr.bsodium.cron.service.SleepSessionService
 import fr.bsodium.cron.session.model.ActionType
 import fr.bsodium.cron.session.model.SessionStatus
 import fr.bsodium.cron.session.model.EventData
@@ -308,6 +309,9 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                 }
             } else {
                 eveningPlanScheduler.cancel()
+                // Stop the monitor so sensors stop emitting — the FSM also drops automatic events, but
+                // tearing down the FGS is the actual stand-down the user asked for.
+                getApplication<Application>().startService(SleepSessionService.stopIntent(getApplication()))
                 repository.findCurrent()?.let { session ->
                     alarmScheduler.cancel(session.date)
                     hardLatestScheduler.clear(session.date)

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
@@ -281,31 +281,8 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             settings.setAutoAlarmsEnabled(enabled)
             if (enabled) {
                 eveningPlanScheduler.armNext()
-                // Re-arm what the current session already decided — toggling ON must make Android aware
-                // of the alarm again (symmetry with the OFF teardown below). Each target is gated on still
-                // being AHEAD: re-enabling after the wake window must not ring instantly (a past
-                // setAlarmClock fires at once, and the AI alarm would clamp to now + a minute).
-                repository.findCurrent()?.let { session ->
-                    val tz = TimeZone.of(session.timezone)
-                    val now = Clock.System.now()
-                    if (session.date.atTime(session.plan.hardLatest).toInstant(tz) > now) {
-                        hardLatestScheduler.arm(session.plan.hardLatest, session.date, tz, session.id)
-                    }
-                    val instr = session.currentInstruction
-                    val alarmTime = instr.alarmTime
-                    if (instr.action == ActionType.SetAlarm && alarmTime != null) {
-                        val requested = session.date.atTime(alarmTime).toInstant(tz)
-                        if (requested > now) {
-                            alarmScheduler.schedule(
-                                requested = requested,
-                                hardLatest = session.plan.hardLatest,
-                                sessionDate = session.date,
-                                timezone = tz,
-                                label = instr.reason.ifBlank { "Cron Alarm" },
-                                sessionId = session.id,
-                            )
-                        }
-                    }
+                repository.findCurrent()?.let {
+                    rearmSessionAlarms(it, alarmScheduler, hardLatestScheduler)
                 }
             } else {
                 eveningPlanScheduler.cancel()

--- a/app/src/main/java/fr/bsodium/cron/worker/CalendarChangeWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/CalendarChangeWorker.kt
@@ -27,6 +27,10 @@ class CalendarChangeWorker(
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result {
+        if (!SettingsRepository(applicationContext).autoAlarmsEnabledNow()) {
+            Log.d(TAG, "Auto-plan disabled — skipping calendar change check")
+            return Result.success()
+        }
         val repository = SessionRepository(applicationContext)
         val session = repository.findCurrent() ?: run {
             Log.d(TAG, "No active session — skipping calendar change check")

--- a/app/src/main/java/fr/bsodium/cron/worker/HealthConnectPollWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/HealthConnectPollWorker.kt
@@ -17,6 +17,7 @@ import fr.bsodium.cron.session.model.SleepSession
 import fr.bsodium.cron.session.model.SleepStage
 import fr.bsodium.cron.session.model.TriggerType
 import fr.bsodium.cron.settings.PollCheckpointStore
+import fr.bsodium.cron.settings.SettingsRepository
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime
@@ -43,6 +44,10 @@ class HealthConnectPollWorker(
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result {
+        if (!SettingsRepository(applicationContext).autoAlarmsEnabledNow()) {
+            Log.d(TAG, "Auto-plan disabled — skipping HC poll")
+            return Result.success()
+        }
         val reader = SleepStageReader(applicationContext)
         if (reader.availability() != SleepStageReader.Availability.Available) {
             return Result.success()

--- a/app/src/release/java/fr/bsodium/cron/sensors/SleepTuning.kt
+++ b/app/src/release/java/fr/bsodium/cron/sensors/SleepTuning.kt
@@ -1,0 +1,14 @@
+package fr.bsodium.cron.sensors
+
+import android.content.Context
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+/** RELEASE variant — production sleep-detection timings; no debug overrides. */
+object SleepTuning {
+    @Suppress("UNUSED_PARAMETER")
+    fun onsetThreshold(context: Context): Duration = 20.minutes
+
+    @Suppress("UNUSED_PARAMETER")
+    fun rearmThreshold(context: Context): Duration = 15.minutes
+}

--- a/app/src/test/java/fr/bsodium/cron/sensors/ScreenStateMonitorTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/sensors/ScreenStateMonitorTest.kt
@@ -1,0 +1,43 @@
+package fr.bsodium.cron.sensors
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.time.Duration.Companion.minutes
+
+class ScreenStateMonitorTest {
+
+    private val base = 20.minutes
+
+    @Test
+    fun never_fires_in_a_lit_room() {
+        assertFalse(
+            ScreenStateMonitor.shouldEmitOnset(base * 5, base, isDark = false, isCharging = true),
+        )
+    }
+
+    @Test
+    fun charging_and_dark_fires_at_base_threshold() {
+        assertTrue(
+            ScreenStateMonitor.shouldEmitOnset(base, base, isDark = true, isCharging = true),
+        )
+    }
+
+    @Test
+    fun charging_and_dark_below_threshold_does_not_fire() {
+        assertFalse(
+            ScreenStateMonitor.shouldEmitOnset(base - 1.minutes, base, isDark = true, isCharging = true),
+        )
+    }
+
+    @Test
+    fun uncharged_needs_double_the_window() {
+        // The face-down-on-a-table case: dark and idle, but not charging — must wait twice as long.
+        assertFalse(
+            ScreenStateMonitor.shouldEmitOnset(base, base, isDark = true, isCharging = false),
+        )
+        assertTrue(
+            ScreenStateMonitor.shouldEmitOnset(base * 2, base, isDark = true, isCharging = false),
+        )
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/session/SessionFsmTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/session/SessionFsmTest.kt
@@ -1,0 +1,58 @@
+package fr.bsodium.cron.session
+
+import fr.bsodium.cron.session.model.SessionStatus
+import fr.bsodium.cron.session.model.TriggerType
+import kotlinx.datetime.Instant
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.time.Duration.Companion.minutes
+
+class SessionFsmTest {
+
+    private val now = Instant.parse("2026-05-22T03:00:00Z")
+
+    @Test
+    fun completed_session_never_fires() {
+        assertFalse(
+            SessionFsm.shouldTriggerAi(TriggerType.SleepOnset, SessionStatus.Complete, null, now),
+        )
+    }
+
+    @Test
+    fun non_ai_trigger_never_fires() {
+        assertFalse(
+            SessionFsm.shouldTriggerAi(TriggerType.AlarmDismissed, SessionStatus.Monitoring, null, now),
+        )
+    }
+
+    @Test
+    fun state_changing_trigger_fires_even_right_after_a_turn() {
+        assertTrue(
+            SessionFsm.shouldTriggerAi(TriggerType.SleepOnset, SessionStatus.Monitoring, now, now),
+        )
+    }
+
+    @Test
+    fun throttleable_trigger_suppressed_within_cooldown() {
+        val lastCall = now - 5.minutes
+        assertFalse(
+            SessionFsm.shouldTriggerAi(TriggerType.MidSleepActivity, SessionStatus.Monitoring, lastCall, now),
+        )
+    }
+
+    @Test
+    fun throttleable_trigger_fires_after_cooldown() {
+        val lastCall = now - 20.minutes
+        assertTrue(
+            SessionFsm.shouldTriggerAi(TriggerType.MidSleepActivity, SessionStatus.Monitoring, lastCall, now),
+        )
+    }
+
+    @Test
+    fun throttleable_trigger_fires_when_no_prior_turn() {
+        assertTrue(
+            SessionFsm.shouldTriggerAi(TriggerType.MidSleepActivity, SessionStatus.Monitoring, null, now),
+        )
+    }
+}


### PR DESCRIPTION
Audit of bugs surfaced in real-world testing (two of them a cost/credit risk). Branched from `main` (includes the #139 card redesign). Each fix is its own commit; non-trivial decisions are covered by pure unit tests.

## Bug 4 — "Auto-plan" toggle did nothing
The toggle only gated the nightly scheduler; the sensor→AI path ignored it, so sleep/calendar/Health-Connect events kept firing paid AI turns with the switch off. OFF is now a **full stand-down**: stop the `SleepSessionService` (sensors stop), `SessionFsm.onEvent` drops every automatic event (manual runs carry `isManual` and stay exempt), and the calendar + HC workers early-return. Reuses the existing `autoAlarmsEnabledNow()` — no new setting. (`rearmSessionAlarms` extracted to keep `HomeViewModel` under the file-length cap.)

## Bug 3 — AI plan storm
Every screen-on while "asleep" fired a paid AI turn with no cooldown. Throttleable triggers (`MidSleepActivity`, `HcStageUpdate`) are now suppressed within 15 min of the last turn; state-changing triggers (onset, out-of-bed, plan, snooze) always pass. Decision extracted to a pure, unit-tested `SessionFsm.shouldTriggerAi`.

## Bug 2 — False sleep detection (standalone)
Onset was "screen off ≥ 20 min" alone, so an idle phone on a lit couch read as asleep. Adopted Google Clock's model (["motionless in a dark room"](https://support.google.com/clock/answer/9887159)) with on-device, permission-free signals:
- **Ambient light** (`TYPE_LIGHT`): onset requires a dark room — distinguishes a lit couch from a bedside table.
- **Charging booster**: an uncharged device (more likely set down than in bed) must stay dark + idle twice as long — cuts the face-down-on-a-table case. Conditions re-checked while the screen stays off.
- **Unlock = hard wake/reset**: `USER_PRESENT` emits `OutOfBedConfirmed` (→ Awake → rearm) instead of `MidSleepActivity`, so a pickup no longer fires a plan on every handle.

Decision logic is a pure, unit-tested `ScreenStateMonitor.shouldEmitOnset` — **no LLM, no learned model**; even Google's method fails on a face-down phone, so the cost guards (Bugs 3 & 4) are the real safety net and onset is deliberately conservative.

**Deferred hardening:** stationary (Activity Recognition) corroboration + an explicit bedtime-window gate, layered on the dark+charging core.

## Bug 1 — Alarm card contradiction (DEFERRED)
After the alarm fired, the digits greyed out while the greeting still said "Today, you'll wake up at". A first attempt switched the spent-alarm view to a resting state, but that **hid the session timeline/history** — backed out. Needs a narrower, card-level label fix that keeps history visible; left for a follow-up so it can be designed against the #139 redesign.

## Verification
- `:app:assembleDebug`, `:app:lintDebug`, `:app:checkAnimationPreviews`, `:app:checkFileLength`, `:app:testDebugUnitTest` all pass (incl. new `SessionFsmTest` + `ScreenStateMonitorTest`).
- Manual on-device check still recommended (toggle stand-down, lit-room non-detection, unlock-wakes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
