### PR TITLE
fix(ai): close cost-control and turn-completion gaps in AiTurnWorker

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ai/TurnIndexResolver.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/TurnIndexResolver.kt
@@ -1,0 +1,38 @@
+package fr.bsodium.cron.ai
+
+import android.util.Log
+import fr.bsodium.cron.ai.wire.ContentBlock
+import fr.bsodium.cron.session.db.AiMessageDao
+import fr.bsodium.cron.session.db.AiMessageEntity
+import fr.bsodium.cron.session.db.SessionJson
+
+/**
+ * Picks the turn index an AI-turn worker attempt should run.
+ *
+ * A first attempt always starts a fresh turn after the highest persisted index. A retry whose
+ * failed predecessor left partial rows resumes that turn instead — [TurnRunner.loadOrSeed] picks
+ * the persisted messages back up — so round-trips that already billed aren't re-run and
+ * side-effectful tools (alarms, notifications) aren't re-executed. First attempts never resume:
+ * a REPLACE'd worker's partial turn carries a stale prompt, and the new trigger wants a new turn.
+ */
+object TurnIndexResolver {
+
+    suspend fun resolve(dao: AiMessageDao, sessionId: String, isRetry: Boolean): Int {
+        val maxIndex = dao.maxTurnIndex(sessionId) ?: return 0
+        if (isRetry && !isSettled(dao.findByTurn(sessionId, maxIndex))) return maxIndex
+        return maxIndex + 1
+    }
+
+    /** A turn is settled once its last row is an assistant message with no pending tool_use. */
+    private fun isSettled(rows: List<AiMessageEntity>): Boolean {
+        val last = rows.lastOrNull() ?: return true
+        if (last.role != "assistant") return false
+        // An undecodable row can't be resumed either (loadOrSeed would throw on it) — start fresh.
+        val blocks = runCatching { SessionJson.decodeFromString<List<ContentBlock>>(last.contentJson) }
+            .onFailure { Log.w(TAG, "Undecodable row ${last.id} in turn ${last.turnIndex}", it) }
+            .getOrNull() ?: return true
+        return blocks.none { it is ContentBlock.ToolUse }
+    }
+}
+
+private const val TAG = "TurnIndexResolver"

--- a/app/src/main/java/fr/bsodium/cron/ai/TurnRunner.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/TurnRunner.kt
@@ -30,6 +30,9 @@ import kotlin.math.min
  *     round-trip budget is exhausted.
  *
  * Retries on 429 / 5xx with exponential backoff, capped at [maxRetries].
