### PR TITLE
test: coverage for receiver package

### DIFF
--- a/app/src/test/java/fr/bsodium/cron/receiver/AlarmReceiverTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/receiver/AlarmReceiverTest.kt
@@ -1,0 +1,157 @@
+package fr.bsodium.cron.receiver
+
+import android.app.Application
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.testing.WorkManagerTestInitHelper
+import fr.bsodium.cron.alarm.AlarmConstants
+import fr.bsodium.cron.session.SessionRepository
+import fr.bsodium.cron.session.db.CronDatabase
+import fr.bsodium.cron.session.model.SessionStatus
+import fr.bsodium.cron.session.model.TriggerType
+import fr.bsodium.cron.settings.SettingsRepository
+import fr.bsodium.cron.testutil.Fixtures
+import fr.bsodium.cron.testutil.awaitCondition
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class AlarmReceiverTest {
+
+    private lateinit var app: Application
+    private lateinit var repository: SessionRepository
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        WorkManagerTestInitHelper.initializeTestWorkManager(app)
+        repository = SessionRepository(app)
+        runBlocking {
+            repository.clearAll()
+            // Room's CronDatabase singleton and DataStore's backing file aren't reset between test
+            // classes by Robolectric, so a disabled toggle can leak in from an unrelated test — reset it.
+            SettingsRepository(app).setAutoAlarmsEnabled(true)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        runBlocking { repository.clearAll() }
+    }
+
+    private fun dispatch(action: String, extras: Intent.() -> Unit = {}) {
+        val receiver = AlarmReceiver()
+        app.registerReceiver(receiver, IntentFilter(action))
+        app.sendBroadcast(Intent(action).apply(extras))
+        shadowOf(Looper.getMainLooper()).idle()
+        app.unregisterReceiver(receiver)
+    }
+
+    @Test
+    fun alarm_fired_with_hard_latest_kind_appends_hard_latest_fired_event() = runBlocking {
+        val session = repository.createSession(Fixtures.dayPlan(), Fixtures.DATE, "Europe/Paris")
+        repository.updateStatus(session.id, SessionStatus.Monitoring)
+
+        dispatch(AlarmReceiver.ACTION_ALARM_FIRED) {
+            putExtra(AlarmConstants.EXTRA_KIND, AlarmConstants.KIND_HARD_LATEST)
+            putExtra(AlarmConstants.EXTRA_SESSION_ID, session.id)
+            putExtra(AlarmReceiver.EXTRA_LABEL, "Wake up")
+        }
+
+        awaitCondition {
+            runBlocking { repository.findById(session.id)?.events?.any { it.trigger == TriggerType.HardLatestFired } == true }
+        }
+        // HardLatestFired is a no-op trigger — status must be unaffected.
+        assertEquals(SessionStatus.Monitoring, repository.findById(session.id)?.status)
+    }
+
+    @Test
+    fun dismiss_from_monitoring_rearms_to_awake_and_cancels_notification() = runBlocking {
+        val session = repository.createSession(Fixtures.dayPlan(), Fixtures.DATE, "Europe/Paris")
+        repository.updateStatus(session.id, SessionStatus.Monitoring)
+        postNotification()
+
+        dispatch(AlarmReceiver.ACTION_DISMISS)
+
+        awaitCondition { runBlocking { repository.findById(session.id)?.status == SessionStatus.Awake } }
+        assertTrue(activeNotificationIds().isEmpty())
+    }
+
+    @Test
+    fun dismiss_with_no_active_session_does_not_crash() {
+        postNotification()
+        dispatch(AlarmReceiver.ACTION_DISMISS)
+        shadowOf(Looper.getMainLooper()).idle()
+        // No session to update; the notification is still cancelled unconditionally.
+        assertTrue(activeNotificationIds().isEmpty())
+    }
+
+    @Test
+    fun snooze_below_threshold_increments_count_and_stays_via_fsm() = runBlocking {
+        val session = repository.createSession(Fixtures.dayPlan(), Fixtures.DATE, "Europe/Paris")
+        repository.updateStatus(session.id, SessionStatus.Monitoring)
+
+        dispatch(AlarmReceiver.ACTION_SNOOZE) {
+            putExtra(AlarmReceiver.EXTRA_REQUEST_CODE, 42)
+            putExtra(AlarmReceiver.EXTRA_LABEL, "Wake up")
+        }
+
+        awaitCondition { runBlocking { (repository.findById(session.id)?.events?.size ?: 0) > 0 } }
+        assertEquals(1, repository.findById(session.id)?.events?.count { it.trigger == TriggerType.AlarmSnoozed })
+    }
+
+    @Test
+    fun snooze_with_no_active_session_falls_back_to_simple_snooze_alarm() {
+        dispatch(AlarmReceiver.ACTION_SNOOZE) {
+            putExtra(AlarmReceiver.EXTRA_REQUEST_CODE, 7)
+            putExtra(AlarmReceiver.EXTRA_LABEL, "Wake up")
+        }
+
+        awaitCondition { simpleSnoozePendingIntent(7) != null }
+    }
+
+    @Test
+    fun snooze_with_corrupted_plan_json_falls_back_to_simple_snooze_alarm() = runBlocking {
+        val session = repository.createSession(Fixtures.dayPlan(), Fixtures.DATE, "Europe/Paris")
+        repository.updateStatus(session.id, SessionStatus.Monitoring)
+        val dao = CronDatabase.get(app).sessionDao()
+        val corrupted = requireNotNull(dao.findById(session.id)).copy(planJson = "{not valid json")
+        dao.update(corrupted)
+
+        dispatch(AlarmReceiver.ACTION_SNOOZE) {
+            putExtra(AlarmReceiver.EXTRA_REQUEST_CODE, 13)
+            putExtra(AlarmReceiver.EXTRA_LABEL, "Wake up")
+        }
+
+        awaitCondition { simpleSnoozePendingIntent(13) != null }
+    }
+
+    private fun postNotification() {
+        // handleDismiss/handleSnooze cancel unconditionally; a real prior notification isn't required to
+        // exercise that path, but posting one first is a closer approximation of the real ring→dismiss flow.
+        val nm = app.getSystemService(NotificationManager::class.java)
+        nm.notify(AlarmReceiver.NOTIFICATION_ID, android.app.Notification.Builder(app, AlarmReceiver.CHANNEL_ID).build())
+    }
+
+    private fun activeNotificationIds(): List<Int> =
+        shadowOf(app.getSystemService(NotificationManager::class.java)).activeNotifications.map { it.id }
+
+    private fun simpleSnoozePendingIntent(requestCode: Int): PendingIntent? =
+        PendingIntent.getBroadcast(
+            app,
+            requestCode + 30000,
+            Intent(app, AlarmReceiver::class.java).apply { action = AlarmReceiver.ACTION_ALARM_FIRED },
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        )
+}

