### PR TITLE
fix(session): make SessionFsm.transition() exhaustive over closed enums

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -45,8 +45,7 @@ class SessionFsm(
      * session exists and the event cannot bootstrap one.
      */
     suspend fun onEvent(event: SessionEvent): String? = withContext(Dispatchers.IO) {
-        // Auto-plan off = full stand-down: drop every automatic event. A manual run (the "run one
-        // yourself" CTA) carries isManual and is exempt, so it still works with the toggle off.
+        // Auto-plan off = full stand-down: drop every automatic event, except a manual run (isManual), which stays exempt.
         if (!SettingsRepository(context).autoAlarmsEnabledNow() &&
             (event.data as? EventData.EveningPlan)?.isManual != true
         ) {
@@ -80,8 +79,7 @@ class SessionFsm(
         }
 
         if (shouldTriggerAi(event.trigger, nextStatus, session.lastAiCallAt)) {
-            // Stamp the trigger time before enqueueing so the cooldown is effective immediately —
-            // a burst of noisy events otherwise each slip through before the worker's tool sets it.
+            // Stamp the trigger time before enqueueing so the cooldown is immediate — a noise burst would otherwise all slip through before the worker's tool sets it.
             repository.markAiTriggered(session.id)
             repository.triggerAiTurn(session.id)
         }
@@ -184,7 +182,7 @@ class SessionFsm(
                 context.startService(SleepSessionService.stopIntent(context))
                 Log.i(TAG, "Session ${session.id} complete — alarms cleared, service stopped")
             }
-            else -> {} // Planning/Monitoring/ReMonitoring: no status-change side effect
+            SessionStatus.Planning, SessionStatus.Monitoring, SessionStatus.ReMonitoring -> {}
         }
     }
 
@@ -254,14 +252,22 @@ class SessionFsm(
                 TriggerType.SleepOnset -> when (session.status) {
                     SessionStatus.Planning, SessionStatus.Monitoring -> SessionStatus.Monitoring
                     SessionStatus.Awake -> SessionStatus.ReMonitoring
-                    else -> session.status // already past monitoring: no change
+                    SessionStatus.ReMonitoring, SessionStatus.Complete -> session.status
                 }
                 TriggerType.OutOfBedConfirmed -> when (session.status) {
                     SessionStatus.Monitoring, SessionStatus.ReMonitoring -> SessionStatus.Awake
                     SessionStatus.Awake -> SessionStatus.Complete
-                    else -> session.status
+                    SessionStatus.Planning, SessionStatus.Complete -> session.status
                 }
-                else -> session.status // other triggers don't change status
+                // Advisory/AI-only signals: inform a replan but never move status themselves.
+                TriggerType.EveningPlan,
+                TriggerType.HcStageUpdate,
+                TriggerType.MidSleepActivity,
+                TriggerType.WakeWindowOpportunity,
+                TriggerType.AlarmSnoozed,
+                TriggerType.CalendarChange,
+                TriggerType.HardLatestFired,
+                -> session.status
             }
 
         /**

--- a/app/src/test/java/fr/bsodium/cron/session/SessionFsmTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/session/SessionFsmTest.kt
@@ -28,6 +28,24 @@ class SessionFsmTest {
         data = EventData.OutOfBedConfirmed(evidence = listOf("test")),
     )
 
+    private val sleepOnset = SessionEvent(
+        trigger = TriggerType.SleepOnset,
+        timestamp = now,
+        data = EventData.Empty,
+    )
+
+    private val hardLatestFired = SessionEvent(
+        trigger = TriggerType.HardLatestFired,
+        timestamp = now,
+        data = EventData.Empty,
+    )
+
+    private val calendarChange = SessionEvent(
+        trigger = TriggerType.CalendarChange,
+        timestamp = now,
+        data = EventData.Empty,
+    )
+
     @Test
     fun alarm_dismissed_from_monitoring_rearms_to_awake() {
         val session = Fixtures.session(status = SessionStatus.Monitoring)
@@ -56,6 +74,42 @@ class SessionFsmTest {
     fun out_of_bed_confirmed_from_monitoring_wakes_up() {
         val session = Fixtures.session(status = SessionStatus.Monitoring)
         assertEquals(SessionStatus.Awake, SessionFsm.transition(session, outOfBedConfirmed))
+    }
+
+    @Test
+    fun out_of_bed_confirmed_from_planning_is_a_no_op() {
+        val session = Fixtures.session(status = SessionStatus.Planning)
+        assertEquals(SessionStatus.Planning, SessionFsm.transition(session, outOfBedConfirmed))
+    }
+
+    @Test
+    fun out_of_bed_confirmed_from_complete_is_a_no_op() {
+        val session = Fixtures.session(status = SessionStatus.Complete)
+        assertEquals(SessionStatus.Complete, SessionFsm.transition(session, outOfBedConfirmed))
+    }
+
+    @Test
+    fun sleep_onset_from_remonitoring_is_a_no_op() {
+        val session = Fixtures.session(status = SessionStatus.ReMonitoring)
+        assertEquals(SessionStatus.ReMonitoring, SessionFsm.transition(session, sleepOnset))
+    }
+
+    @Test
+    fun sleep_onset_from_complete_is_a_no_op() {
+        val session = Fixtures.session(status = SessionStatus.Complete)
+        assertEquals(SessionStatus.Complete, SessionFsm.transition(session, sleepOnset))
+    }
+
+    @Test
+    fun hard_latest_fired_never_changes_status() {
+        val session = Fixtures.session(status = SessionStatus.Monitoring)
+        assertEquals(SessionStatus.Monitoring, SessionFsm.transition(session, hardLatestFired))
+    }
+
+    @Test
+    fun calendar_change_never_changes_status() {
+        val session = Fixtures.session(status = SessionStatus.ReMonitoring)
+        assertEquals(SessionStatus.ReMonitoring, SessionFsm.transition(session, calendarChange))
     }
 
     @Test


### PR DESCRIPTION
## Summary
Part of the cleanup/audit pass. `SessionFsm.transition()` (touched by the just-merged #150) and `onStatusChange()` matched over `SessionStatus`/`TriggerType` using `else` branches — the exact anti-pattern CLAUDE.md's "exhaustive when, no else" rule exists to prevent in a state machine that's already had three rounds of subtle bugs (#150, #146, #142). Adding an 11th `TriggerType` or 6th `SessionStatus` later would now be a compile error instead of a silent no-op.

Each newly-explicit branch was reasoned through individually, not rubber-stamped from the prior `else`:
- `SleepOnset`/`OutOfBedConfirmed` already covered their live transitions; the missing `ReMonitoring`/`Complete`/`Planning` cases are legitimate no-ops (already past that stage, or already ended).
- `EveningPlan`, `HcStageUpdate`, `MidSleepActivity`, `WakeWindowOpportunity`, `AlarmSnoozed`, `CalendarChange`, `HardLatestFired` are advisory/AI-only signals that inform a replan but never move status themselves — only a sensor-confirmed onset, out-of-bed, or dismiss does that. Grouped into one branch since they share identical no-op behavior.

**No behavior change** — every branch's resulting value matches what the prior `else` produced; verified by tracing each case by hand and confirmed with new tests.

Also folded in this file's own multi-line `//` comment cleanup (2 pre-existing + compressing my own additions to one line each), to avoid a rebase conflict with the separate repo-wide comment-cleanup PR.

## Notable side-finding (not fixed here, flagged for a separate PR)
While tracing trigger call sites: `TriggerType.AlarmSnoozed` is listed in `AI_TRIGGERS` but is *never actually reachable* there — snooze events are always routed through the separate `onSnooze()` method (bypassing `onEvent()`/`transition()`/`shouldTriggerAi()` entirely), per `AlarmReceiver.kt`. Its `AI_TRIGGERS` membership appears to be dead code. Also found `AlarmReceiver.handleAlarmFired()` launching `CoroutineScope(Dispatchers.IO).launch { }` inside a `goAsync()` receiver for the `HardLatestFired` event write — violates CLAUDE.md's goAsync()-must-finish-in-10s rule (should be a WorkManager job). Tracking both for the receiver test-coverage PR.

## Test plan
- [x] `./gradlew :app:assembleDebug :app:lintDebug` passes.
- [x] `./gradlew :app:checkFileLength` / `:app:checkAnimationPreviews` pass.
- [x] `./gradlew :app:testDebugUnitTest --tests 'fr.bsodium.cron.session.SessionFsmTest'` — 15/15 pass, including 6 new cases covering every newly-explicit branch.
- [x] No composables touched — no Roborazzi needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)