### PR TITLE
fix(session): re-ring alarm if user falls back asleep after dismissing

### DIFF
--- a/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
@@ -41,6 +41,7 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlin.time.Duration.Companion.minutes
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun DeveloperSettingsScreen(onBack: () -> Unit) {
     val context = LocalContext.current
@@ -211,12 +212,14 @@ private fun FsmEventInjector(
 
     // Append-only records the event; FSM mode routes through SessionFsm.onEvent so transitions,
     // the auto-plan gate (Bug 4) and the AI cooldown (Bug 3) actually run.
-    val inject: suspend (SessionEvent) -> Boolean = { event ->
+    val inject: suspend (SessionEvent) -> String? = { event ->
         if (driveFsm) {
-            SessionFsm(context, repo).onEvent(event) != null
+            SessionFsm(context, repo).onEvent(event)?.let { sessionId ->
+                repo.findById(sessionId)?.status?.name
+            } ?: "dropped"
         } else {
             val session = repo.findCurrent()
-            if (session == null) false else { repo.appendEvent(session.id, event); true }
+            if (session == null) null else { repo.appendEvent(session.id, event); "appended" }
         }
     }
 
@@ -242,6 +245,13 @@ private fun FsmEventInjector(
                     trigger = TriggerType.SleepOnset,
                     timestamp = Clock.System.now(),
                     data = EventData.SleepOnset(screenOffSince = Clock.System.now(), rearm = false),
+                ))
+            }
+            InjectButton("Sleep Onset (rearm)", scope) {
+                inject(SessionEvent(
+                    trigger = TriggerType.SleepOnset,
+                    timestamp = Clock.System.now(),
+                    data = EventData.SleepOnset(screenOffSince = Clock.System.now(), rearm = true),
                 ))
             }
             InjectButton("Mid Sleep Activity", scope) {
@@ -284,13 +294,14 @@ private fun FsmEventInjector(
 private fun InjectButton(
     label: String,
     scope: kotlinx.coroutines.CoroutineScope,
-    action: suspend () -> Boolean,
+    action: suspend () -> String?,
 ) {
     val context = LocalContext.current
     FilledTonalButton(
         onClick = {
             scope.launch {
-                val msg = if (action()) "$label injected" else "No active session"
+                val result = action()
+                val msg = if (result != null) "$label → $result" else "No active session"
                 Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
             }
         },

--- a/app/src/main/java/fr/bsodium/cron/ai/SystemPrompts.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/SystemPrompts.kt
@@ -163,6 +163,7 @@ object SystemPrompts {
         - NEVER set an alarm later than the hard latest.
         - If the user has been continuously out of bed for 10+ minutes (see event log): send_brief.
         - If a new sleep_onset fires after out_of_bed_confirmed: re-arm with a fresh set_alarm.
+        - If a new sleep_onset fires after alarm_dismissed: re-arm with a fresh set_alarm — the user fell back asleep after dismissing.
         - If snoozeCount >= 3: don't call any tools — the FSM has already handled this.
         - A mid_sleep_activity under 3 minutes is likely a bathroom trip: do_nothing unless
           followed by out_of_bed_confirmed.

--- a/app/src/main/java/fr/bsodium/cron/ai/TurnRunner.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/TurnRunner.kt
@@ -89,7 +89,7 @@ class TurnRunner(
                     system = systemPrompt,
                     messages = messages.toList(),
                     tools = tools.definitions,
-                    tool_choice = toolChoice,
+                    tool_choice = if (round == 0) toolChoice else null,
                     thinking = thinking,
                 )
 

--- a/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
@@ -47,6 +47,8 @@ class ScreenStateMonitor(
     private var pendingOnset: Job? = null
     /** True after [rearm] has been called; consumed by the next SleepOnset emission. */
     private var isRearm: Boolean = false
+    /** The threshold the pending onset check is using; survives a screen-on/off blip during rearm. */
+    private var currentOnsetThreshold: Duration = sleepOnsetThreshold
     private val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
     private val batteryManager = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
 
@@ -92,14 +94,15 @@ class ScreenStateMonitor(
     fun rearm(threshold: Duration = rearmThreshold) {
         sleepOnsetEmitted = false
         isRearm = true
+        currentOnsetThreshold = threshold
         screenOffSince = if (!powerManager.isInteractive) Clock.System.now() else null
         scheduleOnsetCheck(threshold)
     }
 
     private fun onScreenOff() {
         screenOffSince = Clock.System.now()
-        Log.d(TAG, "Screen off — onset check scheduled (threshold=$sleepOnsetThreshold)")
-        scheduleOnsetCheck()
+        Log.d(TAG, "Screen off — onset check scheduled (threshold=$currentOnsetThreshold)")
+        scheduleOnsetCheck(currentOnsetThreshold)
     }
 
     private fun onScreenOn() {

--- a/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
+++ b/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
@@ -82,7 +82,7 @@ class SleepSessionService : Service() {
             }
             ACTION_REARM -> {
                 screenStateMonitor?.rearm()
-                return START_NOT_STICKY
+                return START_STICKY
             }
         }
         val eveningPlan = intent?.action == ACTION_EVENING_PLAN

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -174,7 +174,10 @@ class SessionFsm(
 
     private fun transition(session: SleepSession, event: SessionEvent): SessionStatus =
         when (event.trigger) {
-            TriggerType.AlarmDismissed -> SessionStatus.Complete
+            TriggerType.AlarmDismissed -> when (session.status) {
+                SessionStatus.Monitoring, SessionStatus.ReMonitoring -> SessionStatus.Awake
+                else -> SessionStatus.Complete
+            }
             TriggerType.SleepOnset -> when (session.status) {
                 SessionStatus.Planning, SessionStatus.Monitoring -> SessionStatus.Monitoring
                 SessionStatus.Awake -> SessionStatus.ReMonitoring

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -172,25 +172,6 @@ class SessionFsm(
         return true
     }
 
-    private fun transition(session: SleepSession, event: SessionEvent): SessionStatus =
-        when (event.trigger) {
-            TriggerType.AlarmDismissed -> when (session.status) {
-                SessionStatus.Monitoring, SessionStatus.ReMonitoring -> SessionStatus.Awake
-                SessionStatus.Planning, SessionStatus.Awake, SessionStatus.Complete -> SessionStatus.Complete
-            }
-            TriggerType.SleepOnset -> when (session.status) {
-                SessionStatus.Planning, SessionStatus.Monitoring -> SessionStatus.Monitoring
-                SessionStatus.Awake -> SessionStatus.ReMonitoring
-                else -> session.status // already past monitoring: no change
-            }
-            TriggerType.OutOfBedConfirmed -> when (session.status) {
-                SessionStatus.Monitoring, SessionStatus.ReMonitoring -> SessionStatus.Awake
-                SessionStatus.Awake -> SessionStatus.Complete
-                else -> session.status
-            }
-            else -> session.status // other triggers don't change status
-        }
-
     private fun onStatusChange(session: SleepSession, newStatus: SessionStatus) {
         when (newStatus) {
             SessionStatus.Awake -> {
@@ -257,6 +238,31 @@ class SessionFsm(
         )
 
         private val AI_COOLDOWN = 15.minutes
+
+        /**
+         * Pure status transition, unit-testable: given the session's current status and an incoming
+         * event, what status should it become? A dismiss while still asleep re-arms (→ Awake) rather
+         * than completing outright, so a second sleep onset can re-ring the alarm; a second dismiss
+         * (already Awake) ends the session.
+         */
+        internal fun transition(session: SleepSession, event: SessionEvent): SessionStatus =
+            when (event.trigger) {
+                TriggerType.AlarmDismissed -> when (session.status) {
+                    SessionStatus.Monitoring, SessionStatus.ReMonitoring -> SessionStatus.Awake
+                    SessionStatus.Planning, SessionStatus.Awake, SessionStatus.Complete -> SessionStatus.Complete
+                }
+                TriggerType.SleepOnset -> when (session.status) {
+                    SessionStatus.Planning, SessionStatus.Monitoring -> SessionStatus.Monitoring
+                    SessionStatus.Awake -> SessionStatus.ReMonitoring
+                    else -> session.status // already past monitoring: no change
+                }
+                TriggerType.OutOfBedConfirmed -> when (session.status) {
+                    SessionStatus.Monitoring, SessionStatus.ReMonitoring -> SessionStatus.Awake
+                    SessionStatus.Awake -> SessionStatus.Complete
+                    else -> session.status
+                }
+                else -> session.status // other triggers don't change status
+            }
 
         /**
          * Whether an event should fire an AI turn. Pure (no IO) so it's unit-testable: a completed

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -176,7 +176,7 @@ class SessionFsm(
         when (event.trigger) {
             TriggerType.AlarmDismissed -> when (session.status) {
                 SessionStatus.Monitoring, SessionStatus.ReMonitoring -> SessionStatus.Awake
-                else -> SessionStatus.Complete
+                SessionStatus.Planning, SessionStatus.Awake, SessionStatus.Complete -> SessionStatus.Complete
             }
             TriggerType.SleepOnset -> when (session.status) {
                 SessionStatus.Planning, SessionStatus.Monitoring -> SessionStatus.Monitoring

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -185,7 +185,8 @@ class SessionFsm(
             }
             TriggerType.OutOfBedConfirmed -> when (session.status) {
                 SessionStatus.Monitoring, SessionStatus.ReMonitoring -> SessionStatus.Awake
-                else -> session.status // only Monitoring/ReMonitoring wake to Awake
+                SessionStatus.Awake -> SessionStatus.Complete
+                else -> session.status
             }
             else -> session.status // other triggers don't change status
         }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiPlanMapper.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiPlanMapper.kt
@@ -24,7 +24,7 @@ sealed interface RunKind {
     data object ManualBase : RunKind
 
     /** A later rerun, named by the event that triggered it (null trigger → generic "Re-planned"). */
-    data class Replan(val trigger: TriggerType?) : RunKind
+    data class Replan(val trigger: TriggerType?, val rearm: Boolean = false) : RunKind
 }
 
 /** The tab label for a run. Exhaustive over [RunKind] and [TriggerType]. */
@@ -36,7 +36,7 @@ val RunKind.label: String
             null -> "Re-planned"
             TriggerType.EveningPlan -> "Re-planned"
             TriggerType.CalendarChange -> "Your schedule changed"
-            TriggerType.SleepOnset -> "You fell asleep"
+            TriggerType.SleepOnset -> if (rearm) "You fell back asleep" else "You fell asleep"
             TriggerType.HcStageUpdate -> "Sleep update"
             TriggerType.MidSleepActivity -> "Movement detected"
             TriggerType.OutOfBedConfirmed -> "You got up"
@@ -123,7 +123,10 @@ object AiPlanMapper {
             // yet (the seed beats the event write), so inferring from `events` alone would briefly mislabel it.
             val effectiveTrigger = streaming?.trigger?.takeIf { turn == streamingTurn } ?: sourceEvent?.trigger
             val kind = when {
-                index > 0 -> RunKind.Replan(effectiveTrigger)
+                index > 0 -> RunKind.Replan(
+                    trigger = effectiveTrigger,
+                    rearm = (sourceEvent?.data as? EventData.SleepOnset)?.rearm == true,
+                )
                 (sourceEvent?.data as? EventData.EveningPlan)?.isManual == true -> RunKind.ManualBase
                 else -> RunKind.ScheduledBase
             }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeScreen.kt
@@ -88,11 +88,12 @@ fun HomeScreen(
     val streamingThread = uiState.aiPlan?.iterations?.lastOrNull { it.thread.isStreaming }?.thread
     val revealed = rememberRevealedThread(streamingThread)
     val displayPlan = uiState.aiPlan?.withStreamingReplaced(revealed)
-    // Once the alarm has passed (out of date) or been dismissed (session Complete), the plan is spent:
-    // Home rests on the onset card + "next plan" line rather than the now-stale thread. Ticks live via
-    // rememberAlarmTiming, so it flips to resting the minute the alarm time passes.
     val timing = rememberAlarmTiming(uiState.sessionDisplay?.alarmTime, uiState.sessionDisplay?.sessionDate)
-    val resting = uiState.sessionDisplay?.status == SessionStatus.Complete || timing is AlarmTiming.Past
+    val resting = when (uiState.sessionDisplay?.status) {
+        SessionStatus.Complete, null -> true
+        SessionStatus.Awake, SessionStatus.ReMonitoring -> false
+        SessionStatus.Planning, SessionStatus.Monitoring -> timing is AlarmTiming.Past
+    }
     // Subtle haptic ticks paced to the reveal animation (gated by the preference). UI-less effect.
     StreamingHaptics(thread = revealed, enabled = uiState.hapticsEnabled)
     val isFirstRun = displayPlan == null

--- a/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
@@ -22,6 +22,7 @@ import fr.bsodium.cron.ai.ToolRegistry
 import fr.bsodium.cron.ai.ToolRegistryFactory
 import fr.bsodium.cron.ai.TurnRunner
 import fr.bsodium.cron.ai.wire.ThinkingConfig
+import fr.bsodium.cron.ai.wire.ToolChoice
 import fr.bsodium.cron.ai.tools.CancelAlarmTool
 import fr.bsodium.cron.ai.tools.DoNothingTool
 import fr.bsodium.cron.ai.tools.EstimateCommuteMultiModeTool
@@ -111,6 +112,7 @@ class AiTurnWorker(
         // Anthropic requires max_tokens > thinking budget, so widen the ceiling on evening_plan turns.
         val thinking = if (isEveningPlan) ThinkingConfig(budgetTokens = THINKING_BUDGET) else null
         val maxTokens = if (isEveningPlan) THINKING_BUDGET + 2048 else 2048
+        val toolChoice = if (thinking == null) ToolChoice.Any else null
         val runner = TurnRunner(
             client = client,
             aiMessageDao = db.aiMessageDao(),
@@ -118,6 +120,7 @@ class AiTurnWorker(
             systemPrompt = systemPrompt,
             tools = tools,
             maxTokens = maxTokens,
+            toolChoice = toolChoice,
             thinking = thinking,
             isMocked = mockTools != null,
         )

--- a/app/src/test/java/fr/bsodium/cron/session/SessionFsmTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/session/SessionFsmTest.kt
@@ -1,8 +1,12 @@
 package fr.bsodium.cron.session
 
+import fr.bsodium.cron.session.model.EventData
+import fr.bsodium.cron.session.model.SessionEvent
 import fr.bsodium.cron.session.model.SessionStatus
 import fr.bsodium.cron.session.model.TriggerType
+import fr.bsodium.cron.testutil.Fixtures
 import kotlinx.datetime.Instant
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -11,6 +15,48 @@ import kotlin.time.Duration.Companion.minutes
 class SessionFsmTest {
 
     private val now = Instant.parse("2026-05-22T03:00:00Z")
+
+    private val alarmDismissed = SessionEvent(
+        trigger = TriggerType.AlarmDismissed,
+        timestamp = now,
+        data = EventData.Empty,
+    )
+
+    private val outOfBedConfirmed = SessionEvent(
+        trigger = TriggerType.OutOfBedConfirmed,
+        timestamp = now,
+        data = EventData.OutOfBedConfirmed(evidence = listOf("test")),
+    )
+
+    @Test
+    fun alarm_dismissed_from_monitoring_rearms_to_awake() {
+        val session = Fixtures.session(status = SessionStatus.Monitoring)
+        assertEquals(SessionStatus.Awake, SessionFsm.transition(session, alarmDismissed))
+    }
+
+    @Test
+    fun alarm_dismissed_from_remonitoring_rearms_to_awake() {
+        val session = Fixtures.session(status = SessionStatus.ReMonitoring)
+        assertEquals(SessionStatus.Awake, SessionFsm.transition(session, alarmDismissed))
+    }
+
+    @Test
+    fun alarm_dismissed_from_awake_completes_session() {
+        val session = Fixtures.session(status = SessionStatus.Awake)
+        assertEquals(SessionStatus.Complete, SessionFsm.transition(session, alarmDismissed))
+    }
+
+    @Test
+    fun out_of_bed_confirmed_from_awake_completes_session() {
+        val session = Fixtures.session(status = SessionStatus.Awake)
+        assertEquals(SessionStatus.Complete, SessionFsm.transition(session, outOfBedConfirmed))
+    }
+
+    @Test
+    fun out_of_bed_confirmed_from_monitoring_wakes_up() {
+        val session = Fixtures.session(status = SessionStatus.Monitoring)
+        assertEquals(SessionStatus.Awake, SessionFsm.transition(session, outOfBedConfirmed))
+    }
 
     @Test
     fun completed_session_never_fires() {


### PR DESCRIPTION
## Problem

Closes #96.

`SessionFsm.transition()` unconditionally mapped `AlarmDismissed -> Complete`. A user who dismisses the alarm without getting out of bed and falls back asleep never gets a second alarm — the session is already `Complete` and every sensor/service is torn down before a new `SleepOnset` can fire.

## Fix

- `AlarmDismissed` is now state-conditional: `Monitoring`/`ReMonitoring` (still "asleep") → `Awake` (re-arms the sensor via the existing `onStatusChange(Awake)` path); `Planning`/`Awake`/`Complete` → `Complete` as before (so a *second* dismiss still ends the session).
- `OutOfBedConfirmed` from `Awake` now also completes the session (previously a no-op).
- `ScreenStateMonitor.currentOnsetThreshold` persists the 15-min rearm threshold across a screen-on/off blip during the rearm window — it was reverting to the 20-min default.
- `SystemPrompts.kt`: tells the AI to re-arm with a fresh `set_alarm` when a new `sleep_onset` fires after `alarm_dismissed`.
- `AiPlanMapper.kt`/timeline: a rearm-triggered replan is labeled "You fell back asleep" instead of the generic "You fell asleep".
- `TurnRunner`/`AiTurnWorker`: forced `tool_choice` now only applies on round 0 of a multi-round turn, fixing a separate silent-no-op risk on overnight replans.
- Developer Settings: FSM event-injection panel gets a "Sleep Onset (rearm)" button and reports the resulting session status, so this path is testable on-device without waiting overnight.

Rebased onto current `main` (was 36 commits behind, predates the #142 sleep-audit rewrite of `SessionFsm`/`ScreenStateMonitor`) — conflicts resolved by hand, keeping both sides' debug tooling and folding the rearm-threshold fix into the audit's rewritten onset logic.

## Test plan

- [x] `SessionFsm.transition()` extracted to a pure `internal` companion function (was private/instance-scoped, untested) + 5 new unit tests covering the dismiss→Awake→Complete and out-of-bed→Complete paths.
- [x] `assembleDebug`, `lintDebug`, `checkFileLength`, `checkAnimationPreviews`, `testDebugUnitTest` all pass.
- [x] Independent sub-agent review against the current `main` (post sleep-audit): confirmed `SleepOnset` isn't throttled by the Bug-3 AI cooldown, `onStatusChange(Awake)` rearm wiring is unconditional regardless of source transition, and auto-plan-off gating still drops dismiss events correctly.
- [x] Manual on-device verification: dismiss → fall back asleep → confirm a second alarm actually rings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)