--- a/app/src/test/java/fr/bsodium/cron/receiver/CalendarChangeReceiverTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/receiver/CalendarChangeReceiverTest.kt
@@ -1,0 +1,48 @@
+package fr.bsodium.cron.receiver
+
+import android.app.Application
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.WorkManagerTestInitHelper
+import fr.bsodium.cron.worker.CalendarChangeWorker
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CalendarChangeReceiverTest {
+
+    private lateinit var app: Application
+    private lateinit var workManager: WorkManager
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        WorkManagerTestInitHelper.initializeTestWorkManager(app)
+        workManager = WorkManager.getInstance(app)
+    }
+
+    @Test
+    fun onReceive_enqueues_unique_calendar_change_work() {
+        CalendarChangeReceiver().onReceive(app, Intent())
+
+        val infos = workManager.getWorkInfosForUniqueWork(CalendarChangeWorker.NAME).get()
+        assertEquals(1, infos.size)
+        assertTrue(infos.single().state == WorkInfo.State.ENQUEUED)
+    }
+
+    @Test
+    fun onReceive_twice_in_a_row_replaces_rather_than_stacking() {
+        CalendarChangeReceiver().onReceive(app, Intent())
+        CalendarChangeReceiver().onReceive(app, Intent())
+
+        val infos = workManager.getWorkInfosForUniqueWork(CalendarChangeWorker.NAME).get()
+        // REPLACE cancels the first request and enqueues a fresh one — only one survives as non-cancelled.
+        assertEquals(1, infos.count { it.state != WorkInfo.State.CANCELLED })
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/receiver/EveningPlanReceiverTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/receiver/EveningPlanReceiverTest.kt
@@ -1,0 +1,71 @@
+package fr.bsodium.cron.receiver
+
+import android.app.Application
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import fr.bsodium.cron.alarm.AlarmConstants
+import fr.bsodium.cron.settings.SettingsRepository
+import fr.bsodium.cron.testutil.awaitCondition
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class EveningPlanReceiverTest {
+
+    private lateinit var app: Application
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        // Room's CronDatabase singleton and DataStore's backing file aren't reset between test
+        // classes by Robolectric, so a disabled toggle can leak in from an unrelated test — reset it.
+        runBlocking { SettingsRepository(app).setAutoAlarmsEnabled(true) }
+    }
+
+    private fun dispatch() {
+        val receiver = EveningPlanReceiver()
+        app.registerReceiver(receiver, IntentFilter(EveningPlanReceiver.ACTION_FIRE))
+        app.sendBroadcast(Intent(EveningPlanReceiver.ACTION_FIRE))
+        shadowOf(Looper.getMainLooper()).idle()
+        app.unregisterReceiver(receiver)
+    }
+
+    private fun nextTriggerPendingIntent(): PendingIntent? =
+        PendingIntent.getBroadcast(
+            app,
+            AlarmConstants.EVENING_PLAN_REQUEST_CODE,
+            Intent(app, EveningPlanReceiver::class.java).apply { action = EveningPlanReceiver.ACTION_FIRE },
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+    @Test
+    fun fires_rearms_tomorrow_and_starts_the_sleep_session_service() {
+        dispatch()
+
+        awaitCondition { nextTriggerPendingIntent() != null }
+        val started = shadowOf(app).nextStartedService
+        assertNotNull(started)
+    }
+
+    @Test
+    fun auto_alarms_disabled_skips_planning_and_does_not_rearm() = runBlocking {
+        SettingsRepository(app).setAutoAlarmsEnabled(false)
+
+        dispatch()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // Give the background coroutine a moment; then assert neither side effect happened.
+        Thread.sleep(200)
+        assertNull(nextTriggerPendingIntent())
+        assertNull(shadowOf(app).nextStartedService)
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/receiver/TimeZoneChangedReceiverTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/receiver/TimeZoneChangedReceiverTest.kt
@@ -1,0 +1,49 @@
+package fr.bsodium.cron.receiver
+
+import android.app.Application
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import fr.bsodium.cron.alarm.AlarmConstants
+import fr.bsodium.cron.settings.SettingsRepository
+import fr.bsodium.cron.testutil.awaitCondition
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class TimeZoneChangedReceiverTest {
+
+    private lateinit var app: Application
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        // Room's CronDatabase singleton and DataStore's backing file aren't reset between test
+        // classes by Robolectric, so a disabled toggle can leak in from an unrelated test — reset it.
+        runBlocking { SettingsRepository(app).setAutoAlarmsEnabled(true) }
+    }
+
+    @Test
+    fun timezone_change_rearms_the_evening_plan_trigger() {
+        val receiver = TimeZoneChangedReceiver()
+        app.registerReceiver(receiver, IntentFilter(Intent.ACTION_TIMEZONE_CHANGED))
+        app.sendBroadcast(Intent(Intent.ACTION_TIMEZONE_CHANGED))
+        shadowOf(Looper.getMainLooper()).idle()
+        app.unregisterReceiver(receiver)
+
+        awaitCondition {
+            PendingIntent.getBroadcast(
+                app,
+                AlarmConstants.EVENING_PLAN_REQUEST_CODE,
+                Intent(app, EveningPlanReceiver::class.java).apply { action = EveningPlanReceiver.ACTION_FIRE },
+                PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+            ) != null
+        }
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/testutil/Awaiting.kt
+++ b/app/src/test/java/fr/bsodium/cron/testutil/Awaiting.kt
@@ -1,0 +1,12 @@
+package fr.bsodium.cron.testutil
+
+/** Polls [condition] until it's true or [timeoutMs] elapses; the goAsync()-launched IO work under test runs on a real thread outside Robolectric's looper, so assertions can't fire immediately after a broadcast. */
+fun awaitCondition(timeoutMs: Long = 2_000, intervalMs: Long = 10, condition: () -> Boolean) {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (!condition()) {
+        if (System.currentTimeMillis() >= deadline) {
+            check(condition()) { "Condition not met within ${timeoutMs}ms" }
+        }
+        Thread.sleep(intervalMs)
+    }
+}


### PR DESCRIPTION
## Summary
Part of the cleanup/audit pass. Adds unit test coverage for the previously-untested `receiver/` package:

- **AlarmReceiver** — `ACTION_ALARM_FIRED`/`ACTION_DISMISS`/`ACTION_SNOOZE` trigger routing into the FSM, null-session no-ops, notification cancellation, and the `scheduleSimpleSnooze` fallback (both the "no active session" and "corrupted plan JSON causes a decode exception" paths).
- **EveningPlanReceiver** — re-arms tomorrow's trigger and starts `SleepSessionService`; verifies the auto-alarms-disabled skip (neither re-arm nor service start happens).
- **TimeZoneChangedReceiver** — re-arms the evening-plan trigger on `ACTION_TIMEZONE_CHANGED`.
- (CalendarChangeReceiver already had coverage from an earlier commit on this branch.)

Adds a shared `awaitCondition()` polling helper in `testutil/` — these receivers' `goAsync()`-launched work runs on a real JVM thread outside Robolectric's looper, so assertions can't fire immediately after `sendBroadcast()` + looper idle.

No production code changes.

## Known finding — not fixed here
`AlarmReceiver` (all 3 handlers), `BootReceiver`, `EveningPlanReceiver`, and `TimeZoneChangedReceiver` all launch a raw `CoroutineScope(Dispatchers.IO).launch { ... }` inside `goAsync()` — the anti-pattern CLAUDE.md flags ("BroadcastReceivers using goAsync() must finish within ~10s. Don't add long-running work behind CoroutineScope(Dispatchers.IO).launch inside one — schedule a WorkManager job"):

- `AlarmReceiver.kt:67-68` (handleAlarmFired), `:127-128` (handleDismiss), `:155-156` (handleSnooze)
- `BootReceiver.kt:39-40`
- `EveningPlanReceiver.kt:30-31`
- `TimeZoneChangedReceiver.kt:25-26`

`CalendarChangeReceiver` in this same package already does it correctly via `WorkManager.getInstance(context).enqueueUniqueWork(...)` — the in-repo reference pattern.

This is left as a deliberate follow-up rather than fixed here: `AlarmReceiver`'s dismiss/snooze paths are latency-sensitive (a user expects instant feedback dismissing an alarm), so migrating them needs a considered WorkManager-expedited-work decision, not a blind refactor. `BootReceiver`/`EveningPlanReceiver`/`TimeZoneChangedReceiver` are lower-risk candidates for a straightforward WorkManager migration.

## Test plan
- [x] `./gradlew :app:assembleDebug :app:lintDebug :app:checkFileLength :app:checkAnimationPreviews` all pass.
- [x] `./gradlew :app:testDebugUnitTest` — full suite green, including 11 new receiver tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)