### PR TITLE
style(home): recover unpushed header + countdown polish

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AutoAlarmToggle.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AutoAlarmToggle.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -30,6 +32,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import fr.bsodium.cron.ui.components.rememberCronHaptics
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.MaterialSymbol
@@ -131,11 +134,12 @@ internal fun AutoAlarmToggle(
 private fun AutoAlarmTogglePreview() {
     CronTheme {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(Spacing.xl),
-            modifier = Modifier.padding(Spacing.lg),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.height(50.dp),
         ) {
-            AutoAlarmToggle(enabled = true, onChange = {})
-            AutoAlarmToggle(enabled = false, onChange = {})
+            AutoAlarmToggle(enabled = true, onChange = {}, modifier = Modifier.fillMaxHeight())
+            AutoAlarmToggle(enabled = false, onChange = {}, modifier = Modifier.fillMaxHeight())
         }
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/CollapsibleAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/CollapsibleAlarmCard.kt
@@ -111,14 +111,14 @@ internal fun CollapsibleAlarmCard(
             }.first().measure(cWrap)
             // The remaining is the SAME CountdownStack as expanded (identical font/size/weight) — it just
             // moves and re-aligns its lines (left→right) via alignFraction; it never fades or resizes.
-            // showLabel=false: the "fires in" label is subcomposed separately so it doesn't inflate
+            // showLabel=false: the "remaining" label is subcomposed separately so it doesn't inflate
             // the countdown height and break pill centering.
             val countdown = subcompose("countdown") {
                 RemainingOrStatus(timing = timing, progress = reveal.progress, color = countdownColor, alignFraction = f, showLabel = false)
             }.first().measure(cWrap)
             val firesInAlpha = (1f - f * 3f).coerceIn(0f, 1f)
             val firesIn = subcompose("fires-in") {
-                Text(text = "fires in", color = countdownColor, style = FIRES_IN_STYLE)
+                Text(text = "remaining", color = countdownColor, style = FIRES_IN_STYLE)
             }.first().measure(cWrap)
 
             val w = extras.width

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/Countdown.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/Countdown.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.CronTypography
-import fr.bsodium.cron.ui.theme.ExpressiveWideFontFamily
+import fr.bsodium.cron.ui.theme.ExpressiveCondensedFontFamily
 import fr.bsodium.cron.ui.theme.Spacing
 import fr.bsodium.cron.ui.theme.TightTextStyle
 import kotlinx.coroutines.delay
@@ -43,7 +43,7 @@ import kotlin.time.Duration
 internal data class HoursMinutes(val hours: Long, val minutes: Long)
 
 internal val FIRES_IN_STYLE = TightTextStyle.copy(
-    fontFamily = ExpressiveWideFontFamily,
+    fontFamily = ExpressiveCondensedFontFamily,
     fontWeight = FontWeight.Medium,
     fontSize = 13.sp,
     lineHeight = 13.sp,
@@ -67,7 +67,7 @@ internal fun CountdownStack(
         TwoLineLcdStack(top = top, bottom = bottom, color = color, alignFraction = alignFraction)
         if (showLabel) {
             Text(
-                text = "fires in",
+                text = "remaining",
                 color = color,
                 style = FIRES_IN_STYLE,
                 modifier = Modifier.graphicsLayer { alpha = labelAlpha },

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/GreetingHeader.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/GreetingHeader.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,7 +33,7 @@ fun HomeGreetingRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Spacing.md),
     ) {
-        Column(modifier = Modifier.weight(1f)) {
+        Column(modifier = Modifier.weight(1f).padding(start = Spacing.sm)) {
             if (!name.isNullOrBlank()) {
                 Text(
                     text = "$prefix,",


### PR DESCRIPTION
Recovers home-screen polish tweaks that were made **after** PR #139 (the card redesign) was squash-merged, but never pushed — they were sitting on the local `style/homepage-alarm-card-polish` branch (its remote was deleted post-merge).

- **`GreetingHeader.kt`** — `.padding(start = Spacing.sm)` on the greeting column (header padding fix).
- **`Countdown.kt` / `CollapsibleAlarmCard.kt`** — countdown label "fires in" → **"remaining"**, switched to the condensed font axis (`ExpressiveCondensedFontFamily`).
- **`AutoAlarmToggle.kt`** — `@Preview`-only layout cosmetics.

All self-contained against current `main` (the font family already exists). `assembleDebug`, `lintDebug`, `checkAnimationPreviews`, `checkFileLength` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
