### PR TITLE
chore(lint): audit remaining when-else blocks

### DIFF
--- a/app/src/debug/java/fr/bsodium/cron/debug/FakeAnthropicClient.kt
+++ b/app/src/debug/java/fr/bsodium/cron/debug/FakeAnthropicClient.kt
@@ -89,7 +89,7 @@ class FakeAnthropicClient : AnthropicMessages {
             onPartial(listOf(thinking.signed(), toolUse))
             response(model, listOf(thinking.signed(), toolUse), stopReason = "tool_use")
         }
-        else -> {
+        else -> { // turn is an unbounded call counter; every turn past the scripted 3 lands here
             val thinking = streamThinking(THINK_DONE.random(), onPartial)
             val text = streamText(ANSWERS.random(), listOf(thinking.signed()), onPartial)
             response(model, listOf(thinking.signed(), text))

--- a/app/src/main/java/fr/bsodium/cron/sensors/ActivityRecognitionMonitor.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/ActivityRecognitionMonitor.kt
@@ -115,7 +115,7 @@ class ActivityRecognitionMonitor(
             DetectedActivity.STILL -> ActivityType.Still
             DetectedActivity.WALKING -> ActivityType.Walking
             DetectedActivity.RUNNING -> ActivityType.Running
-            else -> return
+            else -> return // only STILL/WALKING/RUNNING are subscribed to; other Play Services codes can't arrive
         }
         scope.launch {
             sink.emit(

--- a/app/src/main/java/fr/bsodium/cron/sensors/healthconnect/DataOriginClassifier.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/healthconnect/DataOriginClassifier.kt
@@ -24,6 +24,6 @@ object DataOriginClassifier {
     fun classify(packageName: String, ownPackage: String): SignalConfidence = when {
         packageName == ownPackage -> SignalConfidence.Low
         HIGH_CONFIDENCE_PACKAGES.any { packageName.startsWith(it) } -> SignalConfidence.High
-        else -> SignalConfidence.Medium
+        else -> SignalConfidence.Medium // any other origin (open set of installed apps) is unverified
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/sensors/healthconnect/SleepStageReader.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/healthconnect/SleepStageReader.kt
@@ -43,7 +43,7 @@ class SleepStageReader(private val context: Context) {
     fun availability(): Availability = when (HealthConnectClient.getSdkStatus(context)) {
         HealthConnectClient.SDK_AVAILABLE -> Availability.Available
         HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED -> Availability.ProviderUpdateRequired
-        else -> Availability.NotInstalled
+        else -> Availability.NotInstalled // covers SDK_UNAVAILABLE and any future status the SDK adds
     }
 
     /** Whether the sleep read permission is currently granted (false if HC is unavailable). */
@@ -123,7 +123,7 @@ class SleepStageReader(private val context: Context) {
         STAGE_TYPE_DEEP -> SleepStage.Deep
         STAGE_TYPE_REM -> SleepStage.Rem
         STAGE_TYPE_OUT_OF_BED, STAGE_TYPE_UNKNOWN -> null
-        else -> null
+        else -> null // any stage code the SDK adds later; skip rather than misclassify
     }
 
     companion object {

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiThreadMapper.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiThreadMapper.kt
@@ -230,7 +230,7 @@ object AiThreadMapper {
                 .minOrNull()
                 ?.let { "${it / 60} min" }
             "geocode_address" -> obj["formatted"]?.jsonPrimitive?.content?.take(28)
-            else -> null
+            else -> null // unrecognized or future tool name (LLM-controlled, open input) — no summary rather than guess
         }
     }.onFailure { Log.w(TAG, "summarize tool result failed for $name", it) }.getOrNull()
 

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeUiMappers.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeUiMappers.kt
@@ -94,6 +94,7 @@ internal fun formatDateLabel(session: SessionDisplayState?, autoAlarmsEnabled: B
     val dayPart = when (ChronoUnit.DAYS.between(today, date)) {
         0L -> "Today"
         1L -> "Tomorrow"
+        // locale-default weekday name is intentional here (human-language); any other day gap (unbounded)
         else -> date.format(DateTimeFormatter.ofPattern("EEEE", Locale.getDefault()))
     }
     return "$dayPart, you'll wake up at"

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/TimelineMapper.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/TimelineMapper.kt
@@ -141,6 +141,6 @@ private fun formatTimelineDateLabel(date: LocalDate): String {
     return when (ChronoUnit.DAYS.between(jDate, today)) {
         0L -> "Today"
         1L -> "Yesterday"
-        else -> jDate.format(DateTimeFormatter.ofPattern("EEE d MMM", Locale.getDefault()))
+        else -> jDate.format(DateTimeFormatter.ofPattern("EEE d MMM", Locale.getDefault())) // any other day gap (unbounded)
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextPlanHint.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/NextPlanHint.kt
@@ -115,7 +115,7 @@ private fun NoPlanIllustration(modifier: Modifier = Modifier) {
                 NO_PLAN_TERTIARY_LIGHT -> scheme.tertiaryContainer
                 NO_PLAN_PAPER -> scheme.surface
                 NO_PLAN_GROUND -> scheme.surfaceVariant
-                else -> original
+                else -> original // any fill outside the sentinel palette (open Color space) passes through unchanged
             }
         }
     }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/OnboardingHint.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/OnboardingHint.kt
@@ -70,7 +70,7 @@ internal fun OnboardingHint(modifier: Modifier = Modifier) {
                     CAKE_GROUND -> ground
                     CAKE_ACCENT -> accent
                     CAKE_SHADOW -> shadow
-                    else -> original
+                    else -> original // any fill outside the sentinel palette (open Color space) passes through unchanged
                 }
             }
         }


### PR DESCRIPTION
## Summary

Audits all remaining `else ->` sites in `app/src/main` and `app/src/debug` (excluding `session/SessionFsm.kt`, fixed in a prior PR) against the CLAUDE.md rule: closed Kotlin `sealed`/`enum` sets must be matched exhaustively with no `else`; `else` is only for genuinely open input, documented with a comment.

**Result: every remaining site is legitimate open-input matching — none were matching over a closed `sealed`/`enum` type.** No exhaustive-match conversions were needed. Where a site lacked a justification comment, one was added.

## Per-site classification

**Documented (comment added) — matching open external/unbounded input:**
- `debug/FakeAnthropicClient.kt:92` — `turn: Int`, an unbounded mock-run call counter.
- `sensors/healthconnect/DataOriginClassifier.kt:27` — `packageName: String`, open set of installed apps.
- `sensors/healthconnect/SleepStageReader.kt:46,126` — Health Connect SDK status / stage `Int` codes from an external SDK that can add values.
- `sensors/ActivityRecognitionMonitor.kt:118` — Play Services `DetectedActivity` `Int` code; only 3 of many are subscribed.
- `ui/screens/home/AiThreadMapper.kt:233` — LLM-controlled tool name `String` (the canonical CLAUDE.md open-input example).
- `ui/screens/home/HomeUiMappers.kt:97`, `TimelineMapper.kt:144` — unbounded `Long` day-gap, falling back to locale weekday name (human-language, intentionally locale-default).
- `ui/screens/home/components/OnboardingHint.kt:73`, `NextPlanHint.kt:118` — `Color` values from an SVG's sentinel fill palette; any fill outside the known palette passes through unchanged.

**Already adequately documented — no change:**
- `ai/StreamAccumulator.kt:115` — `type: String` tag, comment already explains tool_result/future-type handling.
- `ui/screens/home/GreetingSource.kt:13` — `Int` hour-of-day, documented in the function KDoc.
- `ui/screens/home/components/OldPlanFooter.kt:81` — unbounded `Long` minutes-ago, documented in the function KDoc (explicitly called out as the canonical "minutes ago" case).
- `ui/screens/home/components/ProcessRows.kt:200` — LLM tool name → icon fallback, CLAUDE.md's own canonical example, already has a KDoc line ("wrench for anything unmapped").

**Confirmed NOT violations (boolean-condition `when {}` chains, not closed-type matches) — no change needed:**
- `ui/screens/home/HomeScreen.kt:234`, `HomeViewModel.kt:326`, `AiPlanMapper.kt:131`, `AiThreadMapper.kt:112,256`, `TimelineMapper.kt:134`, `components/StreamingReveal.kt:127`, `components/ProcessRows.kt:265`, `components/AiThinkingThread.kt:142,300` — these are `when { cond1 -> ...; cond2 -> ...; else -> ... }` multi-branch if/else-if chains over independent `Boolean`/nullable conditions, not `when(x)` matching over a single closed `sealed`/`enum` instance. The rule targets exhaustive matching over closed sets; an if-chain's terminal `else` is a normal default branch, not a fall-through escape hatch. Several of these (e.g. `AiThinkingThread.kt:142`) compute a value of a closed enum type (`ShapePhase`) but do so by branching on unrelated booleans, not by switching on the enum itself — genuinely exhaustive `when(shapePhase)` matches elsewhere in the same file (`ThinkingShape.kt`) already have no `else`.

No behavior changes — comment-only diff. No new exhaustive-match conversions means no new unit tests were required per the task's own criteria (tests are only for sites converted from `else` to exhaustive matching).

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` after each incremental commit
- [x] `./gradlew :app:assembleDebug :app:lintDebug :app:checkFileLength :app:checkAnimationPreviews`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] No composables' visual output changed (comment-only diff) — no Roborazzi re-record needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)