### PR TITLE
fix(style): remove null assertion, stray shadow, and redundant null check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ local.properties
 
 # Claude Code local state
 .claude/
+
+# Gradle toolchain auto-discovery (machine-specific)
+gradle/gradle-daemon-jvm.properties

--- a/app/src/debug/java/fr/bsodium/cron/ui/components/MockModeChevron.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ui/components/MockModeChevron.kt
@@ -67,7 +67,7 @@ fun rememberFabChevron(): FabChevronSlot? {
                             shape = MaterialTheme.shapes.extraSmall,
                             color = MaterialTheme.colorScheme.surfaceContainerLow,
                             tonalElevation = 3.dp,
-                            shadowElevation = 3.dp,
+                            shadowElevation = 0.dp,
                         ) {
                             Column(
                                 Modifier

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiPlanMapper.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiPlanMapper.kt
@@ -95,8 +95,12 @@ object AiPlanMapper {
 
         // The live partial overrides the persisted rows of its turn → never a duplicate/stale iteration.
         fun threadOf(turn: Int): AiThreadUi =
-            if (turn == streamingTurn && streaming != null) AiThreadMapper.buildFromBlocks(turn, streaming.blocks, isMocked = streaming.isMocked)
-            else threadFor(turn, byTurn.getValue(turn))
+            if (turn == streamingTurn) {
+                requireNotNull(streaming) { "streamingTurn is non-null only when streaming is set" }
+                AiThreadMapper.buildFromBlocks(turn, streaming.blocks, isMocked = streaming.isMocked)
+            } else {
+                threadFor(turn, byTurn.getValue(turn))
+            }
 
         fun startOf(turn: Int): Long =
             byTurn[turn]?.minOfOrNull { it.createdAt }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextAlarmCard.kt
@@ -304,7 +304,7 @@ internal fun rememberLcdReveal(alarmTime: LocalTime?): LcdReveal {
             progressAnim.snapTo(1f)
             animatedKey = valueKey
         } else if (valueKey != animatedKey) {
-            fromKey = animatedKey!!
+            fromKey = requireNotNull(animatedKey) { "checked non-null by the enclosing else-if" }
             progressAnim.snapTo(0f)
             // Sanctioned motionScheme exception (docs/expressive.md § Sanctioned exceptions): the reveal
             // gates digit rolling on a 0→1 progress; a spring's overshoot past 1 would re-roll the digits.


### PR DESCRIPTION
## Summary
Part of a broader cleanup pass (dead code / convention / bug / vuln audit). This is the trivial, zero-conflict-risk batch:

- `NextAlarmCard.kt:307` — the app's only `!!` (`fromKey = animatedKey!!`) replaced with `requireNotNull(...)`, per the repo's no-`!!` rule.
- `MockModeChevron.kt` (debug-only) — `shadowElevation = 3.dp` → `0.dp`, matching the flat-design convention (`tonalElevation` only) already used consistently by `NavPill`, `NextAlarmCard`, and `TimePickerRow`.
- `AiPlanMapper.kt` — removed a `streaming != null` check the Kotlin compiler flagged as always-true (`Condition is always 'true'` build warning) given the preceding `turn == streamingTurn` equality; replaced with an explicit `requireNotNull` documenting the invariant instead of a silent redundant check.
- Gitignored the machine-generated `gradle/gradle-daemon-jvm.properties`.

## Test plan
- [x] `./gradlew :app:assembleDebug :app:lintDebug` passes, no warnings.
- [x] `./gradlew :app:checkFileLength` passes.
- [x] Re-ran `NextAlarmCardScreenshotTest` via Roborazzi — no visual regression (verified by reading the captured PNG).
- [x] `MockModeChevron` has no existing screenshot test (debug-only dev tool); verified by code review that it now follows the same tonalElevation-only pattern as every other surface in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)