### PR TITLE
fix(test): specify RECEIVER_NOT_EXPORTED on dynamically-registered test receivers

### DIFF
--- a/app/src/test/java/fr/bsodium/cron/receiver/AlarmReceiverTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/receiver/AlarmReceiverTest.kt
@@ -6,6 +6,7 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Looper
+import androidx.core.content.ContextCompat
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.testing.WorkManagerTestInitHelper
 import fr.bsodium.cron.alarm.AlarmConstants
@@ -52,7 +53,7 @@ class AlarmReceiverTest {
 
     private fun dispatch(action: String, extras: Intent.() -> Unit = {}) {
         val receiver = AlarmReceiver()
-        app.registerReceiver(receiver, IntentFilter(action))
+        ContextCompat.registerReceiver(app, receiver, IntentFilter(action), ContextCompat.RECEIVER_NOT_EXPORTED)
         app.sendBroadcast(Intent(action).apply(extras))
         shadowOf(Looper.getMainLooper()).idle()
         app.unregisterReceiver(receiver)

--- a/app/src/test/java/fr/bsodium/cron/receiver/EveningPlanReceiverTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/receiver/EveningPlanReceiverTest.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Looper
+import androidx.core.content.ContextCompat
 import androidx.test.core.app.ApplicationProvider
 import fr.bsodium.cron.alarm.AlarmConstants
 import fr.bsodium.cron.settings.SettingsRepository
@@ -33,7 +34,9 @@ class EveningPlanReceiverTest {
 
     private fun dispatch() {
         val receiver = EveningPlanReceiver()
-        app.registerReceiver(receiver, IntentFilter(EveningPlanReceiver.ACTION_FIRE))
+        ContextCompat.registerReceiver(
+            app, receiver, IntentFilter(EveningPlanReceiver.ACTION_FIRE), ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
         app.sendBroadcast(Intent(EveningPlanReceiver.ACTION_FIRE))
         shadowOf(Looper.getMainLooper()).idle()
         app.unregisterReceiver(receiver)

--- a/app/src/test/java/fr/bsodium/cron/receiver/TimeZoneChangedReceiverTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/receiver/TimeZoneChangedReceiverTest.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Looper
+import androidx.core.content.ContextCompat
 import androidx.test.core.app.ApplicationProvider
 import fr.bsodium.cron.alarm.AlarmConstants
 import fr.bsodium.cron.settings.SettingsRepository
@@ -32,7 +33,9 @@ class TimeZoneChangedReceiverTest {
     @Test
     fun timezone_change_rearms_the_evening_plan_trigger() {
         val receiver = TimeZoneChangedReceiver()
-        app.registerReceiver(receiver, IntentFilter(Intent.ACTION_TIMEZONE_CHANGED))
+        ContextCompat.registerReceiver(
+            app, receiver, IntentFilter(Intent.ACTION_TIMEZONE_CHANGED), ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
         app.sendBroadcast(Intent(Intent.ACTION_TIMEZONE_CHANGED))
         shadowOf(Looper.getMainLooper()).idle()
         app.unregisterReceiver(receiver)


### PR DESCRIPTION
## Summary
`main` currently fails `lintDebug` (`UnspecifiedRegisterReceiverFlag`) — the three receiver tests added in #164 use the unflagged `Context.registerReceiver(receiver, filter)` overload, which Android 14+ requires an explicit `RECEIVER_EXPORTED`/`RECEIVER_NOT_EXPORTED` flag for. Missed in #164's own gate run (a narrower gate combination didn't surface it); caught re-running the full combined gate during a later rebase.

Fix: switch all three to `ContextCompat.registerReceiver(..., ContextCompat.RECEIVER_NOT_EXPORTED)` — these are app-internal test broadcasts, never meant to receive from other apps.

## Test plan
- [x] `./gradlew :app:assembleDebug :app:lintDebug :app:checkFileLength :app:checkAnimationPreviews :app:testDebugUnitTest` — all green, lint error gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)