### PR TITLE
feat(health-connect): write detected sleep sessions to Health Connect

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
 
     <!-- Health Connect: sleep session records -->
     <uses-permission android:name="android.permission.health.READ_SLEEP" />
+    <uses-permission android:name="android.permission.health.WRITE_SLEEP" />
 
     <!-- Health Connect provider visibility (Android 11+) -->
     <queries>

--- a/app/src/main/java/fr/bsodium/cron/sensors/healthconnect/SleepSessionWriter.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/healthconnect/SleepSessionWriter.kt
@@ -1,0 +1,68 @@
+package fr.bsodium.cron.sensors.healthconnect
+
+import android.content.Context
+import android.util.Log
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.records.metadata.Device
+import androidx.health.connect.client.records.metadata.Metadata
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.offsetAt
+import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toJavaZoneOffset
+
+/**
+ * Writes Cron's own detected sleep window to Health Connect as a stage-less [SleepSessionRecord],
+ * so Cron is a sleep-data source in its own right for users without a wearable app already
+ * populating Health Connect (see [SleepStageReader], the read-side counterpart).
+ */
+class SleepSessionWriter(private val context: Context) {
+
+    val requiredPermissions: Set<String> = setOf(
+        HealthPermission.getWritePermission(SleepSessionRecord::class),
+    )
+
+    /** Whether the sleep write permission is currently granted (false if HC is unavailable). */
+    suspend fun hasWritePermission(): Boolean {
+        if (HealthConnectClient.getSdkStatus(context) != HealthConnectClient.SDK_AVAILABLE) return false
+        val granted = HealthConnectClient.getOrCreate(context).permissionController.getGrantedPermissions()
+        return granted.containsAll(requiredPermissions)
+    }
+
+    /**
+     * Insert one [SleepSessionRecord] for [start]..[end]. [clientRecordId] (Cron's session id) makes
+     * repeated writes for the same session idempotent — Health Connect upserts by client record id
+     * rather than inserting a duplicate.
+     */
+    suspend fun write(start: Instant, end: Instant, timezone: TimeZone, clientRecordId: String): Boolean {
+        val client = HealthConnectClient.getOrCreate(context)
+        val granted = client.permissionController.getGrantedPermissions()
+        if (!granted.containsAll(requiredPermissions)) {
+            Log.d(TAG, "Sleep write permission not granted; skipping write")
+            return false
+        }
+        val record = SleepSessionRecord(
+            startTime = start.toJavaInstant(),
+            startZoneOffset = timezone.offsetAt(start).toJavaZoneOffset(),
+            endTime = end.toJavaInstant(),
+            endZoneOffset = timezone.offsetAt(end).toJavaZoneOffset(),
+            metadata = Metadata.autoRecorded(
+                device = Device(type = Device.TYPE_PHONE),
+                clientRecordId = clientRecordId,
+            ),
+        )
+        return try {
+            client.insertRecords(listOf(record))
+            true
+        } catch (t: Throwable) {
+            Log.e(TAG, "Failed to write sleep session", t)
+            false
+        }
+    }
+
+    companion object {
+        private const val TAG = "SleepSessionWriter"
+    }
+}

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -180,6 +180,7 @@ class SessionFsm(
                 alarmScheduler.cancel(session.date)
                 hardLatestScheduler.clear(session.date)
                 repository.cancelAiTurn(session.id)
+                repository.triggerSleepSessionWrite(session.id)
                 context.startService(SleepSessionService.stopIntent(context))
                 Log.i(TAG, "Session ${session.id} complete — alarms cleared, AI turn cancelled, service stopped")
             }

--- a/app/src/main/java/fr/bsodium/cron/session/SessionRepository.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionRepository.kt
@@ -19,6 +19,7 @@ import fr.bsodium.cron.session.model.SessionEvent
 import fr.bsodium.cron.session.model.SessionStatus
 import fr.bsodium.cron.session.model.SleepSession
 import fr.bsodium.cron.worker.AiTurnWorker