+ *
+ * [onRoundTripUsage] fires after every successful round-trip — not just at the end of the
+ * turn — so spend already billed by the API is recorded even when the turn later fails.
  */
 class TurnRunner(
     private val client: AnthropicMessages,
@@ -43,6 +46,7 @@ class TurnRunner(
     private val toolChoice: ToolChoice? = null,
     private val thinking: ThinkingConfig? = null,
     private val isMocked: Boolean = false,
+    private val onRoundTripUsage: (Usage) -> Unit = {},
 ) {
 
     sealed class Outcome {
@@ -105,6 +109,7 @@ class TurnRunner(
                 )
 
                 val response = streamWithRetries(sessionId, turnIndex, request, committedBlocks, startedAtMs)
+                response.usage?.let(onRoundTripUsage)
                 aggregateUsage = aggregateUsage.plus(response.usage)
 
                 // Persist assistant message (complete — keeps resume safe), then settle the partial.

--- a/app/src/main/java/fr/bsodium/cron/ai/TurnRunner.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/TurnRunner.kt
@@ -19,7 +19,9 @@ import kotlin.math.min
  * Drives a single AI tool-use loop for one [sessionId] + [turnIndex] pair.
  *
  * Behaviour:
- *  1. Reads any persisted messages for the (session, turn) — supports resume.
+ *  1. Reads any persisted messages for the (session, turn) — supports resume. A resumed turn
+ *     whose last message is an assistant tool_use with no persisted results runs those tools
+ *     first, so the conversation is valid for the API again.
  *  2. Sends them to Anthropic via [client].
  *  3. For each tool_use block in the response, runs the tool and appends the
  *     tool_result block back to the conversation. Persists both before the
@@ -86,6 +88,11 @@ class TurnRunner(
         var aggregateUsage = Usage()
 
         return try {
+            answerPendingToolUses(sessionId, turnIndex, messages)?.let { toolResults ->
+                committedBlocks = committedBlocks + toolResults
+                publish(sessionId, turnIndex, committedBlocks, startedAtMs)
+            }
+
             repeat(maxRoundTrips) { round ->
                 val request = MessagesRequest(
                     model = model,
@@ -127,6 +134,30 @@ class TurnRunner(
         } finally {
             StreamingTurnStore.clear(sessionId, turnIndex)
         }
+    }
+
+    /**
+     * On resume, a turn interrupted between persisting the assistant tool_use message and its
+     * tool results ends with unanswered tool_use blocks — the API rejects such a conversation.
+     * Executes those tools, persists the results, appends them to [messages], and returns them;
+     * null when there's nothing pending.
+     */
+    private suspend fun answerPendingToolUses(
+        sessionId: String,
+        turnIndex: Int,
+        messages: MutableList<MessageInput>,
+    ): List<ContentBlock>? {
+        val pending = messages.last()
+            .takeIf { it.role == "assistant" }
+            ?.content
+            ?.filterIsInstance<ContentBlock.ToolUse>()
+            .orEmpty()
+        if (pending.isEmpty()) return null
+
+        val toolResults: List<ContentBlock> = pending.map { executeToolCall(it) }
+        persistMessage(sessionId, turnIndex, role = "user", blocks = toolResults)
+        messages.add(MessageInput(role = "user", content = toolResults))
+        return toolResults
     }
 
     private fun publish(sessionId: String, turnIndex: Int, blocks: List<ContentBlock>, startedAtMs: Long) =

--- a/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
@@ -20,6 +20,7 @@ import fr.bsodium.cron.ai.SystemPrompts
 import fr.bsodium.cron.ai.Tool
 import fr.bsodium.cron.ai.ToolRegistry
 import fr.bsodium.cron.ai.ToolRegistryFactory
+import fr.bsodium.cron.ai.TurnIndexResolver
 import fr.bsodium.cron.ai.TurnRunner
 import fr.bsodium.cron.ai.wire.ThinkingConfig
 import fr.bsodium.cron.ai.wire.ToolChoice
@@ -54,11 +55,11 @@ import kotlinx.datetime.TimeZone
 /**
  * Resumable WorkManager worker that drives one AI tool-use turn for a session.
  *
- * The turn index is resolved at startup by reading the max already-persisted
- * index from Room (+1). This means: if the OS kills the worker mid-turn and
- * WorkManager re-runs it, [TurnRunner.loadOrSeed] finds the existing messages
- * for that turn and resumes from the last persisted block rather than starting
- * over.
+ * The turn index comes from [TurnIndexResolver]: first attempts start a fresh
+ * turn after the highest persisted index, while a retry whose failed predecessor
+ * left partial rows resumes that turn — [TurnRunner.loadOrSeed] finds the
+ * existing messages and continues from the last persisted block instead of
+ * re-running (and re-billing) the round-trips that already succeeded.
  *
  * Only one instance per session can run at a time (UNIQUE_WORK with REPLACE).
  */
@@ -104,7 +105,7 @@ class AiTurnWorker(
             return Result.failure(workDataOf(KEY_REASON to REASON_BUDGET, KEY_USED to used, KEY_LIMIT to limit))
         }
 
-        val turnIndex = (db.aiMessageDao().maxTurnIndex(sessionId) ?: -1) + 1
+        val turnIndex = TurnIndexResolver.resolve(db.aiMessageDao(), sessionId, isRetry = runAttemptCount > 0)
         // A manual replan re-appends an EveningPlan event (→ Sonnet); sensor-driven overnight replans leave the latest trigger ≠ EveningPlan, so they stay on Haiku.
         val isEveningPlan = session.events.lastOrNull()?.trigger == TriggerType.EveningPlan
 

--- a/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
@@ -130,6 +130,8 @@ class AiTurnWorker(
             toolChoice = toolChoice,
             thinking = thinking,
             isMocked = mockTools != null,
+            // Billed per round-trip so a turn that fails partway still counts against the daily cap.
+            onRoundTripUsage = budget::record,
         )
 
         val instructions = settingsRepository.currentUserInstructions()
@@ -137,7 +139,6 @@ class AiTurnWorker(
 
         return try {
             val outcome = runner.run(sessionId, turnIndex, userMessage)
-            budget.record(outcome.totalUsage)
             when (outcome) {
                 is TurnRunner.Outcome.Completed ->
                     Log.i(TAG, "Turn $turnIndex complete for $sessionId (stop=${outcome.response.stop_reason}, tokens=${outcome.totalUsage.input_tokens + outcome.totalUsage.output_tokens})")
@@ -153,10 +154,19 @@ class AiTurnWorker(
             Result.failure(workDataOf(KEY_REASON to REASON_NO_API_KEY))
         } catch (e: AnthropicClient.AnthropicHttpException) {
             Log.e(TAG, "Anthropic HTTP ${e.code} during turn for $sessionId", e)
-            if (e.isRetryable) Result.retry() else Result.failure(workDataOf(KEY_REASON to REASON_HTTP))
+            if (e.isRetryable && runAttemptCount < MAX_RETRY_ATTEMPTS) {
+                Result.retry()
+            } else {
+                Result.failure(workDataOf(KEY_REASON to REASON_HTTP))
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Unexpected error during AI turn for $sessionId", e)
-            Result.retry()
+            if (runAttemptCount < MAX_RETRY_ATTEMPTS) {
+                Result.retry()
+            } else {
+                Log.w(TAG, "Turn $turnIndex for $sessionId gave up after $runAttemptCount attempts")
+                Result.failure(workDataOf(KEY_REASON to REASON_MAX_RETRIES))
+            }
         }
     }
 
@@ -244,10 +254,12 @@ class AiTurnWorker(
         const val REASON_BUDGET = "budget_exhausted"
         const val REASON_NO_API_KEY = "no_api_key"
         const val REASON_HTTP = "http_error"
+        const val REASON_MAX_RETRIES = "max_retries_exceeded"
 
         private const val TAG = "AiTurnWorker"
 
         /** Total across the turn; with interleaved thinking it's spread over a fresh think after each tool result. Kept modest so reasoning stays on the anchor decision, not mechanical recompute. */
         private const val THINKING_BUDGET = 2_560
+        private const val MAX_RETRY_ATTEMPTS = 5
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/AiTurnWorker.kt
@@ -39,6 +39,7 @@ import fr.bsodium.cron.session.SessionRepository
 import fr.bsodium.cron.session.db.CronDatabase
 import fr.bsodium.cron.session.model.ActionType
 import fr.bsodium.cron.session.model.LocationSource
+import fr.bsodium.cron.session.model.SessionStatus
 import fr.bsodium.cron.session.model.SleepSession
 import fr.bsodium.cron.session.model.latestEveningPlanLocation
 import fr.bsodium.cron.session.model.TriggerType
@@ -78,6 +79,12 @@ class AiTurnWorker(
         if (session == null) {
             Log.w(TAG, "Session $sessionId not found — skipping turn")
             return Result.failure()
+        }
+
+        // Second line of defense behind SessionFsm's cancelAiTurn-on-Complete: never bill a finished session.
+        if (session.status == SessionStatus.Complete) {
+            Log.i(TAG, "Session $sessionId already complete — skipping AI turn")
+            return Result.success()
         }
 
         val useMock = ToolRegistryFactory.shouldUseMock(applicationContext)

--- a/app/src/test/java/fr/bsodium/cron/ai/TurnIndexResolverTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ai/TurnIndexResolverTest.kt
@@ -1,0 +1,109 @@
+package fr.bsodium.cron.ai
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import fr.bsodium.cron.ai.wire.ContentBlock
+import fr.bsodium.cron.session.db.AiMessageDao
+import fr.bsodium.cron.session.db.AiMessageEntity
+import fr.bsodium.cron.session.db.CronDatabase
+import fr.bsodium.cron.session.db.SessionJson
+import fr.bsodium.cron.session.db.toEntity
+import fr.bsodium.cron.testutil.Fixtures
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class TurnIndexResolverTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var db: CronDatabase
+    private lateinit var dao: AiMessageDao
+
+    @Before
+    fun setUp() = runTest(dispatcher) {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext<Context>(),
+            CronDatabase::class.java,
+        ).setQueryExecutor(dispatcher.asExecutor())
+            .setTransactionExecutor(dispatcher.asExecutor())
+            .allowMainThreadQueries()
+            .build()
+        dao = db.aiMessageDao()
+        db.sessionDao().insert(Fixtures.session(id = "s1").toEntity())
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    @Test
+    fun no_rows_starts_at_zero() = runTest(dispatcher) {
+        assertEquals(0, TurnIndexResolver.resolve(dao, "s1", isRetry = false))
+        assertEquals(0, TurnIndexResolver.resolve(dao, "s1", isRetry = true))
+    }
+
+    @Test
+    fun settled_turn_always_starts_the_next_one() = runTest(dispatcher) {
+        insert(turn = 3, role = "user", blocks = listOf(ContentBlock.Text("prompt")))
+        insert(turn = 3, role = "assistant", blocks = listOf(ContentBlock.Text("done")))
+
+        assertEquals(4, TurnIndexResolver.resolve(dao, "s1", isRetry = false))
+        assertEquals(4, TurnIndexResolver.resolve(dao, "s1", isRetry = true))
+    }
+
+    @Test
+    fun retry_resumes_a_turn_holding_only_the_seed() = runTest(dispatcher) {
+        insert(turn = 2, role = "user", blocks = listOf(ContentBlock.Text("prompt")))
+
+        assertEquals(2, TurnIndexResolver.resolve(dao, "s1", isRetry = true))
+    }
+
+    @Test
+    fun retry_resumes_a_turn_with_unanswered_tool_use() = runTest(dispatcher) {
+        insert(turn = 5, role = "user", blocks = listOf(ContentBlock.Text("prompt")))
+        insert(turn = 5, role = "assistant", blocks = listOf(toolUse("t1")))
+
+        assertEquals(5, TurnIndexResolver.resolve(dao, "s1", isRetry = true))
+    }
+
+    @Test
+    fun first_attempt_never_resumes_a_partial_turn() = runTest(dispatcher) {
+        insert(turn = 5, role = "user", blocks = listOf(ContentBlock.Text("prompt")))
+        insert(turn = 5, role = "assistant", blocks = listOf(toolUse("t1")))
+
+        assertEquals(6, TurnIndexResolver.resolve(dao, "s1", isRetry = false))
+    }
+
+    @Test
+    fun undecodable_last_row_starts_fresh() = runTest(dispatcher) {
+        dao.insert(
+            AiMessageEntity(sessionId = "s1", turnIndex = 1, role = "assistant", contentJson = "not json", createdAt = 0L)
+        )
+
+        assertEquals(2, TurnIndexResolver.resolve(dao, "s1", isRetry = true))
+    }
+
+    private suspend fun insert(turn: Int, role: String, blocks: List<ContentBlock>) {
+        dao.insert(
+            AiMessageEntity(
+                sessionId = "s1",
+                turnIndex = turn,
+                role = role,
+                contentJson = SessionJson.encodeToString(blocks),
+                createdAt = 0L,
+            )
+        )
+    }
+
+    private fun toolUse(id: String) = ContentBlock.ToolUse(id = id, name = "echo", input = JsonObject(emptyMap()))
+}

--- a/app/src/test/java/fr/bsodium/cron/ai/TurnRunnerResumeTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ai/TurnRunnerResumeTest.kt
@@ -1,0 +1,150 @@
+package fr.bsodium.cron.ai
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import fr.bsodium.cron.ai.wire.ContentBlock
+import fr.bsodium.cron.ai.wire.MessagesRequest
+import fr.bsodium.cron.ai.wire.MessagesResponse
+import fr.bsodium.cron.ai.wire.ToolDefinition
+import fr.bsodium.cron.ai.wire.Usage
+import fr.bsodium.cron.session.db.AiMessageDao
+import fr.bsodium.cron.session.db.AiMessageEntity
+import fr.bsodium.cron.session.db.CronDatabase
+import fr.bsodium.cron.session.db.SessionJson
+import fr.bsodium.cron.session.db.toEntity
+import fr.bsodium.cron.testutil.Fixtures
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class TurnRunnerResumeTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var db: CronDatabase
+    private lateinit var dao: AiMessageDao
+    private lateinit var echoTool: CountingEchoTool
+
+    @Before
+    fun setUp() = runTest(dispatcher) {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext<Context>(),
+            CronDatabase::class.java,
+        ).setQueryExecutor(dispatcher.asExecutor())
+            .setTransactionExecutor(dispatcher.asExecutor())
+            .allowMainThreadQueries()
+            .build()
+        dao = db.aiMessageDao()
+        echoTool = CountingEchoTool()
+        db.sessionDao().insert(Fixtures.session(id = "s1").toEntity())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+        StreamingTurnStore.active.value?.let { StreamingTurnStore.clear(it.sessionId, it.turnIndex) }
+    }
+
+    @Test
+    fun resume_with_unanswered_tool_use_runs_the_tool_before_the_first_api_call() = runTest(dispatcher) {
+        persist(role = "user", blocks = listOf(ContentBlock.Text("prompt")))
+        persist(role = "assistant", blocks = listOf(toolUse("t1")))
+        val fake = FakeAnthropic(listOf(response(listOf(ContentBlock.Text("Done")), stop = "end_turn")))
+
+        val outcome = runner(fake).run("s1", turnIndex = 0, initialUserMessage = "ignored on resume")
+
+        assertTrue(outcome is TurnRunner.Outcome.Completed)
+        assertEquals(1, echoTool.executions)
+        assertEquals(1, fake.requests.size)
+        // The single request carries the resumed history plus the freshly-run tool results.
+        val roles = fake.requests.single().messages.map { it.role }
+        assertEquals(listOf("user", "assistant", "user"), roles)
+        val lastContent = fake.requests.single().messages.last().content.single()
+        assertEquals("t1", (lastContent as ContentBlock.ToolResult).tool_use_id)
+        assertEquals(
+            listOf("user", "assistant", "user", "assistant"),
+            dao.findBySession("s1").map { it.role },
+        )
+    }
+
+    @Test
+    fun resume_from_seed_only_does_not_duplicate_the_seed_row() = runTest(dispatcher) {
+        persist(role = "user", blocks = listOf(ContentBlock.Text("prompt")))
+        val fake = FakeAnthropic(listOf(response(listOf(ContentBlock.Text("Done")), stop = "end_turn")))
+
+        val outcome = runner(fake).run("s1", turnIndex = 0, initialUserMessage = "ignored on resume")
+
+        assertTrue(outcome is TurnRunner.Outcome.Completed)
+        assertEquals(0, echoTool.executions)
+        assertEquals(listOf("user", "assistant"), dao.findBySession("s1").map { it.role })
+        assertEquals("prompt", (fake.requests.single().messages.first().content.single() as ContentBlock.Text).text)
+    }
+
+    private suspend fun persist(role: String, blocks: List<ContentBlock>) {
+        dao.insert(
+            AiMessageEntity(
+                sessionId = "s1",
+                turnIndex = 0,
+                role = role,
+                contentJson = SessionJson.encodeToString(blocks),
+                createdAt = 0L,
+            )
+        )
+    }
+
+    private fun runner(client: AnthropicMessages) = TurnRunner(
+        client = client,
+        aiMessageDao = dao,
+        model = "claude-haiku-4-5",
+        systemPrompt = "system",
+        tools = ToolRegistry(listOf(echoTool)),
+        maxTokens = 1024,
+    )
+
+    private fun toolUse(id: String) = ContentBlock.ToolUse(id = id, name = "echo", input = JsonObject(emptyMap()))
+
+    private fun response(blocks: List<ContentBlock>, stop: String) = MessagesResponse(
+        id = "msg",
+        model = "claude-haiku-4-5",
+        role = "assistant",
+        content = blocks,
+        stop_reason = stop,
+        usage = Usage(output_tokens = 3),
+    )
+
+    private class FakeAnthropic(private val script: List<MessagesResponse>) : AnthropicMessages {
+        val requests = mutableListOf<MessagesRequest>()
+
+        override suspend fun send(request: MessagesRequest): MessagesResponse =
+            throw UnsupportedOperationException("streaming path only")
+
+        override suspend fun stream(
+            request: MessagesRequest,
+            onPartial: suspend (List<ContentBlock>) -> Unit,
+        ): MessagesResponse {
+            requests += request
+            return script[requests.size - 1]
+        }
+    }
+
+    private class CountingEchoTool : Tool {
+        var executions = 0
+        override val definition = ToolDefinition(name = "echo", description = "echoes", input_schema = JsonObject(emptyMap()))
+        override suspend fun execute(input: JsonElement): ToolResult {
+            executions++
+            return ToolResult(payload = """{"ok":true}""")
+        }
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/worker/AiTurnWorkerTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/worker/AiTurnWorkerTest.kt
@@ -1,0 +1,59 @@
+package fr.bsodium.cron.worker
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.testing.WorkManagerTestInitHelper
+import androidx.work.workDataOf
+import fr.bsodium.cron.session.db.CronDatabase
+import fr.bsodium.cron.session.db.toEntity
+import fr.bsodium.cron.session.model.SessionStatus
+import fr.bsodium.cron.testutil.Fixtures
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AiTurnWorkerTest {
+
+    private lateinit var app: Application
+    private lateinit var db: CronDatabase
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        WorkManagerTestInitHelper.initializeTestWorkManager(app)
+        db = CronDatabase.get(app)
+        // The production CronDatabase singleton is file-backed and persists across tests in the JVM;
+        // wipe it (cascades to events + ai_messages) so each test starts from a clean slate.
+        runBlocking { db.sessionDao().deleteOlderThan(Long.MAX_VALUE) }
+    }
+
+    @Test
+    fun missing_session_fails_without_running_a_turn() = runTest {
+        val result = buildWorker("nope").doWork()
+
+        assertEquals(ListenableWorker.Result.failure(), result)
+    }
+
+    @Test
+    fun completed_session_skips_the_turn_without_billing() = runTest {
+        db.sessionDao().insert(Fixtures.session(id = "s1", status = SessionStatus.Complete).toEntity())
+
+        val result = buildWorker("s1").doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+        assertTrue(db.aiMessageDao().findBySession("s1").isEmpty())
+    }
+
+    private fun buildWorker(sessionId: String): AiTurnWorker =
+        TestListenableWorkerBuilder.from(app, AiTurnWorker::class.java)
+            .setInputData(workDataOf(AiTurnWorker.KEY_SESSION_ID to sessionId))
+            .build()
+}


### PR DESCRIPTION
## Summary
Part of the cleanup/audit pass — fixes a chain of compounding cost-control and turn-completion bugs found in the AI turn pipeline by a prior deep audit. Four bugs, one PR since they interact:

1. **`AiTurnWorker` never checked session status.** A companion fix (#163) makes `SessionFsm.onStatusChange(Complete)` cancel any in-flight AI turn — this adds a second line of defense: `doWork` now checks `session.status == Complete` up front and skips the turn (no billing) rather than relying solely on cancellation timing.
2. **Resume-after-retry was dead code.** `AiTurnWorker` always computed `turnIndex = maxTurnIndex + 1` on every attempt, so a retried worker whose previous attempt left partial rows always started a brand-new turn instead of resuming — re-billing every round-trip and re-executing side-effectful tools. Extracted `TurnIndexResolver` to find and reuse an in-progress partial turn's index on retry (`isRetry = runAttemptCount > 0`), so `TurnRunner.loadOrSeed` actually resumes instead of duplicating.
3. **Usage was only recorded on success.** `TurnRunner` now fires a new `onRoundTripUsage` callback after every successful round-trip, wired to `budget::record` in `AiTurnWorker` — so a turn that fails partway through still has its already-billed spend counted against the daily cap (the old end-of-turn-only `budget.record(outcome.totalUsage)` call is removed to avoid double-counting).
4. **Unbounded retries.** `AiTurnWorker` retried every retryable HTTP error and unexpected exception forever. Now caps at `MAX_RETRY_ATTEMPTS = 5` via WorkManager's `runAttemptCount`, giving up with a diagnosable `REASON_MAX_RETRIES` failure reason once exceeded.

## Test plan
- [x] `./gradlew :app:assembleDebug :app:lintDebug :app:checkFileLength :app:checkAnimationPreviews` all pass.
- [x] `./gradlew :app:testDebugUnitTest` — full suite green, including new `AiTurnWorkerTest` (Bug 1), `TurnIndexResolverTest` + `TurnRunnerResumeTest` (Bug 2) cases.
- [ ] Bug 4 (retry cap) has **no dedicated regression test** — `FakeAnthropicClient`'s error injection is probabilistic (`ERROR_RATE`-gated on turn 0 of its internal call counter), not deterministically triggerable from a test without further mock-plumbing work. The fix is a small, standard `runAttemptCount` guard; verified by code review and the full suite staying green rather than a forced/flaky test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)