### PR TITLE
test: coverage for calendar, location, permissions, settings, travel

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/location/LocationProvider.kt
+++ b/app/src/main/java/fr/bsodium/cron/location/LocationProvider.kt
@@ -108,7 +108,7 @@ class LocationProvider(private val context: Context) {
         // Reject fixes coarser than the cap — a precise fix is gated at 500 m (cell-tower-only
         // positions misplace by kilometres); the balanced current fix uses a looser cap since a
         // current city-level position is still far better than a stale precise one elsewhere.
-        if (location.accuracy > maxAccuracyMeters) return null
+        if (!isWithinAccuracyCap(location.accuracy, maxAccuracyMeters)) return null
         val capturedAt = Instant.fromEpochMilliseconds(location.time)
         checkpoints.setLastLocationFix(location.latitude, location.longitude, capturedAt)
         return LocationPayload(
@@ -206,10 +206,18 @@ class LocationProvider(private val context: Context) {
         // alternative is a stale fix in the wrong city (commute origin only needs the right area).
         private const val COARSE_MAX_ACCURACY_METERS = 5000f
         private val REVERSE_GEOCODE_TIMEOUT = 5.seconds
+
+        /** Pure cap check: a fix coarser than [maxAccuracyMeters] is rejected outright. */
+        internal fun isWithinAccuracyCap(accuracyMeters: Float, maxAccuracyMeters: Float): Boolean =
+            accuracyMeters <= maxAccuracyMeters
+
+        /** Pure recency check: a fix older than [maxAge] relative to [nowMs] is stale. */
+        internal fun isRecent(nowMs: Long, locationTimeMs: Long, maxAge: kotlin.time.Duration): Boolean =
+            (nowMs - locationTimeMs) <= maxAge.inWholeMilliseconds
     }
 
     private fun isRecent(location: Location, maxAge: kotlin.time.Duration): Boolean =
-        (System.currentTimeMillis() - location.time) <= maxAge.inWholeMilliseconds
+        isRecent(System.currentTimeMillis(), location.time, maxAge)
 
     private fun hasAnyLocationPermission(): Boolean {
         val coarse = ContextCompat.checkSelfPermission(

--- a/app/src/test/java/fr/bsodium/cron/calendar/CalendarChangeAnalyzerTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/calendar/CalendarChangeAnalyzerTest.kt
@@ -1,0 +1,191 @@
+package fr.bsodium.cron.calendar
+
+import android.content.ContentResolver
+import android.database.Cursor
+import fr.bsodium.cron.testutil.Fixtures
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.datetime.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CalendarChangeAnalyzerTest {
+
+    private data class Row(
+        val eventId: Long,
+        val title: String,
+        val begin: Long,
+        val end: Long,
+        val allDay: Boolean,
+        val calendarId: Long,
+        val location: String?,
+        val selfAttendeeStatus: Int,
+    )
+
+    private fun newCursor(rows: List<Row>): Cursor {
+        val cursor = mockk<Cursor>(relaxed = true)
+        var index = -1
+        every { cursor.moveToNext() } answers {
+            index++
+            index < rows.size
+        }
+        every { cursor.getLong(0) } answers { rows[index].eventId }
+        every { cursor.getString(1) } answers { rows[index].title }
+        every { cursor.getLong(2) } answers { rows[index].begin }
+        every { cursor.getLong(3) } answers { rows[index].end }
+        every { cursor.getInt(4) } answers { if (rows[index].allDay) 1 else 0 }
+        every { cursor.getLong(5) } answers { rows[index].calendarId }
+        every { cursor.getString(6) } answers { rows[index].location }
+        every { cursor.getInt(7) } answers { rows[index].selfAttendeeStatus }
+        return cursor
+    }
+
+    private fun contentResolver(rows: List<Row>): ContentResolver {
+        val resolver = mockk<ContentResolver>()
+        every { resolver.query(any(), any(), any(), any(), any()) } answers { newCursor(rows) }
+        return resolver
+    }
+
+    private val morningStart = Instant.parse("2026-05-22T04:00:00Z") // ~06:00 Paris
+
+    @Test
+    fun unchanged_signature_reports_no_change() {
+        val row = Row(
+            eventId = 1L,
+            title = "Standup",
+            begin = morningStart.toEpochMilliseconds(),
+            end = morningStart.toEpochMilliseconds() + 60_000,
+            allDay = false,
+            calendarId = 10L,
+            location = "Office",
+            selfAttendeeStatus = 1,
+        )
+        val resolver = contentResolver(listOf(row))
+        val analyzer = CalendarChangeAnalyzer(resolver)
+
+        val first = analyzer.analyze(Fixtures.session())
+        assertTrue(first.firstEventChanged)
+        assertEquals("1|${row.begin}|Office|1", first.newSig)
+
+        val session2 = Fixtures.session().copy(cachedFirstEventSig = first.newSig)
+        val second = analyzer.analyze(session2)
+        assertFalse(second.firstEventChanged)
+        assertEquals(first.newSig, second.newSig)
+    }
+
+    @Test
+    fun changed_start_time_is_detected() {
+        val row = Row(
+            eventId = 1L,
+            title = "Standup",
+            begin = morningStart.toEpochMilliseconds(),
+            end = morningStart.toEpochMilliseconds() + 60_000,
+            allDay = false,
+            calendarId = 10L,
+            location = "Office",
+            selfAttendeeStatus = 1,
+        )
+        val cachedSig = "1|${row.begin - 3_600_000}|Office|1"
+        val session = Fixtures.session().copy(cachedFirstEventSig = cachedSig)
+
+        val result = CalendarChangeAnalyzer(contentResolver(listOf(row))).analyze(session)
+        assertTrue(result.firstEventChanged)
+    }
+
+    @Test
+    fun all_day_event_is_excluded_and_first_timed_event_is_used() {
+        val allDay = Row(
+            eventId = 1L,
+            title = "Vacation",
+            begin = morningStart.toEpochMilliseconds(),
+            end = morningStart.toEpochMilliseconds() + 86_400_000,
+            allDay = true,
+            calendarId = 10L,
+            location = null,
+            selfAttendeeStatus = 1,
+        )
+        val timed = Row(
+            eventId = 2L,
+            title = "Standup",
+            begin = morningStart.toEpochMilliseconds() + 3_600_000,
+            end = morningStart.toEpochMilliseconds() + 3_660_000,
+            allDay = false,
+            calendarId = 10L,
+            location = "Office",
+            selfAttendeeStatus = 1,
+        )
+        val resolver = contentResolver(listOf(allDay, timed))
+        val result = CalendarChangeAnalyzer(resolver).analyze(Fixtures.session())
+        assertEquals("2|${timed.begin}|Office|1", result.newSig)
+    }
+
+    @Test
+    fun no_events_yields_null_signature() {
+        val result = CalendarChangeAnalyzer(contentResolver(emptyList())).analyze(Fixtures.session())
+        assertFalse(result.firstEventChanged)
+        assertNull(result.newSig)
+    }
+
+    @Test
+    fun only_all_day_events_yields_null_signature() {
+        val allDay = Row(
+            eventId = 1L,
+            title = "Vacation",
+            begin = morningStart.toEpochMilliseconds(),
+            end = morningStart.toEpochMilliseconds() + 86_400_000,
+            allDay = true,
+            calendarId = 10L,
+            location = null,
+            selfAttendeeStatus = 1,
+        )
+        val result = CalendarChangeAnalyzer(contentResolver(listOf(allDay))).analyze(Fixtures.session())
+        assertNull(result.newSig)
+    }
+
+    @Test
+    fun declined_event_excluded_when_rsvp_filter_disallows_it() {
+        val declined = Row(
+            eventId = 1L,
+            title = "Standup",
+            begin = morningStart.toEpochMilliseconds(),
+            end = morningStart.toEpochMilliseconds() + 60_000,
+            allDay = false,
+            calendarId = 10L,
+            location = "Office",
+            selfAttendeeStatus = 2, // Declined code
+        )
+        val analyzer = CalendarChangeAnalyzer(
+            contentResolver(listOf(declined)),
+            allowedRsvpStatuses = setOf(RsvpStatus.Accepted),
+        )
+        val result = analyzer.analyze(Fixtures.session())
+        assertNull(result.newSig)
+        assertFalse(result.firstEventChanged)
+    }
+
+    @Test
+    fun declined_event_included_when_rsvp_filter_allows_declined() {
+        val declined = Row(
+            eventId = 1L,
+            title = "Standup",
+            begin = morningStart.toEpochMilliseconds(),
+            end = morningStart.toEpochMilliseconds() + 60_000,
+            allDay = false,
+            calendarId = 10L,
+            location = "Office",
+            selfAttendeeStatus = 2,
+        )
+        val analyzer = CalendarChangeAnalyzer(
+            contentResolver(listOf(declined)),
+            allowedRsvpStatuses = setOf(RsvpStatus.Declined),
+        )
+        val result = analyzer.analyze(Fixtures.session())
+        assertEquals("1|${declined.begin}|Office|2", result.newSig)
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/calendar/CalendarReaderTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/calendar/CalendarReaderTest.kt
@@ -1,0 +1,139 @@
+package fr.bsodium.cron.calendar
+
+import android.content.ContentResolver
+import android.database.Cursor
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.datetime.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CalendarReaderTest {
+
+    private data class Row(
+        val eventId: Long,
+        val title: String?,
+        val begin: Long,
+        val end: Long,
+        val allDay: Boolean,
+        val calendarId: Long,
+        val location: String?,
+        val selfAttendeeStatus: Int,
+    )
+
+    private fun cursorOf(rows: List<Row>): Cursor {
+        val cursor = mockk<Cursor>(relaxed = true)
+        var index = -1
+        every { cursor.moveToNext() } answers {
+            index++
+            index < rows.size
+        }
+        every { cursor.getLong(0) } answers { rows[index].eventId }
+        every { cursor.getString(1) } answers { rows[index].title }
+        every { cursor.getLong(2) } answers { rows[index].begin }
+        every { cursor.getLong(3) } answers { rows[index].end }
+        every { cursor.getInt(4) } answers { if (rows[index].allDay) 1 else 0 }
+        every { cursor.getLong(5) } answers { rows[index].calendarId }
+        every { cursor.getString(6) } answers { rows[index].location }
+        every { cursor.getInt(7) } answers { rows[index].selfAttendeeStatus }
+        return cursor
+    }
+
+    private val from = Instant.parse("2026-05-22T00:00:00Z")
+    private val to = Instant.parse("2026-05-22T18:00:00Z")
+
+    @Test
+    fun reads_events_and_maps_all_fields() {
+        val row = Row(
+            eventId = 42L,
+            title = "Standup",
+            begin = from.toEpochMilliseconds() + 1000,
+            end = from.toEpochMilliseconds() + 2000,
+            allDay = false,
+            calendarId = 7L,
+            location = "Office",
+            selfAttendeeStatus = 1,
+        )
+        val resolver = mockk<ContentResolver>()
+        every { resolver.query(any(), any(), any(), any(), any()) } returns cursorOf(listOf(row))
+
+        val events = CalendarReader(resolver).readEvents(from, to)
+        assertEquals(1, events.size)
+        val event = events.single()
+        assertEquals(42L, event.id)
+        assertEquals("Standup", event.title)
+        assertEquals("Office", event.location)
+        assertEquals(7L, event.calendarId)
+        assertEquals(false, event.allDay)
+        assertEquals(1, event.selfAttendeeStatus)
+    }
+
+    @Test
+    fun blank_location_is_normalized_to_null() {
+        val row = Row(
+            eventId = 1L,
+            title = "No location",
+            begin = from.toEpochMilliseconds(),
+            end = from.toEpochMilliseconds() + 1000,
+            allDay = false,
+            calendarId = 1L,
+            location = "   ",
+            selfAttendeeStatus = 1,
+        )
+        val resolver = mockk<ContentResolver>()
+        every { resolver.query(any(), any(), any(), any(), any()) } returns cursorOf(listOf(row))
+
+        val events = CalendarReader(resolver).readEvents(from, to)
+        assertEquals(null, events.single().location)
+    }
+
+    @Test
+    fun missing_title_defaults_to_placeholder() {
+        val row = Row(
+            eventId = 1L,
+            title = null,
+            begin = from.toEpochMilliseconds(),
+            end = from.toEpochMilliseconds() + 1000,
+            allDay = false,
+            calendarId = 1L,
+            location = null,
+            selfAttendeeStatus = 1,
+        )
+        val resolver = mockk<ContentResolver>()
+        every { resolver.query(any(), any(), any(), any(), any()) } returns cursorOf(listOf(row))
+
+        val events = CalendarReader(resolver).readEvents(from, to)
+        assertEquals("(No title)", events.single().title)
+    }
+
+    @Test
+    fun events_outside_allowed_rsvp_statuses_are_filtered_out() {
+        val accepted = Row(1L, "Accepted", from.toEpochMilliseconds(), from.toEpochMilliseconds() + 1000, false, 1L, null, 1)
+        val declined = Row(2L, "Declined", from.toEpochMilliseconds(), from.toEpochMilliseconds() + 1000, false, 1L, null, 2)
+        val resolver = mockk<ContentResolver>()
+        every { resolver.query(any(), any(), any(), any(), any()) } returns cursorOf(listOf(accepted, declined))
+
+        val events = CalendarReader(resolver).readEvents(from, to, allowedRsvpStatuses = setOf(RsvpStatus.Accepted))
+        assertEquals(listOf("Accepted"), events.map { it.title })
+    }
+
+    @Test
+    fun null_cursor_from_query_yields_empty_list() {
+        val resolver = mockk<ContentResolver>()
+        every { resolver.query(any(), any(), any(), any(), any()) } returns null
+
+        assertTrue(CalendarReader(resolver).readEvents(from, to).isEmpty())
+    }
+
+    @Test
+    fun security_exception_from_query_yields_empty_list() {
+        val resolver = mockk<ContentResolver>()
+        every { resolver.query(any(), any(), any(), any(), any()) } throws SecurityException("permission revoked")
+
+        assertTrue(CalendarReader(resolver).readEvents(from, to).isEmpty())
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/calendar/RsvpStatusTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/calendar/RsvpStatusTest.kt
@@ -1,0 +1,31 @@
+package fr.bsodium.cron.calendar
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RsvpStatusTest {
+
+    @Test
+    fun fromCode_maps_known_codes_to_the_right_status() {
+        assertEquals(RsvpStatus.NotResponded, RsvpStatus.fromCode(0))
+        assertEquals(RsvpStatus.Accepted, RsvpStatus.fromCode(1))
+        assertEquals(RsvpStatus.Declined, RsvpStatus.fromCode(2))
+        assertEquals(RsvpStatus.NotResponded, RsvpStatus.fromCode(3))
+        assertEquals(RsvpStatus.Tentative, RsvpStatus.fromCode(4))
+    }
+
+    @Test
+    fun fromCode_returns_null_for_unknown_code() {
+        assertNull(RsvpStatus.fromCode(99))
+    }
+
+    @Test
+    fun default_rsvp_statuses_exclude_declined() {
+        assertEquals(
+            setOf(RsvpStatus.Accepted, RsvpStatus.NotResponded, RsvpStatus.Tentative),
+            DEFAULT_RSVP_STATUSES,
+        )
+        assertEquals(false, RsvpStatus.Declined in DEFAULT_RSVP_STATUSES)
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/location/LocationProviderAccuracyTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/location/LocationProviderAccuracyTest.kt
@@ -1,0 +1,51 @@
+package fr.bsodium.cron.location
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+class LocationProviderAccuracyTest {
+
+    @Test
+    fun fix_at_exactly_the_cap_is_within_bounds() {
+        assertTrue(LocationProvider.isWithinAccuracyCap(500f, maxAccuracyMeters = 500f))
+    }
+
+    @Test
+    fun fix_coarser_than_the_cap_is_rejected() {
+        assertFalse(LocationProvider.isWithinAccuracyCap(500.1f, maxAccuracyMeters = 500f))
+    }
+
+    @Test
+    fun fix_finer_than_the_cap_is_accepted() {
+        assertTrue(LocationProvider.isWithinAccuracyCap(10f, maxAccuracyMeters = 500f))
+    }
+
+    @Test
+    fun coarse_cap_accepts_city_level_accuracy_that_the_precise_cap_would_reject() {
+        assertFalse(LocationProvider.isWithinAccuracyCap(4000f, maxAccuracyMeters = 500f))
+        assertTrue(LocationProvider.isWithinAccuracyCap(4000f, maxAccuracyMeters = 5000f))
+    }
+
+    @Test
+    fun last_known_fix_exactly_at_max_age_counts_as_recent() {
+        val now = 10.hours.inWholeMilliseconds
+        val fixTime = now - 2.hours.inWholeMilliseconds
+        assertTrue(LocationProvider.isRecent(now, fixTime, maxAge = 2.hours))
+    }
+
+    @Test
+    fun last_known_fix_older_than_max_age_is_stale() {
+        val now = 10.hours.inWholeMilliseconds
+        val fixTime = now - 2.hours.inWholeMilliseconds - 1.minutes.inWholeMilliseconds
+        assertFalse(LocationProvider.isRecent(now, fixTime, maxAge = 2.hours))
+    }
+
+    @Test
+    fun fresh_fix_is_recent() {
+        val now = 10.hours.inWholeMilliseconds
+        assertTrue(LocationProvider.isRecent(now, now, maxAge = 2.hours))
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/location/LocationProviderFallbackTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/location/LocationProviderFallbackTest.kt
@@ -1,0 +1,82 @@
+package fr.bsodium.cron.location
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import fr.bsodium.cron.session.model.LocationSource
+import fr.bsodium.cron.settings.PollCheckpointStore
+import fr.bsodium.cron.settings.SettingsRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Robolectric grants no runtime permissions by default, so [LocationProvider.acquireForEveningPlan]
+ * takes the `permission_denied` branch without ever touching FusedLocationProviderClient — this
+ * exercises the fallback-tier ordering (stored last-known -> home address -> unavailable) in isolation.
+ */
+@RunWith(RobolectricTestRunner::class)
+class LocationProviderFallbackTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+    private val provider = LocationProvider(context)
+
+    private fun settings(homeLat: Double? = null, homeLng: Double? = null): SettingsRepository {
+        val settings = mockk<SettingsRepository>()
+        every { settings.homeAddressLat } returns flowOf(homeLat)
+        every { settings.homeAddressLng } returns flowOf(homeLng)
+        return settings
+    }
+
+    @Test
+    fun no_permission_and_no_fallback_data_yields_unavailable() = runTest {
+        val checkpoints = mockk<PollCheckpointStore>()
+        every { checkpoints.lastLocationLatLng() } returns null
+        every { checkpoints.lastLocationFixAt() } returns null
+
+        val result = provider.acquireForEveningPlan(checkpoints, settings())
+        assertEquals(LocationSource.Unavailable, result.source)
+        assertEquals(0.0, result.lat, 0.0)
+        assertEquals(0.0, result.lng, 0.0)
+        assertNull(result.accuracyMeters)
+    }
+
+    @Test
+    fun no_permission_falls_back_to_stored_last_known_fix() = runTest {
+        val checkpoints = mockk<PollCheckpointStore>()
+        every { checkpoints.lastLocationLatLng() } returns (46.624 to 14.308)
+        every { checkpoints.lastLocationFixAt() } returns fr.bsodium.cron.testutil.Fixtures.T0
+
+        val result = provider.acquireForEveningPlan(checkpoints, settings())
+        assertEquals(LocationSource.LastKnown, result.source)
+        assertEquals(46.624, result.lat, 0.0001)
+        assertEquals(14.308, result.lng, 0.0001)
+    }
+
+    @Test
+    fun no_permission_and_no_stored_fix_falls_back_to_home_address() = runTest {
+        val checkpoints = mockk<PollCheckpointStore>()
+        every { checkpoints.lastLocationLatLng() } returns null
+        every { checkpoints.lastLocationFixAt() } returns null
+
+        val result = provider.acquireForEveningPlan(checkpoints, settings(homeLat = 48.85, homeLng = 2.35))
+        assertEquals(LocationSource.HomeAddress, result.source)
+        assertEquals(48.85, result.lat, 0.0001)
+        assertEquals(2.35, result.lng, 0.0001)
+    }
+
+    @Test
+    fun stored_last_known_fix_is_preferred_over_home_address() = runTest {
+        val checkpoints = mockk<PollCheckpointStore>()
+        every { checkpoints.lastLocationLatLng() } returns (46.624 to 14.308)
+        every { checkpoints.lastLocationFixAt() } returns fr.bsodium.cron.testutil.Fixtures.T0
+
+        val result = provider.acquireForEveningPlan(checkpoints, settings(homeLat = 48.85, homeLng = 2.35))
+        assertEquals(LocationSource.LastKnown, result.source)
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/permissions/SystemPermissionsTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/permissions/SystemPermissionsTest.kt
@@ -1,0 +1,50 @@
+package fr.bsodium.cron.permissions
+
+import android.Manifest
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Thin wrapper around Android permission checks — minimal smoke coverage confirming the boolean
+ * reflects the granted/revoked state, not exhaustive per-SDK-level branching.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SystemPermissionsTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    @Test
+    fun hasForegroundLocation_is_false_when_nothing_granted() {
+        assertFalse(SystemPermissions.hasForegroundLocation(context))
+    }
+
+    @Test
+    fun hasForegroundLocation_is_true_once_fine_location_is_granted() {
+        shadowOf(context).grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
+        assertTrue(SystemPermissions.hasForegroundLocation(context))
+    }
+
+    @Test
+    fun hasForegroundLocation_is_true_with_only_coarse_location_granted() {
+        shadowOf(context).grantPermissions(Manifest.permission.ACCESS_COARSE_LOCATION)
+        assertTrue(SystemPermissions.hasForegroundLocation(context))
+    }
+
+    @Test
+    fun batteryOptimizationIntent_targets_this_package() {
+        val intent = SystemPermissions.batteryOptimizationIntent(context)
+        assertTrue(intent.data.toString().contains(context.packageName))
+    }
+
+    @Test
+    fun exactAlarmSettingsIntent_targets_this_package() {
+        val intent = SystemPermissions.exactAlarmSettingsIntent(context)
+        assertTrue(intent.data.toString().contains(context.packageName))
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/settings/PollCheckpointStoreTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/settings/PollCheckpointStoreTest.kt
@@ -1,0 +1,53 @@
+package fr.bsodium.cron.settings
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import fr.bsodium.cron.testutil.Fixtures
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PollCheckpointStoreTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    @Test
+    fun missing_health_connect_checkpoint_returns_null() {
+        assertNull(PollCheckpointStore(context).lastHealthConnectPoll())
+    }
+
+    @Test
+    fun health_connect_checkpoint_round_trips() {
+        val store = PollCheckpointStore(context)
+        store.setLastHealthConnectPoll(Fixtures.T0)
+        assertEquals(Fixtures.T0, store.lastHealthConnectPoll())
+    }
+
+    @Test
+    fun missing_location_fix_returns_null_for_both_timestamp_and_latlng() {
+        val store = PollCheckpointStore(context)
+        assertNull(store.lastLocationFixAt())
+        assertNull(store.lastLocationLatLng())
+    }
+
+    @Test
+    fun location_fix_round_trips_timestamp_and_coordinates() {
+        val store = PollCheckpointStore(context)
+        store.setLastLocationFix(46.624, 14.308, Fixtures.T0)
+
+        assertEquals(Fixtures.T0, store.lastLocationFixAt())
+        val latLng = store.lastLocationLatLng()
+        assertEquals(46.624, latLng?.first ?: Double.NaN, 0.001)
+        assertEquals(14.308, latLng?.second ?: Double.NaN, 0.001)
+    }
+
+    @Test
+    fun checkpoints_persist_across_store_instances() {
+        PollCheckpointStore(context).setLastLocationFix(1.0, 2.0, Fixtures.T0)
+        val reloaded = PollCheckpointStore(context)
+        assertEquals(Fixtures.T0, reloaded.lastLocationFixAt())
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/settings/SettingsRepositoryTest.kt
@@ -1,0 +1,154 @@
+package fr.bsodium.cron.settings
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import fr.bsodium.cron.ai.BudgetStore
+import fr.bsodium.cron.calendar.DEFAULT_RSVP_STATUSES
+import fr.bsodium.cron.calendar.RsvpStatus
+import fr.bsodium.cron.session.model.CommuteMode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The `preferencesDataStore` delegate in SettingsRepository.kt caches its Preferences in-process
+ * for the JVM's lifetime (Gradle doesn't fork per test class), so every test in this class resets
+ * the fields it can via setters in [setUp]. Fields with no "unset" API (home address, onboarding)
+ * are covered separately in [SettingsRepositoryWriteOnceDefaultsTest].
+ */
+@RunWith(RobolectricTestRunner::class)
+class SettingsRepositoryTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+    private val repo = SettingsRepository(context)
+
+    @Before
+    fun setUp() = runTest {
+        repo.setEveningTriggerLocalTime(LocalTime(20, 0))
+        repo.setHardLatestDefault(LocalTime(10, 0))
+        repo.setFreeDayWakeWindow(LocalTime(8, 0), LocalTime(9, 30))
+        repo.setCommuteBufferMinutes(15)
+        repo.setPreparationBufferMinutes(15)
+        repo.setAllowedCommuteModes(CommuteMode.entries.toSet())
+        repo.setAllowedRsvpStatuses(DEFAULT_RSVP_STATUSES)
+        repo.setHapticsEnabled(true)
+        repo.setCompactNavEnabled(false)
+        repo.setAutoAlarmsEnabled(true)
+        repo.setDisplayName("")
+        repo.setUserInstructions("")
+        repo.setDailyTokenLimit(BudgetStore.DEFAULT_DAILY_TOKEN_LIMIT)
+    }
+
+    private suspend fun <T> Flow<T>.first(): T {
+        var result: T? = null
+        test(timeout = 5.seconds) {
+            result = awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        @Suppress("UNCHECKED_CAST")
+        return result as T
+    }
+
+    @Test
+    fun defaults_match_documented_values() = runTest {
+        assertEquals(LocalTime(20, 0), repo.eveningTriggerLocalTime.first())
+        assertEquals(LocalTime(10, 0), repo.hardLatestDefault.first())
+        assertEquals(LocalTime(8, 0), repo.freeDayWakeStart.first())
+        assertEquals(LocalTime(9, 30), repo.freeDayWakeEnd.first())
+        assertEquals(15, repo.commuteBufferMinutes.first())
+        assertEquals(15, repo.preparationBufferMinutes.first())
+        assertEquals(CommuteMode.entries.toSet(), repo.allowedCommuteModes.first())
+        assertEquals(DEFAULT_RSVP_STATUSES, repo.allowedRsvpStatuses.first())
+        assertTrue(repo.hapticsEnabled.first())
+        assertFalse(repo.compactNavEnabled.first())
+        assertTrue(repo.autoAlarmsEnabled.first())
+    }
+
+    @Test
+    fun setEveningTriggerLocalTime_is_reflected_and_stamps_settingsUpdatedAt() = runTest {
+        repo.setEveningTriggerLocalTime(LocalTime(21, 15))
+        repo.eveningTriggerLocalTime.test(timeout = 5.seconds) {
+            assertEquals(LocalTime(21, 15), awaitItem())
+        }
+        repo.settingsUpdatedAt.test(timeout = 5.seconds) {
+            assertTrue(awaitItem() > 0L)
+        }
+    }
+
+    @Test
+    fun setHapticsEnabled_does_not_stamp_settingsUpdatedAt() = runTest {
+        val before = repo.settingsUpdatedAt.first()
+        repo.setHapticsEnabled(false)
+        repo.hapticsEnabled.test(timeout = 5.seconds) { assertFalse(awaitItem()) }
+        val after = repo.settingsUpdatedAt.first()
+        assertEquals(before, after)
+    }
+
+    @Test
+    fun allowedCommuteModes_round_trips_a_restricted_set() = runTest {
+        repo.setAllowedCommuteModes(setOf(CommuteMode.Walk))
+        repo.allowedCommuteModes.test(timeout = 5.seconds) {
+            assertEquals(setOf(CommuteMode.Walk), awaitItem())
+        }
+    }
+
+    @Test
+    fun allowedCommuteModes_empty_set_reads_back_as_all_modes() = runTest {
+        repo.setAllowedCommuteModes(emptySet())
+        repo.allowedCommuteModes.test(timeout = 5.seconds) {
+            assertEquals(CommuteMode.entries.toSet(), awaitItem())
+        }
+    }
+
+    @Test
+    fun allowedRsvpStatuses_round_trips_a_restricted_set() = runTest {
+        repo.setAllowedRsvpStatuses(setOf(RsvpStatus.Accepted))
+        repo.allowedRsvpStatuses.test(timeout = 5.seconds) {
+            assertEquals(setOf(RsvpStatus.Accepted), awaitItem())
+        }
+    }
+
+    @Test
+    fun autoAlarmsEnabledNow_reflects_the_persisted_flag() = runTest {
+        assertTrue(repo.autoAlarmsEnabledNow())
+        repo.setAutoAlarmsEnabled(false)
+        assertFalse(repo.autoAlarmsEnabledNow())
+        repo.setAutoAlarmsEnabled(true)
+        assertTrue(repo.autoAlarmsEnabledNow())
+    }
+
+    @Test
+    fun displayName_blank_reads_back_as_null() = runTest {
+        repo.setDisplayName("  ")
+        repo.displayName.test(timeout = 5.seconds) { assertNull(awaitItem()) }
+    }
+
+    @Test
+    fun displayName_is_trimmed_on_write() = runTest {
+        repo.setDisplayName("  Elliot  ")
+        repo.displayName.test(timeout = 5.seconds) { assertEquals("Elliot", awaitItem()) }
+    }
+
+    @Test
+    fun userInstructions_blank_reads_back_as_null() = runTest {
+        repo.setUserInstructions("   ")
+        repo.userInstructions.test(timeout = 5.seconds) { assertNull(awaitItem()) }
+        assertNull(repo.currentUserInstructions())
+    }
+
+    @Test
+    fun currentDailyTokenLimit_reflects_persisted_value() = runTest {
+        repo.setDailyTokenLimit(500)
+        assertEquals(500, repo.currentDailyTokenLimit())
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/settings/SettingsRepositoryWriteOnceDefaultsTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/settings/SettingsRepositoryWriteOnceDefaultsTest.kt
@@ -1,0 +1,54 @@
+package fr.bsodium.cron.settings
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.FixMethodOrder
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.MethodSorters
+import org.robolectric.RobolectricTestRunner
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * homeAddressLat/Lng and onboardingComplete have no "unset" API, so — unlike
+ * [SettingsRepositoryTest] — this class can't reset them between tests. [MethodSorters.NAME_ASCENDING]
+ * keeps the default-reading test alphabetically first, before the mutating test runs.
+ *
+ * settingsUpdatedAt is deliberately not asserted to be zero here: it's a process-wide DataStore
+ * singleton (see SettingsRepositoryTest's class doc) that any other plan-affecting test in the
+ * suite may have already stamped, so "defaults to zero" isn't a safe cross-class assertion. Its
+ * stamping behavior is covered by SettingsRepositoryTest instead.
+ */
+@RunWith(RobolectricTestRunner::class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+class SettingsRepositoryWriteOnceDefaultsTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+    private val repo = SettingsRepository(context)
+
+    @Test
+    fun a_defaults_are_unset() = runTest {
+        repo.homeAddressLat.test(timeout = 5.seconds) { assertNull(awaitItem()) }
+        repo.homeAddressLng.test(timeout = 5.seconds) { assertNull(awaitItem()) }
+        repo.onboardingComplete.test(timeout = 5.seconds) { assertFalse(awaitItem()) }
+    }
+
+    @Test
+    fun b_setOnboardingComplete_flips_the_flag() = runTest {
+        repo.setOnboardingComplete()
+        repo.onboardingComplete.test(timeout = 5.seconds) { assertTrue(awaitItem()) }
+    }
+
+    @Test
+    fun c_homeAddress_round_trips_lat_lng() = runTest {
+        repo.setHomeAddress(48.85, 2.35)
+        repo.homeAddressLat.test(timeout = 5.seconds) { assertEquals(48.85, awaitItem()) }
+        repo.homeAddressLng.test(timeout = 5.seconds) { assertEquals(2.35, awaitItem()) }
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/travel/GeocodingClientTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/travel/GeocodingClientTest.kt
@@ -1,0 +1,109 @@
+package fr.bsodium.cron.travel
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeocodingClientTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() = server.shutdown()
+
+    /** GeocodingClient hardcodes the maps.googleapis.com host, so requests are redirected to the
+     *  MockWebServer via an interceptor that keeps the original path and query intact. */
+    private fun client(): GeocodingClient {
+        val http = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val redirected = chain.request().url.newBuilder()
+                    .scheme("http")
+                    .host(server.hostName)
+                    .port(server.port)
+                    .build()
+                chain.proceed(chain.request().newBuilder().url(redirected).build())
+            }
+            .build()
+        return GeocodingClient(apiKey = "test-key", http = http)
+    }
+
+    @Test
+    fun successful_response_returns_first_result() = runTest {
+        server.enqueue(
+            MockResponse().setBody(
+                """
+                {"results":[{"formatted_address":"1 Rue de Rivoli, Paris","geometry":{"location":{"lat":48.8566,"lng":2.3522}}}]}
+                """.trimIndent(),
+            ),
+        )
+
+        val result = client().geocode("1 Rue de Rivoli").getOrThrow()
+        assertEquals(48.8566, result.lat, 0.0001)
+        assertEquals(2.3522, result.lng, 0.0001)
+        assertEquals("1 Rue de Rivoli, Paris", result.formattedAddress)
+
+        val request = server.takeRequest()
+        assertTrue(request.path.orEmpty().contains("address=1"))
+        assertTrue(request.path.orEmpty().contains("key=test-key"))
+    }
+
+    @Test
+    fun bias_adds_a_bounds_parameter() = runTest {
+        server.enqueue(MockResponse().setBody("""{"results":[{"geometry":{"location":{"lat":1.0,"lng":2.0}}}]}"""))
+
+        client().geocode("Hauptbahnhof", bias = LatLng(46.624, 14.308)).getOrThrow()
+
+        val request = server.takeRequest()
+        assertTrue(request.path.orEmpty().contains("bounds="))
+    }
+
+    @Test
+    fun missing_results_key_is_a_failure() = runTest {
+        server.enqueue(MockResponse().setBody("""{"status":"ZERO_RESULTS"}"""))
+        val result = client().geocode("nowhere")
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun empty_results_array_is_a_failure() = runTest {
+        server.enqueue(MockResponse().setBody("""{"results":[]}"""))
+        val result = client().geocode("nowhere")
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun http_error_response_is_a_failure() = runTest {
+        server.enqueue(MockResponse().setResponseCode(403).setBody("""{"error_message":"key invalid"}"""))
+        val result = client().geocode("somewhere")
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun malformed_json_is_a_failure() = runTest {
+        server.enqueue(MockResponse().setBody("not json"))
+        val result = client().geocode("somewhere")
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun formatted_address_falls_back_to_the_query_when_missing() = runTest {
+        server.enqueue(MockResponse().setBody("""{"results":[{"geometry":{"location":{"lat":1.0,"lng":2.0}}}]}"""))
+        val result = client().geocode("Some Place").getOrThrow()
+        assertEquals("Some Place", result.formattedAddress)
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/travel/RoutesClientTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/travel/RoutesClientTest.kt
@@ -1,0 +1,114 @@
+package fr.bsodium.cron.travel
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RoutesClientTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() = server.shutdown()
+
+    /** RoutesClient hardcodes the routes.googleapis.com host, so requests are redirected to the
+     *  MockWebServer via an interceptor that keeps the original path, query and body intact. */
+    private fun client(): RoutesClient {
+        val http = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val redirected = chain.request().url.newBuilder()
+                    .scheme("http")
+                    .host(server.hostName)
+                    .port(server.port)
+                    .build()
+                chain.proceed(chain.request().newBuilder().url(redirected).build())
+            }
+            .build()
+        return RoutesClient(apiKey = "test-key", http = http)
+    }
+
+    @Test
+    fun successful_response_parses_duration_and_distance() = runTest {
+        server.enqueue(
+            MockResponse().setBody("""{"routes":[{"duration":"620s","distanceMeters":4200}]}"""),
+        )
+
+        val result = client().estimate(1.0, 2.0, 3.0, 4.0, mode = RoutesClient.TravelMode.TRANSIT).getOrThrow()
+        assertEquals(620L, result.durationSeconds)
+        assertEquals(4200, result.distanceMeters)
+
+        val request = server.takeRequest()
+        assertEquals("test-key", request.getHeader("X-Goog-Api-Key"))
+        val body = JSONObject(request.body.readUtf8())
+        assertEquals("TRANSIT", body.getString("travelMode"))
+    }
+
+    @Test
+    fun arrival_time_is_only_sent_for_transit_mode() = runTest {
+        server.enqueue(MockResponse().setBody("""{"routes":[{"duration":"1s","distanceMeters":1}]}"""))
+        client().estimate(1.0, 2.0, 3.0, 4.0, mode = RoutesClient.TravelMode.DRIVE, arrivalTimeEpochMs = 1_000L).getOrThrow()
+
+        val body = JSONObject(server.takeRequest().body.readUtf8())
+        assertTrue(!body.has("arrivalTime"))
+    }
+
+    @Test
+    fun arrival_time_is_sent_as_iso_instant_for_transit_mode() = runTest {
+        server.enqueue(MockResponse().setBody("""{"routes":[{"duration":"1s","distanceMeters":1}]}"""))
+        client().estimate(1.0, 2.0, 3.0, 4.0, mode = RoutesClient.TravelMode.TRANSIT, arrivalTimeEpochMs = 0L).getOrThrow()
+
+        val body = JSONObject(server.takeRequest().body.readUtf8())
+        assertEquals("1970-01-01T00:00:00Z", body.getString("arrivalTime"))
+    }
+
+    @Test
+    fun no_routes_in_response_is_a_failure() = runTest {
+        server.enqueue(MockResponse().setBody("""{"routes":[]}"""))
+        val result = client().estimate(1.0, 2.0, 3.0, 4.0)
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun missing_routes_key_is_a_failure() = runTest {
+        server.enqueue(MockResponse().setBody("""{}"""))
+        val result = client().estimate(1.0, 2.0, 3.0, 4.0)
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun unparsable_duration_is_a_failure() = runTest {
+        server.enqueue(MockResponse().setBody("""{"routes":[{"duration":"not-a-duration","distanceMeters":1}]}"""))
+        val result = client().estimate(1.0, 2.0, 3.0, 4.0)
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun http_error_response_is_a_failure() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500).setBody("""{"error":"internal"}"""))
+        val result = client().estimate(1.0, 2.0, 3.0, 4.0)
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun missing_distance_defaults_to_zero() = runTest {
+        server.enqueue(MockResponse().setBody("""{"routes":[{"duration":"5s"}]}"""))
+        val result = client().estimate(1.0, 2.0, 3.0, 4.0).getOrThrow()
+        assertEquals(0, result.distanceMeters)
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit test coverage to five packages that previously had zero tests. No production behavior changes except a small, safe extraction in `LocationProvider` (see below).

## Coverage by package

**`calendar/`**
- `RsvpStatusTest` — code-to-status mapping, unknown-code handling, `DEFAULT_RSVP_STATUSES` contents.
- `CalendarReaderTest` — field mapping, blank-location normalization, missing-title placeholder, RSVP filtering, null-cursor and `SecurityException` (permission-revoked) handling.
- `CalendarChangeAnalyzerTest` — unchanged vs. changed signature detection, all-day event exclusion, RSVP-status filtering (declined events excluded/included per configured set).

**`location/`**
- Extracted `LocationProvider.isWithinAccuracyCap()` and `LocationProvider.isRecent()` into small `internal` companion functions (following the `AlarmScheduler.clamp()` pattern) so the accuracy-cap and recency logic is directly unit-testable — `LocationProviderAccuracyTest`.
- `LocationProviderFallbackTest` — Robolectric grants no permissions by default, so `acquireForEveningPlan()` takes the `permission_denied` branch without touching `FusedLocationProviderClient`, exercising the fallback-tier ordering: stored last-known fix → home address → unavailable.

**`settings/`**
- `PollCheckpointStoreTest` — health-connect/location checkpoint round-trips, missing-checkpoint defaults.
- `SettingsRepositoryTest` / `SettingsRepositoryWriteOnceDefaultsTest` — documented defaults, plan-affecting vs. plain edits (`settingsUpdatedAt` stamping behavior), RSVP/commute-mode set round-trips (including "empty set reads back as all allowed"), blank-string normalization, `autoAlarmsEnabledNow()`.
  - Split into two classes because the `preferencesDataStore` delegate caches its `Preferences` in-process for the JVM's lifetime (Gradle doesn't fork per test class), so fields with no "unset" API (home address, onboarding) needed test-order isolation from the resettable-field tests.
- `SecureKeyStore` is **not** covered — see "Known gaps" below.

**`travel/`**
- `GeocodingClientTest` / `RoutesClientTest` — via MockWebServer, following `AnthropicClientStreamTest`'s pattern. Both clients hardcode their production host, so requests are redirected to the MockWebServer with an OkHttp interceptor rewriting scheme/host/port while preserving path/query/body. Covers request construction (query params, bias bounds, headers, JSON body shape, TRANSIT-only `arrivalTime`), response parsing, and error handling (HTTP 4xx/5xx, malformed JSON, missing/empty results).

**`permissions/`**
- `SystemPermissionsTest` — minimal smoke coverage per the low-priority guidance: permission-boolean reflects `grantPermissions()` state, deep-link intents target this package.

## Known gaps

- **`SecureKeyStore` has no test.** `EncryptedSharedPreferences`/`MasterKey` requires the `AndroidKeyStore` security provider, which Robolectric's plain-JVM sandbox doesn't shadow — construction fails with `NoSuchAlgorithmException` outside a real device/emulator, and the class has no injection seam to substitute a fake. Left uncovered rather than adding a production-code seam beyond this PR's scope.

## No bugs discovered

Nothing in the covered classes' behavior looked wrong while writing these tests — no separate fix PR needed.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — full suite green, verified stable across repeated runs (DataStore singleton pollution across `settings` test classes was diagnosed and fixed via explicit reset/ordering).
- [x] `./gradlew :app:assembleDebug :app:lintDebug :app:checkFileLength :app:checkAnimationPreviews` — all green.