### PR TITLE
fix(session): close re-ring and completion guarantee gaps found by audit

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/alarm/AlarmRingingState.kt
+++ b/app/src/main/java/fr/bsodium/cron/alarm/AlarmRingingState.kt
@@ -1,0 +1,24 @@
+package fr.bsodium.cron.alarm
+
+/**
+ * Process-wide "is an alarm currently ringing" flag.
+ *
+ * Set when [fr.bsodium.cron.receiver.AlarmReceiver] fires the full-screen alarm UI, cleared on
+ * dismiss or snooze. Lets [fr.bsodium.cron.sensors.ScreenStateMonitor] tell "the user is unlocking
+ * specifically to silence the alarm that's currently ringing" (the keyguard-dismiss that precedes
+ * every slide-to-dismiss gesture) apart from "the user genuinely got out of bed on their own" — only
+ * the latter should synthesize an [fr.bsodium.cron.session.model.TriggerType.OutOfBedConfirmed] event.
+ */
+object AlarmRingingState {
+    @Volatile
+    var isRinging: Boolean = false
+        private set
+
+    fun markRinging() {
+        isRinging = true
+    }
+
+    fun markNotRinging() {
+        isRinging = false
+    }
+}

--- a/app/src/main/java/fr/bsodium/cron/receiver/AlarmReceiver.kt
+++ b/app/src/main/java/fr/bsodium/cron/receiver/AlarmReceiver.kt
@@ -15,6 +15,7 @@ import fr.bsodium.cron.MainActivity
 import fr.bsodium.cron.R
 import fr.bsodium.cron.ui.screens.alarm.AlarmActivity
 import fr.bsodium.cron.alarm.AlarmConstants
+import fr.bsodium.cron.alarm.AlarmRingingState
 import fr.bsodium.cron.session.SessionFsm
 import fr.bsodium.cron.session.SessionRepository
 import fr.bsodium.cron.session.model.EventData
