### PR TITLE
fix(home): spent-alarm card label agrees with greyed digits (Bug 1)

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/CollapsibleAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/CollapsibleAlarmCard.kt
@@ -90,7 +90,7 @@ internal fun CollapsibleAlarmCard(
             onFullHeight(extras.height)
             // Date mover — the same AlignedFirstGlyph as extras, placed so it can slide up out the top.
             val date = subcompose("date") {
-                DateSentenceLabel(text = dateLabel.ifBlank { "—" }, color = onCard.copy(alpha = 0.9f), style = dateStyle)
+                DateSentenceLabel(text = alarmSentenceForTiming(dateLabel, timing).ifBlank { "—" }, color = onCard.copy(alpha = 0.9f), style = dateStyle)
             }.first().measure(cWrap)
             // Collapsed bar is a perfect pill: height = 2 × Radius.xl, so the constant Radius.xl corners round it fully.
             val barHeight = ALARM_BAR_HEIGHT.roundToPx()

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/Countdown.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/Countdown.kt
@@ -157,6 +157,20 @@ internal sealed interface AlarmTiming {
  * that already passed today reads as [AlarmTiming.Past] rather than silently rolling forward to tomorrow.
  * Falls back to the next-occurrence rule when no date is known.
  */
+/**
+ * Keeps the card's date sentence consistent with its (greyed) digits once the alarm has fired: a
+ * future-tense "[day], you'll wake up at" becomes "[day], you woke up at" when [timing] is [AlarmTiming.Past].
+ * Keyed on the same [timing] that greys the digits, so label and digits can never disagree. No-ops on other
+ * timings and on labels without the day-part comma (e.g. "Your alarm is disabled") — the same comma split
+ * DateSentenceLabel already relies on.
+ */
+internal fun alarmSentenceForTiming(dateLabel: String, timing: AlarmTiming): String =
+    if (timing is AlarmTiming.Past && dateLabel.contains(',')) {
+        "${dateLabel.substringBefore(',')}, you woke up at"
+    } else {
+        dateLabel
+    }
+
 internal fun computeAlarmTiming(alarmTime: LocalTime?, sessionDate: LocalDate?): AlarmTiming {
     if (alarmTime == null) return AlarmTiming.None
     val tz = TimeZone.currentSystemDefault()

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
@@ -137,7 +137,7 @@ internal fun AlarmCardContent(
     ) {
         var initialRender by remember { mutableStateOf(true) }
         LaunchedEffect(Unit) { initialRender = false }
-        val displayLabel = dateLabel.ifBlank { "—" }
+        val displayLabel = alarmSentenceForTiming(dateLabel, timing).ifBlank { "—" }
         if (initialRender) {
             DateSentenceLabel(
                 text = displayLabel,
@@ -228,6 +228,22 @@ private fun NextAlarmCardWithSleepPreview() {
             dateLabel = "Monday 1",
             alarmTime = LocalTime(6, 40),
             sessionDate = null,
+            sleepDurationLabel = "7H 28M",
+            sleepSegments = PREVIEW_SLEEP_SEGMENTS,
+            modifier = Modifier.padding(Spacing.xl),
+        )
+    }
+}
+
+/** The spent state — a past alarm: digits grey out and the label reads "you woke up at". */
+@Preview(showBackground = true, name = "Spent — woke up")
+@Composable
+private fun NextAlarmCardSpentPreview() {
+    CronTheme {
+        NextAlarmCard(
+            dateLabel = "Today, you'll wake up at",
+            alarmTime = LocalTime(6, 40),
+            sessionDate = LocalDate(2020, 1, 1),
             sleepDurationLabel = "7H 28M",
             sleepSegments = PREVIEW_SLEEP_SEGMENTS,
             modifier = Modifier.padding(Spacing.xl),

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/AlarmSentenceTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/AlarmSentenceTest.kt
@@ -1,0 +1,42 @@
+package fr.bsodium.cron.ui.screens.home.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AlarmSentenceTest {
+
+    private val upcoming = AlarmTiming.Upcoming(HoursMinutes(hours = 1, minutes = 0))
+
+    @Test
+    fun past_rewrites_future_tense_to_past() {
+        assertEquals(
+            "Today, you woke up at",
+            alarmSentenceForTiming("Today, you'll wake up at", AlarmTiming.Past),
+        )
+        assertEquals(
+            "Tuesday, you woke up at",
+            alarmSentenceForTiming("Tuesday, you'll wake up at", AlarmTiming.Past),
+        )
+    }
+
+    @Test
+    fun upcoming_and_none_are_unchanged() {
+        assertEquals(
+            "Today, you'll wake up at",
+            alarmSentenceForTiming("Today, you'll wake up at", upcoming),
+        )
+        assertEquals(
+            "Today, you'll wake up at",
+            alarmSentenceForTiming("Today, you'll wake up at", AlarmTiming.None),
+        )
+    }
+
+    @Test
+    fun past_leaves_comma_less_labels_alone() {
+        // e.g. the auto-plan-disabled string — no day-part comma, so no rewrite.
+        assertEquals(
+            "Your alarm is disabled",
+            alarmSentenceForTiming("Your alarm is disabled", AlarmTiming.Past),
+        )
+    }
+}


### PR DESCRIPTION
Fixes Bug 1 from the audit (originally reported, then deferred): after the alarm fires, the card's digits/countdown grey out (driven by `AlarmTiming.Past`) but the date sentence still read future-tense **"Today, you'll wake up at"** — a visible contradiction.

**Fix:** a pure `alarmSentenceForTiming(dateLabel, timing)` keyed on the **same `timing`** that greys the digits, rewriting the spent label to **"Today, you woke up at"**. Applied in both `NextAlarmCard`/`AlarmCardContent` and `CollapsibleAlarmCard`. Because label and digits now derive from one source, they can't disagree — and `HomePlanContent`/the timeline stay visible (unlike the earlier reverted attempt that switched the whole phase to Idle and hid history).

No-ops on non-`Past` timings and on comma-less labels (e.g. "Your alarm is disabled"). Unit-tested (`AlarmSentenceTest`); spent-state `@Preview` added.

`assembleDebug`, `lintDebug`, `checkAnimationPreviews`, `checkFileLength`, and the new unit test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
