### PR TITLE
fix(receiver): restore sensing service and planned alarm after reboot

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/receiver/BootReceiver.kt
+++ b/app/src/main/java/fr/bsodium/cron/receiver/BootReceiver.kt
@@ -4,32 +4,37 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import fr.bsodium.cron.alarm.AlarmScheduler
 import fr.bsodium.cron.alarm.EveningPlanScheduler
 import fr.bsodium.cron.alarm.HardLatestScheduler
+import fr.bsodium.cron.service.SleepSessionService
 import fr.bsodium.cron.session.db.CronDatabase
+import fr.bsodium.cron.session.db.SessionEntity
 import fr.bsodium.cron.session.db.SessionJson
 import fr.bsodium.cron.session.model.DayPlan
+import fr.bsodium.cron.session.model.Instruction
 import fr.bsodium.cron.session.model.SessionStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atTime
 import kotlinx.datetime.toInstant
 
 /**
- * Re-arms persistent alarms after device reboot.
- *
- * AlarmManager state is cleared by a reboot. We re-arm:
+ * Restores session state after device reboot: AlarmManager entries and the
+ * sensing foreground service are both wiped by a reboot, so we re-arm:
  *  1. The next evening plan trigger via [EveningPlanScheduler].
- *  2. The hard-latest alarm, **only if** an active (non-complete) session
- *     exists in the database and its hard-latest is still in the future.
+ *  2. For an active (non-complete) session: [SleepSessionService], so sensor
+ *     monitoring resumes (a plain start intent — never re-runs the evening
+ *     plan); the hard-latest safety alarm; and the AI-planned wake alarm
+ *     persisted in the session's current instruction, when one was decided.
  *
- * The mutable AI alarm is intentionally NOT re-armed here — the next
- * sensor event will trigger a fresh AI replan, which will re-arm it
- * naturally. Hard-latest stands as the safety floor in the meantime.
+ * Without the service restart no sensor event could ever fire again, so no
+ * replan would re-arm anything — a mid-session reboot would silently degrade
+ * the night to the hard-latest safety floor.
  */
 class BootReceiver : BroadcastReceiver() {
 
@@ -40,7 +45,7 @@ class BootReceiver : BroadcastReceiver() {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 EveningPlanScheduler(context).armNext()
-                rearmActiveHardLatest(context)
+                recoverActiveSession(context)
             } catch (t: Throwable) {
                 Log.e(TAG, "Boot re-arm failed", t)
             } finally {
@@ -49,35 +54,73 @@ class BootReceiver : BroadcastReceiver() {
         }
     }
 
-    private suspend fun rearmActiveHardLatest(context: Context) {
-        val db = CronDatabase.get(context)
-        val session = db.sessionDao().findCurrent() ?: return
+    internal suspend fun recoverActiveSession(context: Context) {
+        val session = CronDatabase.get(context).sessionDao().findCurrent() ?: return
         if (session.status == SessionStatus.Complete.name) return
 
-        val plan = runCatching { SessionJson.decodeFromString<DayPlan>(session.planJson) }.getOrNull()
-            ?: return
-        val tz = TimeZone.of(session.timezone)
-        val sessionDate = runCatching { LocalDate.parse(session.date) }.getOrNull() ?: run {
-            Log.w(TAG, "Skipping hard-latest re-arm: unparseable date '${session.date}'")
-            return
-        }
-        val target = LocalDateTime(
-            sessionDate.year, sessionDate.monthNumber, sessionDate.dayOfMonth,
-            plan.hardLatest.hour, plan.hardLatest.minute, plan.hardLatest.second, plan.hardLatest.nanosecond,
-        ).toInstant(tz)
+        context.startService(SleepSessionService.startIntent(context))
+        Log.i(TAG, "Restarted sleep-session service for session ${session.id}")
 
+        val plan = runCatching { SessionJson.decodeFromString<DayPlan>(session.planJson) }
+            .onFailure { Log.w(TAG, "Skipping alarm re-arm: unparseable plan", it) }
+            .getOrNull() ?: return
+        val sessionDate = runCatching { LocalDate.parse(session.date) }
+            .onFailure { Log.w(TAG, "Skipping alarm re-arm: unparseable date '${session.date}'", it) }
+            .getOrNull() ?: return
+        val timezone = TimeZone.of(session.timezone)
+
+        rearmHardLatest(context, plan, sessionDate, timezone, session.id)
+        rearmPlannedAlarm(context, session, plan, sessionDate, timezone)
+    }
+
+    private fun rearmHardLatest(
+        context: Context,
+        plan: DayPlan,
+        sessionDate: LocalDate,
+        timezone: TimeZone,
+        sessionId: String,
+    ) {
+        val target = sessionDate.atTime(plan.hardLatest).toInstant(timezone)
         if (target <= Clock.System.now()) {
             Log.i(TAG, "Skipping hard-latest re-arm: target $target already past")
             return
         }
-
         HardLatestScheduler(context).arm(
             hardLatest = plan.hardLatest,
             sessionDate = sessionDate,
-            timezone = tz,
+            timezone = timezone,
+            sessionId = sessionId,
+        )
+        Log.i(TAG, "Re-armed hard-latest for session $sessionId at $target")
+    }
+
+    private fun rearmPlannedAlarm(
+        context: Context,
+        session: SessionEntity,
+        plan: DayPlan,
+        sessionDate: LocalDate,
+        timezone: TimeZone,
+    ) {
+        val instruction = runCatching { SessionJson.decodeFromString<Instruction>(session.currentInstructionJson) }
+            .onFailure { Log.w(TAG, "Skipping planned-alarm re-arm: unparseable instruction", it) }
+            .getOrNull() ?: return
+        // A null alarmTime means no AI decision has armed an alarm (CancelAlarm resets it,
+        // DoNothing carries it forward) — hard-latest alone is the correct state.
+        val alarmTime = instruction.alarmTime ?: return
+        val requested = sessionDate.atTime(alarmTime).toInstant(timezone)
+        if (requested <= Clock.System.now()) {
+            Log.i(TAG, "Skipping planned-alarm re-arm: target $requested already past")
+            return
+        }
+        AlarmScheduler(context).schedule(
+            requested = requested,
+            hardLatest = plan.hardLatest,
+            sessionDate = sessionDate,
+            timezone = timezone,
+            label = "Wake up",
             sessionId = session.id,
         )
-        Log.i(TAG, "Re-armed hard-latest for session ${session.id} at $target")
+        Log.i(TAG, "Re-armed planned alarm for session ${session.id} at $requested")
     }
 
     private companion object {

--- a/app/src/test/java/fr/bsodium/cron/receiver/BootReceiverTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/receiver/BootReceiverTest.kt
@@ -1,0 +1,117 @@
+package fr.bsodium.cron.receiver
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import fr.bsodium.cron.alarm.AlarmScheduler
+import fr.bsodium.cron.alarm.HardLatestScheduler
+import fr.bsodium.cron.service.SleepSessionService
+import fr.bsodium.cron.session.db.CronDatabase
+import fr.bsodium.cron.session.db.toEntity
+import fr.bsodium.cron.session.model.ActionType
+import fr.bsodium.cron.session.model.Instruction
+import fr.bsodium.cron.session.model.SessionStatus
+import fr.bsodium.cron.testutil.Fixtures
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class BootReceiverTest {
+
+    private val timezone = TimeZone.of("Europe/Paris")
+
+    /** Tomorrow in the session timezone, so hard-latest and alarm targets are always in the future. */
+    private val sessionDate: LocalDate =
+        Clock.System.now().toLocalDateTime(timezone).date.plus(1, DateTimeUnit.DAY)
+
+    private lateinit var app: Application
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        // The production CronDatabase singleton is file-backed and persists across tests in the JVM;
+        // wipe it so each test starts from a clean slate.
+        runBlocking { CronDatabase.get(app).sessionDao().deleteOlderThan(Long.MAX_VALUE) }
+    }
+
+    private fun insertSession(
+        status: SessionStatus = SessionStatus.Monitoring,
+        instruction: Instruction = Fixtures.instruction(),
+    ) = runBlocking {
+        CronDatabase.get(app).sessionDao().insert(
+            Fixtures.session(
+                id = "boot-session",
+                date = sessionDate,
+                status = status,
+                plan = Fixtures.dayPlan(hardLatest = LocalTime(10, 0)),
+                currentInstruction = instruction,
+                timezone = timezone.id,
+            ).toEntity(),
+        )
+    }
+
+    private fun recover() = runBlocking { BootReceiver().recoverActiveSession(app) }
+
+    @Test
+    fun active_session_with_planned_alarm_rearms_both_alarms_and_restarts_service() {
+        insertSession(
+            instruction = Fixtures.instruction(action = ActionType.SetAlarm, alarmTime = LocalTime(7, 0)),
+        )
+
+        recover()
+
+        assertTrue(HardLatestScheduler(app).isArmed(sessionDate))
+        assertTrue(AlarmScheduler(app).isArmed(sessionDate))
+        val started = shadowOf(app).nextStartedService
+        assertEquals(SleepSessionService::class.qualifiedName, started.component?.className)
+        assertNull(started.action)
+    }
+
+    @Test
+    fun active_session_without_planned_alarm_rearms_hard_latest_only_and_restarts_service() {
+        insertSession(
+            instruction = Fixtures.instruction(action = ActionType.DoNothing, alarmTime = null),
+        )
+
+        recover()
+
+        assertTrue(HardLatestScheduler(app).isArmed(sessionDate))
+        assertFalse(AlarmScheduler(app).isArmed(sessionDate))
+        val started = shadowOf(app).nextStartedService
+        assertEquals(SleepSessionService::class.qualifiedName, started.component?.className)
+    }
+
+    @Test
+    fun complete_session_rearms_nothing_and_does_not_start_service() {
+        insertSession(status = SessionStatus.Complete)
+
+        recover()
+
+        assertFalse(HardLatestScheduler(app).isArmed(sessionDate))
+        assertFalse(AlarmScheduler(app).isArmed(sessionDate))
+        assertNull(shadowOf(app).peekNextStartedService())
+    }
+
+    @Test
+    fun no_session_rearms_nothing_and_does_not_start_service() {
+        recover()
+
+        assertFalse(HardLatestScheduler(app).isArmed(sessionDate))
+        assertFalse(AlarmScheduler(app).isArmed(sessionDate))
+        assertNull(shadowOf(app).peekNextStartedService())
+    }
+}


### PR DESCRIPTION
## The bug

`BootReceiver`'s KDoc claimed the mutable AI alarm was "intentionally NOT re-armed here — the next sensor event will trigger a fresh AI replan, which will re-arm it naturally." That assumption was broken: **nothing restarts `SleepSessionService` after a reboot.** The service hosts `ScreenStateMonitor` and `ActivityRecognitionMonitor` — the source of every sensor event that could trigger a replan — and neither `BootReceiver` nor anything else started it until the *next* evening plan trigger.

So after a mid-session reboot (e.g. 3 a.m.), there was no sensor monitoring, no sleep/wake detection, and no re-arm path: the user silently woke at the hard-latest safety floor with no attempt at the AI-planned wake time.

## The fix

When an active (non-Complete) session exists at boot:

1. **Restart sensing** — `context.startService(SleepSessionService.startIntent(context))`. This is a plain start intent (no `ACTION_EVENING_PLAN`), so `onStartCommand` only reconstructs the monitors; it never re-bootstraps a session or re-runs the evening-plan flow.
2. **Re-arm the planned alarm** — decode the session's persisted `currentInstruction`; a non-null `alarmTime` (SetAlarm sets it, DoNothing carries it forward, CancelAlarm clears it) is re-armed via `AlarmScheduler.schedule(...)`, gated on the target still being in the future. A null `alarmTime` keeps hard-latest-only behavior, matching the pre-fix semantics.

The existing hard-latest re-arm and evening-plan trigger re-arm are unchanged; the class KDoc now documents the corrected behavior.

## goAsync() budget

The added work is one Room row read (already there), one `startService` call, one small JSON decode, and one `AlarmManager.setAlarmClock` — all synchronous, non-blocking, and well within the ~10s `goAsync()` window. No network, no long-running work.

## Tests

New `BootReceiverTest` (Robolectric, production DB singleton wiped per test):
- active session + non-null `alarmTime` → hard-latest AND planned alarm armed, service started with a plain (action-less) intent
- active session + null `alarmTime` → hard-latest only, service still started
- Complete session / no session → nothing armed, service not started

`assembleDebug`, `lintDebug`, `checkFileLength`, `checkAnimationPreviews`, and the full `testDebugUnitTest` suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)