+import fr.bsodium.cron.worker.SleepSessionWriteWorker
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
@@ -114,6 +115,21 @@ class SessionRepository(private val context: Context) {
     /** Cancels the in-flight AI turn for [sessionId], if any. */
     fun cancelAiTurn(sessionId: String) {
         WorkManager.getInstance(context).cancelUniqueWork("${AiTurnWorker.WORK_PREFIX}$sessionId")
+    }
+
+    /** Enqueues the Health Connect sleep-window write for a just-completed session. KEEP (not REPLACE,
+     *  unlike [triggerAiTurn]): there's only ever one legitimate write per session, so a duplicate
+     *  enqueue should be dropped rather than restarted — idempotency is otherwise backstopped by
+     *  Health Connect's clientRecordId upsert semantics in [fr.bsodium.cron.sensors.healthconnect.SleepSessionWriter]. */
+    fun triggerSleepSessionWrite(sessionId: String) {
+        val request = OneTimeWorkRequestBuilder<SleepSessionWriteWorker>()
+            .setInputData(Data.Builder().putString(SleepSessionWriteWorker.KEY_SESSION_ID, sessionId).build())
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            "${SleepSessionWriteWorker.NAME_PREFIX}$sessionId",
+            ExistingWorkPolicy.KEEP,
+            request,
+        )
     }
 
     /** Live WorkInfo for the session's AI turn — drives the home "working" indicator. */

