### PR TITLE
fix(sensors): dedupe Health Connect stage polling to stop the AI-turn storm

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/sensors/healthconnect/SleepStageReader.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/healthconnect/SleepStageReader.kt
@@ -5,24 +5,12 @@ import android.util.Log
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.SleepSessionRecord
-import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_AWAKE
-import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_AWAKE_IN_BED
-import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_DEEP
-import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_LIGHT
-import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_OUT_OF_BED
-import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_REM
-import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_SLEEPING
-import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_UNKNOWN
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
-import fr.bsodium.cron.session.model.EventData
 import fr.bsodium.cron.session.model.SessionEvent
-import fr.bsodium.cron.session.model.SleepStage
-import fr.bsodium.cron.session.model.TriggerType
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.toJavaInstant
-import kotlinx.datetime.toKotlinInstant
 
 /**
  * Reads sleep stage data from Health Connect.
@@ -30,7 +18,7 @@ import kotlinx.datetime.toKotlinInstant
  * Health Connect has no push API for sleep records, so this reader is
  * driven by [fr.bsodium.cron.worker.HealthConnectPollWorker] on a 15-min
  * periodic schedule. Each poll fetches new stage segments since the last
- * one and emits one [TriggerType.HcStageUpdate] event per segment.
+ * one and emits one `HcStageUpdate` event per segment.
  */
 class SleepStageReader(private val context: Context) {
 
@@ -54,9 +42,12 @@ class SleepStageReader(private val context: Context) {
     }
 
     /**
-     * Read all sleep-stage segments overlapping [start..now], emitting a
-     * [SessionEvent] per stage segment to [emit]. Returns the latest
-     * segment end so the caller can checkpoint progress.
+     * Emit a [SessionEvent] per sleep-stage segment that ended after [start].
+     * The record query fetches everything overlapping [start..now] (a session
+     * record spans the whole night), so segments already seen by a previous
+     * poll are dropped by [StageEventMapper] before they reach [emit].
+     * Returns the latest emitted segment end so the caller can checkpoint
+     * progress, or null when nothing new was found.
      */
     suspend fun readSince(
         start: Instant,
@@ -90,40 +81,18 @@ class SleepStageReader(private val context: Context) {
         val ownPackage = context.packageName
 
         for (record in response.records) {
-            val confidence = DataOriginClassifier.classify(
-                packageName = record.metadata.dataOrigin.packageName,
+            val events = StageEventMapper.newStageEvents(
+                stages = record.stages,
+                source = record.metadata.dataOrigin.packageName,
                 ownPackage = ownPackage,
+                seenThrough = start,
             )
-            for (stage in record.stages) {
-                val mapped = mapStage(stage.stage) ?: continue
-                val startK = stage.startTime.toKotlinInstant()
-                val endK = stage.endTime.toKotlinInstant()
-                if (latestEnd == null || endK > latestEnd) latestEnd = endK
-                emit(
-                    SessionEvent(
-                        trigger = TriggerType.HcStageUpdate,
-                        timestamp = endK,
-                        data = EventData.HcStageUpdate(
-                            stage = mapped,
-                            source = record.metadata.dataOrigin.packageName,
-                            confidence = confidence,
-                            recordStart = startK,
-                            recordEnd = endK,
-                        ),
-                    )
-                )
+            for (event in events) {
+                if (latestEnd == null || event.timestamp > latestEnd) latestEnd = event.timestamp
+                emit(event)
             }
         }
         return latestEnd
-    }
-
-    private fun mapStage(hcStage: Int): SleepStage? = when (hcStage) {
-        STAGE_TYPE_AWAKE, STAGE_TYPE_AWAKE_IN_BED -> SleepStage.Awake
-        STAGE_TYPE_LIGHT, STAGE_TYPE_SLEEPING -> SleepStage.Light
-        STAGE_TYPE_DEEP -> SleepStage.Deep
-        STAGE_TYPE_REM -> SleepStage.Rem
-        STAGE_TYPE_OUT_OF_BED, STAGE_TYPE_UNKNOWN -> null
-        else -> null // any stage code the SDK adds later; skip rather than misclassify
     }
 
     companion object {

--- a/app/src/main/java/fr/bsodium/cron/sensors/healthconnect/StageEventMapper.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/healthconnect/StageEventMapper.kt
@@ -1,0 +1,64 @@
+package fr.bsodium.cron.sensors.healthconnect
+
+import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_AWAKE
+import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_AWAKE_IN_BED
+import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_DEEP
+import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_LIGHT
+import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_OUT_OF_BED
+import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_REM
+import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_SLEEPING
+import androidx.health.connect.client.records.SleepSessionRecord.Companion.STAGE_TYPE_UNKNOWN
+import fr.bsodium.cron.session.model.EventData
+import fr.bsodium.cron.session.model.SessionEvent
+import fr.bsodium.cron.session.model.SleepStage
+import fr.bsodium.cron.session.model.TriggerType
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toKotlinInstant
+
+/**
+ * Pure mapping from Health Connect sleep-stage segments to [SessionEvent]s,
+ * dropping segments a previous poll already emitted.
+ *
+ * Health Connect's `TimeRangeFilter` matches whole `SleepSessionRecord`s, and
+ * one record spans the entire night — so every poll re-fetches every stage
+ * seen so far. Filtering on `endTime > seenThrough` is what keeps a 15-minute
+ * poll from re-appending the whole night to the session event log and
+ * re-triggering paid AI turns on stale data.
+ */
+internal object StageEventMapper {
+
+    fun newStageEvents(
+        stages: List<SleepSessionRecord.Stage>,
+        source: String,
+        ownPackage: String,
+        seenThrough: Instant,
+    ): List<SessionEvent> {
+        val confidence = DataOriginClassifier.classify(packageName = source, ownPackage = ownPackage)
+        return stages.mapNotNull { stage ->
+            val mapped = mapStage(stage.stage) ?: return@mapNotNull null
+            val end = stage.endTime.toKotlinInstant()
+            if (end <= seenThrough) return@mapNotNull null
+            SessionEvent(
+                trigger = TriggerType.HcStageUpdate,
+                timestamp = end,
+                data = EventData.HcStageUpdate(
+                    stage = mapped,
+                    source = source,
+                    confidence = confidence,
+                    recordStart = stage.startTime.toKotlinInstant(),
+                    recordEnd = end,
+                ),
+            )
+        }
+    }
+
+    private fun mapStage(hcStage: Int): SleepStage? = when (hcStage) {
+        STAGE_TYPE_AWAKE, STAGE_TYPE_AWAKE_IN_BED -> SleepStage.Awake
+        STAGE_TYPE_LIGHT, STAGE_TYPE_SLEEPING -> SleepStage.Light
+        STAGE_TYPE_DEEP -> SleepStage.Deep
+        STAGE_TYPE_REM -> SleepStage.Rem
+        STAGE_TYPE_OUT_OF_BED, STAGE_TYPE_UNKNOWN -> null
+        else -> null // HC stage constants are an open int set; unknown types carry no signal
+    }
+}

--- a/app/src/main/java/fr/bsodium/cron/settings/PollCheckpointStore.kt
+++ b/app/src/main/java/fr/bsodium/cron/settings/PollCheckpointStore.kt
@@ -15,6 +15,7 @@ class PollCheckpointStore(context: Context) {
     private val prefs = context.applicationContext
         .getSharedPreferences(FILE, Context.MODE_PRIVATE)
 
+    /** End of the newest stage segment emitted so far — the next poll's dedup cutoff. */
     fun lastHealthConnectPoll(): Instant? = prefs.getLong(KEY_HC, -1L)
         .takeIf { it > 0 }
         ?.let { Instant.fromEpochMilliseconds(it) }

--- a/app/src/test/java/fr/bsodium/cron/sensors/healthconnect/StageEventMapperTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/sensors/healthconnect/StageEventMapperTest.kt
@@ -1,0 +1,113 @@
+package fr.bsodium.cron.sensors.healthconnect
+
+import androidx.health.connect.client.records.SleepSessionRecord
+import fr.bsodium.cron.session.model.EventData
+import fr.bsodium.cron.session.model.SignalConfidence
+import fr.bsodium.cron.session.model.SleepStage
+import fr.bsodium.cron.session.model.TriggerType
+import fr.bsodium.cron.testutil.Fixtures
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toJavaInstant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.time.Duration.Companion.minutes
+
+class StageEventMapperTest {
+
+    private val t0 = Fixtures.T0
+
+    private fun stage(
+        start: Instant,
+        end: Instant,
+        type: Int = SleepSessionRecord.STAGE_TYPE_LIGHT,
+    ) = SleepSessionRecord.Stage(
+        startTime = start.toJavaInstant(),
+        endTime = end.toJavaInstant(),
+        stage = type,
+    )
+
+    private fun map(stages: List<SleepSessionRecord.Stage>, seenThrough: Instant) =
+        StageEventMapper.newStageEvents(
+            stages = stages,
+            source = "com.garmin.android.apps.connectmobile",
+            ownPackage = "fr.bsodium.cron",
+            seenThrough = seenThrough,
+        )
+
+    private val firstPollStages = listOf(
+        stage(t0, t0 + 30.minutes, SleepSessionRecord.STAGE_TYPE_LIGHT),
+        stage(t0 + 30.minutes, t0 + 60.minutes, SleepSessionRecord.STAGE_TYPE_DEEP),
+        stage(t0 + 60.minutes, t0 + 90.minutes, SleepSessionRecord.STAGE_TYPE_REM),
+    )
+
+    @Test
+    fun first_poll_emits_every_segment_past_the_cutoff() {
+        val events = map(firstPollStages, seenThrough = t0 - 15.minutes)
+        assertEquals(3, events.size)
+        assertEquals(
+            listOf(SleepStage.Light, SleepStage.Deep, SleepStage.Rem),
+            events.map { (it.data as EventData.HcStageUpdate).stage },
+        )
+    }
+
+    @Test
+    fun second_poll_seeing_the_same_stages_emits_nothing() {
+        val firstPoll = map(firstPollStages, seenThrough = t0 - 15.minutes)
+        val checkpoint = firstPoll.maxOf { it.timestamp }
+
+        val secondPoll = map(firstPollStages, seenThrough = checkpoint)
+
+        assertTrue(secondPoll.isEmpty())
+    }
+
+    @Test
+    fun poll_with_one_new_stage_emits_only_that_stage() {
+        val firstPoll = map(firstPollStages, seenThrough = t0 - 15.minutes)
+        val checkpoint = firstPoll.maxOf { it.timestamp }
+        val newStage = stage(t0 + 90.minutes, t0 + 120.minutes, SleepSessionRecord.STAGE_TYPE_DEEP)
+
+        val secondPoll = map(firstPollStages + newStage, seenThrough = checkpoint)
+
+        assertEquals(1, secondPoll.size)
+        val data = secondPoll.single().data as EventData.HcStageUpdate
+        assertEquals(SleepStage.Deep, data.stage)
+        assertEquals(t0 + 90.minutes, data.recordStart)
+        assertEquals(t0 + 120.minutes, data.recordEnd)
+    }
+
+    @Test
+    fun segment_ending_exactly_at_the_checkpoint_is_already_seen() {
+        val events = map(
+            listOf(stage(t0, t0 + 30.minutes)),
+            seenThrough = t0 + 30.minutes,
+        )
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun emitted_event_carries_trigger_timestamp_and_confidence() {
+        val event = map(
+            listOf(stage(t0, t0 + 30.minutes)),
+            seenThrough = t0,
+        ).single()
+
+        assertEquals(TriggerType.HcStageUpdate, event.trigger)
+        assertEquals(t0 + 30.minutes, event.timestamp)
+        val data = event.data as EventData.HcStageUpdate
+        assertEquals(SignalConfidence.High, data.confidence)
+        assertEquals("com.garmin.android.apps.connectmobile", data.source)
+    }
+
+    @Test
+    fun unmapped_stage_types_never_emit() {
+        val events = map(
+            listOf(
+                stage(t0, t0 + 30.minutes, SleepSessionRecord.STAGE_TYPE_OUT_OF_BED),
+                stage(t0 + 30.minutes, t0 + 60.minutes, SleepSessionRecord.STAGE_TYPE_UNKNOWN),
+            ),
+            seenThrough = t0 - 15.minutes,
+        )
+        assertTrue(events.isEmpty())
+    }
+}


### PR DESCRIPTION
## The bug

`SleepStageReader.readSince(since)` queried Health Connect with `TimeRangeFilter.between(start, now)` — which filters whole **records**, not individual sleep **stages**. A `SleepSessionRecord` spans the entire night, so it overlaps every 15-minute poll window from the moment it starts, and the stage loop had no `endTime > since` filter. Every stage seen so far in the session was therefore re-emitted into `SessionFsm.onEvent(...)` on every single poll, with no dedup.

## Impact

1. **Event-log corruption**: the session event log grew roughly O(n²) over a night, and `AiPromptBuilder` dumped every duplicate into the AI replan prompt, bloating and confusing model context.
2. **Paid AI-turn storm**: each poll's first `HcStageUpdate` passed `shouldTriggerAi` because `AI_COOLDOWN` (15 min) exactly equals the poll period — a duplicate-driven AI call fired roughly every 15 minutes, all night, with zero new information.

## The fix

- Extracted the stage→event mapping out of `SleepStageReader` into a pure, testable `StageEventMapper`, which drops any segment whose `endTime` is at or before the last poll's checkpoint (`seenThrough`).
- The existing `PollCheckpointStore.lastHealthConnectPoll` checkpoint already stores the latest emitted stage `endTime` (the worker sets it from `readSince`'s return value), so it now doubles as the dedup cutoff — no second checkpoint mechanism needed. Documented that dual role on the accessor.
- The record-level `TimeRangeFilter.between(start, now)` query is unchanged (it must stay wide to catch the night-spanning record); dedup happens post-fetch, before anything reaches `fsm.onEvent`.

## Tests

New `StageEventMapperTest` (plain JUnit, follows `ScreenStateMonitorTest` style):

- `second_poll_seeing_the_same_stages_emits_nothing` — a re-poll of identical stages emits zero events, so no `HcStageUpdate` is appended or forwarded for already-seen stages
- `poll_with_one_new_stage_emits_only_that_stage` — only the genuinely new segment is emitted, not the whole history
- `segment_ending_exactly_at_the_checkpoint_is_already_seen` — boundary is strict
- plus first-poll emission, event-field mapping, and unmapped-stage-type coverage

Full gate green: `assembleDebug`, `lintDebug`, `checkFileLength`, `checkAnimationPreviews`, `testDebugUnitTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)