@@ -62,6 +63,8 @@ class AlarmReceiver : BroadcastReceiver() {
         val kind = intent.getStringExtra(AlarmConstants.EXTRA_KIND) ?: "legacy"
         val sessionId = intent.getStringExtra(AlarmConstants.EXTRA_SESSION_ID)
         Log.i(TAG, "Alarm fired kind=$kind label=$label sessionId=$sessionId")
+
+        AlarmRingingState.markRinging()
 
         if (kind == AlarmConstants.KIND_HARD_LATEST && !sessionId.isNullOrBlank()) {
             val pending = goAsync()
@@ -120,6 +123,7 @@ class AlarmReceiver : BroadcastReceiver() {
     }
 
     private fun handleDismiss(context: Context) {
+        AlarmRingingState.markNotRinging()
         (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
             .cancel(NOTIFICATION_ID)
 
@@ -145,6 +149,7 @@ class AlarmReceiver : BroadcastReceiver() {
     }
 
     private fun handleSnooze(context: Context, intent: Intent) {
+        AlarmRingingState.markNotRinging()
         val requestCode = intent.getIntExtra(EXTRA_REQUEST_CODE, 0)
         val label = intent.getStringExtra(EXTRA_LABEL) ?: "Cron Alarm"
 

--- a/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
@@ -7,6 +7,7 @@ import android.content.IntentFilter
 import android.os.BatteryManager
 import android.os.PowerManager
 import android.util.Log
+import fr.bsodium.cron.alarm.AlarmRingingState
 import fr.bsodium.cron.session.model.EventData
 import fr.bsodium.cron.session.model.SessionEvent
 import fr.bsodium.cron.session.model.TriggerType
@@ -40,6 +41,7 @@ class ScreenStateMonitor(
     private val sleepOnsetThreshold: Duration = 20.minutes,
     private val rearmThreshold: Duration = REARM_ONSET_THRESHOLD,
     private val lightReader: AmbientLightReader = AmbientLightReader(context),
+    private val isAlarmRinging: () -> Boolean = { AlarmRingingState.isRinging },
 ) {
 
     private var screenOffSince: Instant? = null
@@ -117,11 +119,23 @@ class ScreenStateMonitor(
      * A genuine unlock is our strongest "awake" signal — the user is handling the phone, not stirring
      * in their sleep. If we'd latched sleep, treat it as getting out of bed (one event → FSM Awake →
      * [rearm]) rather than firing a plan on every pickup.
+     *
+     * Suppressed while an alarm is actively ringing: [AlarmActivity][fr.bsodium.cron.ui.screens.alarm.AlarmActivity]
+     * dismisses the keyguard as soon as it launches, so USER_PRESENT fires a beat before the user's
+     * actual slide-to-dismiss gesture. Without this guard that unlock alone would drive the session to
+     * Awake, and the dismiss gesture right behind it would then complete the session immediately —
+     * collapsing the dismiss-while-asleep re-ring guarantee on the very first (and only) real
+     * dismissal. Suppressing here leaves status Monitoring/ReMonitoring, so AlarmDismissed itself
+     * carries the transition to Awake as intended.
      */
     private fun onUserPresent() {
         screenOffSince = null
         pendingOnset?.cancel()
         if (!sleepOnsetEmitted) return
+        if (isAlarmRinging()) {
+            Log.i(TAG, "User present while an alarm is ringing — treating as the dismiss unlock, not out-of-bed")
+            return
+        }
         sleepOnsetEmitted = false
         scope.launch {
             sink.emit(

--- a/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
+++ b/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
@@ -75,22 +75,21 @@ class SleepSessionService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        when (intent?.action) {
-            ACTION_STOP -> {
-                stop()
-                return START_NOT_STICKY
-            }
-            ACTION_REARM -> {
-                screenStateMonitor?.rearm()
-                return START_STICKY
-            }
+        if (intent?.action == ACTION_STOP) {
+            stop()
+            return START_NOT_STICKY
         }
+        val isRearm = intent?.action == ACTION_REARM
         val eveningPlan = intent?.action == ACTION_EVENING_PLAN
         ensureNotificationChannel()
         // Location-typed FGS keeps the fetch "in use" on foreground permission alone; a sticky restart (null intent) only resumes monitoring, never re-fires the plan.
         startForegroundService(includeLocation = eveningPlan)
 
-        if (screenStateMonitor == null) {
+        // A REARM after the service was killed and restarted fresh finds screenStateMonitor null —
+        // treat that the same as a normal start (build the monitors) before rearming, so REARM never
+        // silently no-ops and leaves the session with no sensors and no foreground notification.
+        val freshlyConstructed = screenStateMonitor == null
+        if (freshlyConstructed) {
             screenStateMonitor = ScreenStateMonitor(
                 applicationContext,
                 fsmSink,
@@ -101,6 +100,12 @@ class SleepSessionService : Service() {
         }
         if (activityRecognitionMonitor == null) {
             activityRecognitionMonitor = ActivityRecognitionMonitor(applicationContext, fsmSink, serviceScope).also { it.start() }
+        }
+
+        // Only rearm explicitly on a fresh construction — start() already seeds onset detection
+        // from the current screen state, and rearm() would just redundantly reset the same latch.
+        if (isRearm && !freshlyConstructed) {
+            screenStateMonitor?.rearm()
         }
 
         if (eveningPlan) {

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -179,8 +179,9 @@ class SessionFsm(
             SessionStatus.Complete -> {
                 alarmScheduler.cancel(session.date)
                 hardLatestScheduler.clear(session.date)
+                repository.cancelAiTurn(session.id)
                 context.startService(SleepSessionService.stopIntent(context))
-                Log.i(TAG, "Session ${session.id} complete — alarms cleared, service stopped")
+                Log.i(TAG, "Session ${session.id} complete — alarms cleared, AI turn cancelled, service stopped")
             }
             SessionStatus.Planning, SessionStatus.Monitoring, SessionStatus.ReMonitoring -> {}
         }

--- a/app/src/test/java/fr/bsodium/cron/sensors/ScreenStateMonitorUserPresentTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/sensors/ScreenStateMonitorUserPresentTest.kt
@@ -1,0 +1,110 @@
+package fr.bsodium.cron.sensors
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.os.Looper
+import android.os.PowerManager
+import androidx.test.core.app.ApplicationProvider
+import fr.bsodium.cron.session.model.SessionEvent
+import fr.bsodium.cron.session.model.TriggerType
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import kotlin.time.Duration.Companion.ZERO
+
+/**
+ * Regresses Bug 3: [AlarmActivity][fr.bsodium.cron.ui.screens.alarm.AlarmActivity] dismisses the
+ * keyguard on launch, so a real device fires USER_PRESENT a beat before the user's actual
+ * slide-to-dismiss gesture. Left unguarded, that unlock alone drives the session to Awake and the
+ * dismiss gesture right behind it then completes the session immediately — collapsing the
+ * dismiss-while-asleep re-ring guarantee on the very first real dismissal.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class ScreenStateMonitorUserPresentTest {
+
+    private val app: Application = ApplicationProvider.getApplicationContext()
+
+    private class RecordingSink : SensorEventSink {
+        val received = mutableListOf<SessionEvent>()
+        override suspend fun emit(event: SessionEvent) {
+            received += event
+        }
+    }
+
+    private fun seedScreenOff() {
+        val powerManager = app.getSystemService(Context.POWER_SERVICE) as PowerManager
+        shadowOf(powerManager).setIsInteractive(false)
+    }
+
+    private fun sendBroadcastAndIdle(action: String) {
+        app.sendBroadcast(Intent(action))
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    @Test
+    fun user_present_while_alarm_ringing_does_not_emit_out_of_bed() = runTest {
+        seedScreenOff()
+        val sink = RecordingSink()
+        val monitor = ScreenStateMonitor(
+            context = app,
+            sink = sink,
+            scope = this,
+            sleepOnsetThreshold = ZERO,
+            lightReader = AmbientLightReader(app),
+            isAlarmRinging = { true },
+        )
+        try {
+            monitor.start()
+            advanceUntilIdle()
+            assertTrue(
+                "precondition: onset should have latched before USER_PRESENT",
+                sink.received.any { it.trigger == TriggerType.SleepOnset },
+            )
+            sink.received.clear()
+
+            sendBroadcastAndIdle(Intent.ACTION_USER_PRESENT)
+            advanceUntilIdle()
+
+            assertTrue(
+                "OutOfBedConfirmed must be suppressed while an alarm is ringing",
+                sink.received.none { it.trigger == TriggerType.OutOfBedConfirmed },
+            )
+        } finally {
+            monitor.stop()
+        }
+    }
+
+    @Test
+    fun user_present_while_no_alarm_ringing_emits_out_of_bed() = runTest {
+        seedScreenOff()
+        val sink = RecordingSink()
+        val monitor = ScreenStateMonitor(
+            context = app,
+            sink = sink,
+            scope = this,
+            sleepOnsetThreshold = ZERO,
+            lightReader = AmbientLightReader(app),
+            isAlarmRinging = { false },
+        )
+        try {
+            monitor.start()
+            advanceUntilIdle()
+            sink.received.clear()
+
+            sendBroadcastAndIdle(Intent.ACTION_USER_PRESENT)
+            advanceUntilIdle()
+
+            assertEquals(1, sink.received.count { it.trigger == TriggerType.OutOfBedConfirmed })
+        } finally {
+            monitor.stop()
+        }
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/service/SleepSessionServiceTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/service/SleepSessionServiceTest.kt
@@ -1,0 +1,75 @@
+package fr.bsodium.cron.service
+
+import android.app.Application
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.WorkManagerTestInitHelper
+import fr.bsodium.cron.session.db.CronDatabase
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ServiceController
+
+@RunWith(RobolectricTestRunner::class)
+class SleepSessionServiceTest {
+
+    private lateinit var app: Application
+    private lateinit var notificationManager: NotificationManager
+    private var controller: ServiceController<SleepSessionService>? = null
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        WorkManagerTestInitHelper.initializeTestWorkManager(app)
+        runBlocking { CronDatabase.get(app).sessionDao().deleteOlderThan(Long.MAX_VALUE) }
+        notificationManager = app.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+
+    @After
+    fun tearDown() {
+        controller?.destroy()
+    }
+
+    /**
+     * Regresses Bug 1: a REARM delivered to a service instance that was just (re)created by Android
+     * (e.g. after the OS killed the previous instance) must NOT silently no-op on a null monitor — it
+     * must go through the same construction path as a normal start, ending up foregrounded with a
+     * running notification, exactly as ACTION_STOP/no-action starts do today.
+     */
+    @Test
+    fun rearm_on_freshly_created_service_starts_foreground_and_builds_monitor() {
+        controller = Robolectric.buildService(
+            SleepSessionService::class.java,
+            SleepSessionService.rearmIntent(app),
+        )
+        controller?.create()?.startCommand(0, 0)
+
+        val notification = shadowOf(notificationManager).activeNotifications
+            .firstOrNull { it.id == SleepSessionService.NOTIFICATION_ID }
+        assertTrue(
+            "REARM on a fresh service instance must still post the foreground notification " +
+                "(i.e. construct monitors), not silently no-op on a null screenStateMonitor",
+            notification != null,
+        )
+    }
+
+    @Test
+    fun plain_start_then_rearm_keeps_service_foregrounded() {
+        controller = Robolectric.buildService(SleepSessionService::class.java, SleepSessionService.startIntent(app))
+        val service = controller?.create()?.startCommand(0, 0)?.get()
+        requireNotNull(service)
+
+        service.onStartCommand(SleepSessionService.rearmIntent(app), 0, 1)
+
+        val notification = shadowOf(notificationManager).activeNotifications
+            .firstOrNull { it.id == SleepSessionService.NOTIFICATION_ID }
+        assertTrue(notification != null)
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/session/SessionFsmCompleteTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/session/SessionFsmCompleteTest.kt
@@ -1,0 +1,73 @@
+package fr.bsodium.cron.session
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.WorkManagerTestInitHelper
+import fr.bsodium.cron.session.model.EventData
+import fr.bsodium.cron.session.model.SessionEvent
+import fr.bsodium.cron.session.model.SessionStatus
+import fr.bsodium.cron.session.model.TriggerType
+import fr.bsodium.cron.testutil.Fixtures
+import fr.bsodium.cron.worker.AiTurnWorker
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regresses Bug 2: completing a session (e.g. AlarmDismissed while already Awake) must cancel any
+ * in-flight AI turn — otherwise a worker enqueued by the just-prior OutOfBedConfirmed event can still
+ * run against the completed session and arm a ghost alarm nothing in the lifecycle will clear.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SessionFsmCompleteTest {
+
+    private lateinit var app: Application
+    private lateinit var repository: SessionRepository
+    private lateinit var fsm: SessionFsm
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        WorkManagerTestInitHelper.initializeTestWorkManager(app)
+        repository = SessionRepository(app)
+        fsm = SessionFsm(app, repository)
+        runBlocking { repository.clearAll() }
+    }
+
+    @Test
+    fun completing_a_session_cancels_its_in_flight_ai_turn() = runBlocking {
+        val plan = Fixtures.dayPlan()
+        val session = repository.createSession(plan, Fixtures.DATE, "Europe/Paris")
+        repository.updateStatus(session.id, SessionStatus.Awake)
+        repository.triggerAiTurn(session.id)
+
+        val workName = "${AiTurnWorker.WORK_PREFIX}${session.id}"
+        val beforeInfos = WorkManager.getInstance(app).getWorkInfosForUniqueWork(workName).get()
+        assertTrue(
+            "precondition: AI turn should be enqueued before completion",
+            beforeInfos.any { it.state == WorkInfo.State.ENQUEUED },
+        )
+
+        fsm.onEvent(
+            SessionEvent(
+                trigger = TriggerType.AlarmDismissed,
+                timestamp = Fixtures.T0,
+                data = EventData.Empty,
+            ),
+        )
+
+        val completed = repository.findById(session.id)
+        assertTrue(completed?.status == SessionStatus.Complete)
+
+        val afterInfos = WorkManager.getInstance(app).getWorkInfosForUniqueWork(workName).get()
+        assertTrue(
+            "AI turn must be cancelled once the session completes",
+            afterInfos.all { it.state.isFinished && it.state == WorkInfo.State.CANCELLED },
+        )
+    }
+}


### PR DESCRIPTION
## Context

A prior deep audit of the sleep-session state machine found three P1 bugs undermining the core promise: the alarm reliably rings, and reliably re-rings if the user falls back asleep after dismissing. This builds on a9699bf (re-ring on dismiss-while-asleep), 044b565 (sleep-detection/toggle audit), and 63d0d73 (worker gates) — all three fixes below are scoped tightly around the same guarantee those PRs shipped.

## Bug 1 — ACTION_REARM was a silent no-op if the service wasn't running

**Scenario:** FSM transitions to `Awake` → sends `startService(rearmIntent)`. If the foreground service had been killed in the meantime (low-memory killer, force-stop, crash), Android creates a fresh `SleepSessionService` instance. `onStartCommand` hit the `ACTION_REARM` branch, `screenStateMonitor` was `null` (fresh instance, never initialized) → `?.rearm()` silently no-op'd, and the branch returned *before* `startForeground()`/monitor construction ever ran.

**Impact:** the service sat with no sensors and no foreground notification, then got reclaimed (no FGS type declared for that path). No second `SleepOnset` could ever be detected — the alarm would never re-ring after a dismissal in this state.

**Fix:** `ACTION_REARM` now falls through to the same construction path as a normal start whenever `screenStateMonitor` is null — ensures the notification channel, calls `startForeground`, and builds both monitors — then calls `rearm()` explicitly only if the monitor already existed (a fresh construction already seeds onset detection from the current screen state, so an extra `rearm()` there would be redundant).

**Verification:** Robolectric test (`SleepSessionServiceTest`), not just a traced explanation — `Robolectric.buildService` sends `ACTION_REARM` to a freshly built service instance and asserts the foreground notification gets posted (proving monitor construction ran), which fails on the pre-fix code.

## Bug 2 — session completion didn't cancel the in-flight AI turn (ghost alarm)

**Scenario:** normal wake sequence is unlock → `OutOfBedConfirmed` (an AI-trigger, enqueues a turn) → seconds later `AlarmDismissed` → session goes `Complete`. `onStatusChange(Complete)` cancelled both alarms and stopped the service, but never cancelled the just-enqueued AI turn.

**Impact:** the worker could run against an already-`Complete` session, and if the model called `set_alarm`, `AlarmScheduler.schedule` would happily arm a brand-new alarm nothing in the lifecycle can clear — a ghost alarm ringing later in the morning.

**Fix:** `onStatusChange`'s `Complete` branch now also calls `repository.cancelAiTurn(session.id)`, reusing the exact method and call pattern `HomeViewModel`'s toggle-off and `cancelAiPlan` paths already use.

**Verification:** `SessionFsmCompleteTest` (Robolectric + real `WorkManager` test helper) enqueues a real AI turn, drives the FSM Awake → Complete, and asserts the unique work is `CANCELLED`. Confirmed red against the pre-fix code.

## Bug 3 — unlock-before-dismiss ordering silently re-collapsed the re-ring fix

**Scenario:** `AlarmActivity.onCreate` calls `requestDismissKeyguard` immediately on launch. On this very common ordering: keyguard dismisses → `USER_PRESENT` fires → `ScreenStateMonitor.onUserPresent` emits `OutOfBedConfirmed` (`Monitoring` → `Awake`) → a beat later the user's actual slide-to-dismiss gesture emits `AlarmDismissed`, which per the (untouched) transition table, from `Awake`, goes straight to `Complete`. The very first real dismissal completed the session immediately — the dismiss-while-asleep re-ring guarantee from a9699bf never got a chance to engage.

**Fix (judgment call — see below):** no existing signal distinguished "unlocking specifically to silence a ringing alarm" from "genuinely got out of bed unprompted." Added a minimal one: `AlarmRingingState`, a process-wide flag set in `AlarmReceiver.handleAlarmFired` (all alarm kinds — they all launch the full-screen `AlarmActivity`) and cleared on both `handleDismiss` and `handleSnooze`. `ScreenStateMonitor.onUserPresent` takes it as an injectable `isAlarmRinging: () -> Boolean` (matching the existing `lightReader` injection pattern) and suppresses the `OutOfBedConfirmed` emission while true — leaving status `Monitoring`/`ReMonitoring`, so the immediately-following `AlarmDismissed` is the one that carries the transition to `Awake`, exactly per the existing transition table (not touched/restructured).

**Verification:** `ScreenStateMonitorUserPresentTest` (Robolectric): seeds screen-off via `ShadowPowerManager`, lets onset latch, then broadcasts `USER_PRESENT` once with `isAlarmRinging=true` (asserts suppression) and once with `isAlarmRinging=false` (asserts the existing genuine-wake-up behavior is unchanged). Reverting the fix breaks compilation (the constructor parameter it exercises no longer exists) — a strong regression signal.

**⚠️ Needs on-device re-verification before promoting out of draft.** This is the most behaviorally subtle of the three fixes — it depends on the exact ordering and timing of the OS's keyguard-dismiss broadcast relative to the user's swipe gesture, which varies by OEM/Android version and isn't fully reproducible in Robolectric. Please confirm on a real device that: (a) a normal dismissal while the alarm is ringing still re-arms correctly for a second sleep cycle, and (b) a genuine unprompted unlock mid-sleep (no alarm ringing) still fires `OutOfBedConfirmed` as before.

## Branch dependency

This branch forks from `main` (pre-`fix/session-fsm-exhaustive-transitions`, which makes `SessionFsm`'s `transition()`/`onStatusChange()` when-blocks exhaustive with no `else`). The diff here fits an exhaustive-when style (Bug 2 adds one call inside the existing `Complete` branch; the `transition()` table itself is untouched), so the eventual rebase/merge should be low-friction.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` after each commit
- [x] `./gradlew :app:assembleDebug :app:lintDebug :app:checkFileLength :app:checkAnimationPreviews` — all pass
- [x] `./gradlew :app:testDebugUnitTest` — 134 tests, 0 failures, 0 errors
- [x] Each new regression test confirmed red against the pre-fix code, green after
- [ ] **On-device verification of Bug 3's exact keyguard-dismiss → re-ring sequence** (see warning above)

Closes none directly (no linked issue) — flagging for project-board triage as an orphan PR.