--- a/app/src/main/java/fr/bsodium/cron/session/model/DayPlan.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/model/DayPlan.kt
@@ -41,3 +41,16 @@ data class SleepSession(
  *  reading the bootstrap's first event routes commutes from a stale location. */
 fun SleepSession.latestEveningPlanLocation(): LocationPayload? =
     (events.lastOrNull { it.trigger == TriggerType.EveningPlan }?.data as? EventData.EveningPlan)?.location
+
+data class SleepWindow(val start: Instant, val end: Instant)
+
+/** Cron's own coarse asleep→awake window for this session: the earliest [TriggerType.SleepOnset]
+ *  (later ones are re-arms after an interruption, not a new bedtime) through the latest
+ *  [TriggerType.OutOfBedConfirmed]. Null if either boundary is missing or the window is malformed —
+ *  [androidx.health.connect.client.records.SleepSessionRecord] rejects a start not strictly before end. */
+fun SleepSession.detectedSleepWindow(): SleepWindow? {
+    val start = events.filter { it.trigger == TriggerType.SleepOnset }.minByOrNull { it.timestamp } ?: return null
+    val end = events.filter { it.trigger == TriggerType.OutOfBedConfirmed }.maxByOrNull { it.timestamp } ?: return null
+    if (end.timestamp <= start.timestamp) return null
+    return SleepWindow(start.timestamp, end.timestamp)
+}

--- a/app/src/main/java/fr/bsodium/cron/settings/SettingsRepository.kt
+++ b/app/src/main/java/fr/bsodium/cron/settings/SettingsRepository.kt
@@ -111,6 +111,12 @@ class SettingsRepository(private val context: Context) {
         prefs[AUTO_ALARMS_ENABLED] ?: true
     }
 
+    /** Whether Cron's own detected sleep window is written to Health Connect on session completion.
+     *  Defaults on; the actual write still requires the user to grant the write permission. */
+    val saveSleepToHealthConnect: Flow<Boolean> = context.dataStore.data.map { prefs ->
+        prefs[SAVE_SLEEP_TO_HC] ?: true
+    }
+
     /** User-supplied display name shown in the home greeting. */
     val displayName: Flow<String?> = context.dataStore.data.map { prefs ->
         prefs[DISPLAY_NAME]?.takeIf { it.isNotBlank() }
@@ -188,6 +194,13 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun autoAlarmsEnabledNow(): Boolean = autoAlarmsEnabled.first()
 
+    /** Plain edit: a UX toggle, so it mustn't raise the "replan?" pill. */
+    suspend fun setSaveSleepToHealthConnect(enabled: Boolean) =
+        context.dataStore.edit { it[SAVE_SLEEP_TO_HC] = enabled }
+
+    /** One-shot read for use from [fr.bsodium.cron.worker.SleepSessionWriteWorker], which can't collect a Flow. */
+    suspend fun saveSleepToHealthConnectNow(): Boolean = saveSleepToHealthConnect.first()
+
     suspend fun setDisplayName(name: String) =
         context.dataStore.edit { it[DISPLAY_NAME] = name.trim() }
 
@@ -226,6 +239,7 @@ class SettingsRepository(private val context: Context) {
         val HAPTICS_ENABLED = booleanPreferencesKey("haptics_enabled")
         val COMPACT_NAV_ENABLED = booleanPreferencesKey("compact_nav_enabled")
         val AUTO_ALARMS_ENABLED = booleanPreferencesKey("auto_alarms_enabled")
+        val SAVE_SLEEP_TO_HC = booleanPreferencesKey("save_sleep_to_health_connect")
         val DISPLAY_NAME = stringPreferencesKey("display_name")
         val USER_INSTRUCTIONS = stringPreferencesKey("user_instructions")
         val DAILY_TOKEN_LIMIT = intPreferencesKey("daily_token_limit")

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsNavGraph.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsNavGraph.kt
@@ -171,8 +171,15 @@ fun NavGraphBuilder.settingsGraph(
                 onBack = { navController.popBackStack() },
             )
         }
-        settingsDetail(SETTINGS_RELIABILITY) {
-            ReliabilitySettingsScreen(onBack = { navController.popBackStack() })
+        settingsDetail(SETTINGS_RELIABILITY) { entry ->
+            val vm = entry.settingsViewModel(navController)
+            val state by vm.uiState.collectAsState()
+            ReliabilitySettingsScreen(
+                saveSleepToHealthConnect = state.saveSleepToHealthConnect,
+                onSaveSleepToHealthConnect = vm::setSaveSleepToHealthConnect,
+                hapticsEnabled = state.hapticsEnabled,
+                onBack = { navController.popBackStack() },
+            )
         }
         settingsDetail(SETTINGS_ACCOUNT) { entry ->
             val vm = entry.settingsViewModel(navController)

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/SettingsViewModel.kt
@@ -34,6 +34,7 @@ data class SettingsUiState(
     val tokensUsedToday: Int = 0,
     val hapticsEnabled: Boolean = true,
     val compactNavEnabled: Boolean = false,
+    val saveSleepToHealthConnect: Boolean = true,
 )
 
 class SettingsViewModel @JvmOverloads constructor(
@@ -84,6 +85,8 @@ class SettingsViewModel @JvmOverloads constructor(
         state.copy(hapticsEnabled = haptics)
     }.combine(repo.compactNavEnabled) { state, compact ->
         state.copy(compactNavEnabled = compact)
+    }.combine(repo.saveSleepToHealthConnect) { state, saveSleep ->
+        state.copy(saveSleepToHealthConnect = saveSleep)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState())
 
     fun setEveningTrigger(time: LocalTime) {
@@ -139,6 +142,10 @@ class SettingsViewModel @JvmOverloads constructor(
 
     fun setCompactNavEnabled(enabled: Boolean) {
         viewModelScope.launch { repo.setCompactNavEnabled(enabled) }
+    }
+
+    fun setSaveSleepToHealthConnect(enabled: Boolean) {
+        viewModelScope.launch { repo.setSaveSleepToHealthConnect(enabled) }
     }
 
     /** Re-reads today's token spend; called when the Settings screen resumes. */

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/settings/categories/ReliabilitySettingsScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/settings/categories/ReliabilitySettingsScreen.kt
@@ -12,25 +12,37 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.health.connect.client.PermissionController
 import fr.bsodium.cron.permissions.SystemPermissions
+import fr.bsodium.cron.sensors.healthconnect.SleepSessionWriter
 import fr.bsodium.cron.sensors.healthconnect.SleepStageReader
 import fr.bsodium.cron.ui.screens.settings.components.ActionRow
 import fr.bsodium.cron.ui.screens.settings.components.SettingsDetailScaffold
+import fr.bsodium.cron.ui.screens.settings.components.SwitchRow
 
 /**
  * No `@Preview`: this screen reads live system-permission state and wires Activity-result launchers,
  * which the preview renderer can't supply. The individual [ActionRow]s are previewed in `ActionRow.kt`.
  */
 @Composable
-fun ReliabilitySettingsScreen(onBack: () -> Unit) {
+fun ReliabilitySettingsScreen(
+    saveSleepToHealthConnect: Boolean,
+    onSaveSleepToHealthConnect: (Boolean) -> Unit,
+    hapticsEnabled: Boolean,
+    onBack: () -> Unit,
+) {
     val context = LocalContext.current
     val reader = remember { SleepStageReader(context) }
     val hcAvailable = remember { reader.availability() == SleepStageReader.Availability.Available }
+    val writer = remember { SleepSessionWriter(context) }
 
     var bgLocation by remember { mutableStateOf(SystemPermissions.hasBackgroundLocation(context)) }
     var battery by remember { mutableStateOf(SystemPermissions.isIgnoringBatteryOptimizations(context)) }
     var exactAlarms by remember { mutableStateOf(SystemPermissions.canScheduleExactAlarms(context)) }
     var hcConnected by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) { hcConnected = reader.hasSleepPermission() }
+    var hcWriteConnected by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        hcConnected = reader.hasSleepPermission()
+        hcWriteConnected = writer.hasWritePermission()
+    }
 
     val bgLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
         bgLocation = SystemPermissions.hasBackgroundLocation(context)
@@ -43,6 +55,9 @@ fun ReliabilitySettingsScreen(onBack: () -> Unit) {
     val hcLauncher = rememberLauncherForActivityResult(
         PermissionController.createRequestPermissionResultContract()
     ) { granted -> hcConnected = granted.containsAll(reader.requiredPermissions) }
+    val hcWriteLauncher = rememberLauncherForActivityResult(
+        PermissionController.createRequestPermissionResultContract()
+    ) { granted -> hcWriteConnected = granted.containsAll(writer.requiredPermissions) }
 
     SettingsDetailScaffold(title = "Reliability", onBack = onBack) {
         ActionRow(
@@ -77,6 +92,22 @@ fun ReliabilitySettingsScreen(onBack: () -> Unit) {
             actionLabel = "Connect",
             enabled = hcAvailable,
             onClick = { hcLauncher.launch(reader.requiredPermissions) },
+        )
+        ActionRow(
+            title = "Save sleep to Health Connect",
+            subtitle = if (hcAvailable) "Let other apps see when Cron detected you were asleep"
+                else "Install Health Connect to save your sleep data",
+            done = hcWriteConnected,
+            actionLabel = "Connect",
+            enabled = hcAvailable,
+            onClick = { hcWriteLauncher.launch(writer.requiredPermissions) },
+        )
+        SwitchRow(
+            title = "Auto-save sleep sessions",
+            subtitle = "Automatically write each night's detected sleep window",
+            checked = saveSleepToHealthConnect,
+            onCheckedChange = onSaveSleepToHealthConnect,
+            hapticsEnabled = hapticsEnabled,
         )
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/worker/SleepSessionWriteWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/SleepSessionWriteWorker.kt
@@ -23,7 +23,10 @@ class SleepSessionWriteWorker(
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result {
-        val sessionId = inputData.getString(KEY_SESSION_ID) ?: return Result.failure()
+        val sessionId = inputData.getString(KEY_SESSION_ID) ?: run {
+            Log.w(TAG, "Missing session id in input data — skipping HC write")
+            return Result.failure()
+        }
 
         if (!SettingsRepository(applicationContext).saveSleepToHealthConnectNow()) {
             Log.d(TAG, "Health Connect sleep write disabled — skipping")

--- a/app/src/main/java/fr/bsodium/cron/worker/SleepSessionWriteWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/SleepSessionWriteWorker.kt
@@ -1,0 +1,66 @@
+package fr.bsodium.cron.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import fr.bsodium.cron.sensors.healthconnect.SleepSessionWriter
+import fr.bsodium.cron.session.SessionRepository
+import fr.bsodium.cron.session.model.detectedSleepWindow
+import fr.bsodium.cron.settings.SettingsRepository
+import kotlinx.datetime.TimeZone
+
+/**
+ * One-off worker that writes a just-completed session's [detectedSleepWindow] to Health Connect.
+ * Enqueued by [SessionRepository.triggerSleepSessionWrite] when a session reaches
+ * [fr.bsodium.cron.session.model.SessionStatus.Complete]. Every precondition failure is a graceful
+ * skip (log + [Result.success]) — writing to Health Connect is a nice-to-have, never worth crashing
+ * or retrying over.
+ */
+class SleepSessionWriteWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        val sessionId = inputData.getString(KEY_SESSION_ID) ?: return Result.failure()
+
+        if (!SettingsRepository(applicationContext).saveSleepToHealthConnectNow()) {
+            Log.d(TAG, "Health Connect sleep write disabled — skipping")
+            return Result.success()
+        }
+
+        val session = SessionRepository(applicationContext).findById(sessionId)
+        if (session == null) {
+            Log.w(TAG, "Session $sessionId not found — skipping HC write")
+            return Result.success()
+        }
+
+        val window = session.detectedSleepWindow()
+        if (window == null) {
+            Log.d(TAG, "Session $sessionId has no onset/wake pair — skipping HC write")
+            return Result.success()
+        }
+
+        val writer = SleepSessionWriter(applicationContext)
+        if (!writer.hasWritePermission()) {
+            Log.d(TAG, "Health Connect write permission not granted — skipping")
+            return Result.success()
+        }
+
+        val wrote = writer.write(
+            start = window.start,
+            end = window.end,
+            timezone = TimeZone.of(session.timezone),
+            clientRecordId = sessionId,
+        )
+        Log.i(TAG, "Session $sessionId Health Connect write ${if (wrote) "succeeded" else "failed"}")
+        return Result.success()
+    }
+
+    companion object {
+        const val NAME_PREFIX = "cron_hc_sleep_write_"
+        const val KEY_SESSION_ID = "session_id"
+        private const val TAG = "SleepSessionWriteWorker"
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/session/model/SleepWindowTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/session/model/SleepWindowTest.kt
@@ -1,0 +1,68 @@
+package fr.bsodium.cron.session.model
+
+import fr.bsodium.cron.testutil.Fixtures
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SleepWindowTest {
+
+    private fun onset(at: String) = SessionEvent(trigger = TriggerType.SleepOnset, timestamp = Fixtures.at(at), data = EventData.SleepOnset(screenOffSince = Fixtures.at(at), rearm = false))
+    private fun outOfBed(at: String) = SessionEvent(trigger = TriggerType.OutOfBedConfirmed, timestamp = Fixtures.at(at), data = EventData.OutOfBedConfirmed(evidence = listOf("device_unlocked")))
+
+    @Test
+    fun single_onset_and_wake_resolves_the_window() {
+        val session = Fixtures.session(
+            events = listOf(onset("2026-05-22T22:00:00Z"), outOfBed("2026-05-23T06:00:00Z")),
+        )
+        val window = requireNotNull(session.detectedSleepWindow())
+        assertEquals(Fixtures.at("2026-05-22T22:00:00Z"), window.start)
+        assertEquals(Fixtures.at("2026-05-23T06:00:00Z"), window.end)
+    }
+
+    @Test
+    fun a_rearmed_onset_uses_the_earlier_bedtime_as_start() {
+        val session = Fixtures.session(
+            events = listOf(
+                onset("2026-05-22T22:00:00Z"),
+                onset("2026-05-22T23:30:00Z"),
+                outOfBed("2026-05-23T06:00:00Z"),
+            ),
+        )
+        val window = requireNotNull(session.detectedSleepWindow())
+        assertEquals(Fixtures.at("2026-05-22T22:00:00Z"), window.start)
+    }
+
+    @Test
+    fun a_duplicate_wake_event_uses_the_latest_as_end() {
+        val session = Fixtures.session(
+            events = listOf(
+                onset("2026-05-22T22:00:00Z"),
+                outOfBed("2026-05-23T05:50:00Z"),
+                outOfBed("2026-05-23T06:00:00Z"),
+            ),
+        )
+        val window = requireNotNull(session.detectedSleepWindow())
+        assertEquals(Fixtures.at("2026-05-23T06:00:00Z"), window.end)
+    }
+
+    @Test
+    fun no_onset_is_null() {
+        val session = Fixtures.session(events = listOf(outOfBed("2026-05-23T06:00:00Z")))
+        assertNull(session.detectedSleepWindow())
+    }
+
+    @Test
+    fun no_wake_is_null() {
+        val session = Fixtures.session(events = listOf(onset("2026-05-22T22:00:00Z")))
+        assertNull(session.detectedSleepWindow())
+    }
+
+    @Test
+    fun a_wake_at_or_before_onset_is_malformed_and_null() {
+        val session = Fixtures.session(
+            events = listOf(onset("2026-05-22T22:00:00Z"), outOfBed("2026-05-22T22:00:00Z")),
+        )
+        assertNull(session.detectedSleepWindow())
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/worker/SleepSessionWriteWorkerTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/worker/SleepSessionWriteWorkerTest.kt
@@ -1,0 +1,99 @@
+package fr.bsodium.cron.worker
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.testing.WorkManagerTestInitHelper
+import androidx.work.workDataOf
+import fr.bsodium.cron.session.db.CronDatabase
+import fr.bsodium.cron.session.db.toEntity
+import fr.bsodium.cron.session.model.EventData
+import fr.bsodium.cron.session.model.SessionEvent
+import fr.bsodium.cron.session.model.TriggerType
+import fr.bsodium.cron.settings.SettingsRepository
+import fr.bsodium.cron.testutil.Fixtures
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SleepSessionWriteWorkerTest {
+
+    private lateinit var app: Application
+    private lateinit var db: CronDatabase
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        WorkManagerTestInitHelper.initializeTestWorkManager(app)
+        db = CronDatabase.get(app)
+        // The production CronDatabase singleton is file-backed and persists across tests in the JVM;
+        // wipe it (cascades to events) so each test starts from a clean slate.
+        runBlocking { db.sessionDao().deleteOlderThan(Long.MAX_VALUE) }
+    }
+
+    @Test
+    fun missing_session_id_fails_without_writing() = runTest {
+        val worker = TestListenableWorkerBuilder.from(app, SleepSessionWriteWorker::class.java).build()
+
+        val result = worker.doWork()
+
+        assertEquals(ListenableWorker.Result.failure(), result)
+    }
+
+    @Test
+    fun session_not_found_skips_the_write() = runTest {
+        val result = buildWorker("nope").doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun toggle_off_skips_the_write() = runTest {
+        insertSession("s1", withSleepWindow = true)
+        SettingsRepository(app).setSaveSleepToHealthConnect(false)
+
+        val result = buildWorker("s1").doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun no_onset_wake_pair_skips_the_write() = runTest {
+        insertSession("s1", withSleepWindow = false)
+
+        val result = buildWorker("s1").doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun missing_hc_permission_skips_the_write() = runTest {
+        // Health Connect is unavailable under Robolectric, so hasWritePermission() deterministically returns false here without needing to mock it.
+        insertSession("s1", withSleepWindow = true)
+
+        val result = buildWorker("s1").doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    private suspend fun insertSession(sessionId: String, withSleepWindow: Boolean) {
+        db.sessionDao().insert(Fixtures.session(id = sessionId).toEntity())
+        if (withSleepWindow) {
+            val onset = SessionEvent(TriggerType.SleepOnset, Fixtures.at("2026-05-22T22:00:00Z"), EventData.Empty)
+            val wake = SessionEvent(TriggerType.OutOfBedConfirmed, Fixtures.at("2026-05-23T06:00:00Z"), EventData.Empty)
+            db.eventDao().insert(onset.toEntity(sessionId))
+            db.eventDao().insert(wake.toEntity(sessionId))
+        }
+    }
+
+    private fun buildWorker(sessionId: String): SleepSessionWriteWorker =
+        TestListenableWorkerBuilder.from(app, SleepSessionWriteWorker::class.java)
+            .setInputData(workDataOf(SleepSessionWriteWorker.KEY_SESSION_ID to sessionId))
+            .build()
+}

--- a/app/src/test/java/fr/bsodium/cron/worker/SleepSessionWriteWorkerTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/worker/SleepSessionWriteWorkerTest.kt
@@ -32,8 +32,7 @@ class SleepSessionWriteWorkerTest {
         app = ApplicationProvider.getApplicationContext()
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
         db = CronDatabase.get(app)
-        // The production CronDatabase singleton is file-backed and persists across tests in the JVM;
-        // wipe it (cascades to events) so each test starts from a clean slate.
+        // The production CronDatabase singleton is file-backed and persists across tests in the JVM; wipe it (cascades to events) so each test starts from a clean slate.
         runBlocking { db.sessionDao().deleteOlderThan(Long.MAX_VALUE) }
     }
 


### PR DESCRIPTION
## Summary
- Cron already reads sleep-stage data from Health Connect but never wrote to it. On session completion (`SessionFsm.onStatusChange`'s `Complete` branch), a new `SleepSessionWriteWorker` writes Cron's own detected sleep window — earliest `SleepOnset` through latest `OutOfBedConfirmed` — as a stage-less `SleepSessionRecord`, via a new `SleepSessionWriter`.
- Gated by a new "Auto-save sleep sessions" toggle in Settings → Reliability (default **on**), paired with a manual "Connect" permission row for the new `WRITE_SLEEP` permission — mirroring the existing read-permission UX, since Health Connect permission requests require a foreground Activity and can't be launched from a background `CoroutineWorker`. Every precondition failure in the worker (toggle off, no session, no onset/wake pair, permission not granted) is a graceful skip, never a crash or retry.
- Idempotency: the FSM's `Complete` transition fires exactly once per session; `ExistingWorkPolicy.KEEP` avoids a duplicate enqueue, and Health Connect's `clientRecordId` (set to the session id) upserts rather than duplicates as a backstop.

**Stacked on [#149](https://github.com/BSoDium/Cron/pull/149)** — base branch is `feat/timeline-node`, not `main`, so the diff only shows this feature's changes. Merge #149 first, or rebase this onto `main` once #149 lands.

## Test plan
- [x] `./gradlew :app:assembleDebug :app:lintDebug :app:checkFileLength :app:checkAnimationPreviews :app:testDebugUnitTest` — all green.
- [x] New `SleepWindowTest` (6 cases): normal window, re-armed onset uses the earliest bedtime, duplicate wake uses the latest, missing onset/wake → null, malformed (wake ≤ onset) → null.
- [ ] Manual on-device: grant `WRITE_SLEEP` in Settings → Reliability, drive a session through onset → wake → dismiss, confirm via `adb logcat -s SleepSessionWriteWorker:* SleepSessionWriter:*` and the Health Connect app's Sleep data that a new Cron-attributed entry appears with the right start/end.
- [ ] Manual: toggle "Auto-save sleep sessions" off, repeat a session to completion, confirm no new HC entry and a "disabled — skipping" log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)