### PR TITLE
feat(home): redesign the timeline track as a thick two-tone asleep/awake line

### DIFF
--- a/app/src/debug/java/fr/bsodium/cron/debug/FakeAnthropicClient.kt
+++ b/app/src/debug/java/fr/bsodium/cron/debug/FakeAnthropicClient.kt
@@ -20,10 +20,17 @@ import kotlin.random.Random
  *
  * Flow per run: read_calendar → estimate_commute → set_alarm → final answer.
  * Wired in via [fr.bsodium.cron.ai.AnthropicClientFactory] when [MockApiPrefs.isEnabled] is true.
+ *
+ * A fresh instance is created per AI turn (see `AnthropicClientFactory.create`), so [scenario] is
+ * picked once at construction — every turn (base plan or replan alike) gets its own random
+ * destination/timing instead of the same hardcoded one, which is also what makes a replan's
+ * resolved wake time actually differ from the previous turn's (needed for the timeline's PREV ›
+ * NEW pair to ever render — it only shows when the two times differ).
  */
 class FakeAnthropicClient : AnthropicMessages {
 
     private var call = 0
+    private val scenario = SCENARIOS.random()
 
     override suspend fun send(request: MessagesRequest): MessagesResponse =
         throw UnsupportedOperationException("FakeAnthropicClient supports the streaming path only")
@@ -33,7 +40,7 @@ class FakeAnthropicClient : AnthropicMessages {
         onPartial: suspend (List<ContentBlock>) -> Unit,
     ): MessagesResponse {
         val turn = call++
-        Log.i(TAG, "stream turn=$turn model=${request.model}")
+        Log.i(TAG, "stream turn=$turn model=${request.model} scenario=${scenario.destination}")
         return realisticRun(turn, request.model, onPartial)
     }
 
@@ -60,30 +67,34 @@ class FakeAnthropicClient : AnthropicMessages {
             }
         }
         1 -> {
-            val thinking = streamThinking(THINK_COMMUTE.random(), onPartial)
+            val thinking = streamThinking(commuteThought(), onPartial)
             val toolUse = ContentBlock.ToolUse(
                 id = SIM_COMMUTE_ID,
                 name = "estimate_commute",
                 input = buildJsonObject {
                     put("origin_lat", SIM_LAT)
                     put("origin_lng", SIM_LNG)
-                    put("destination", SIM_DESTINATION)
-                    put("mode", "TRANSIT")
-                    put("arrival_time_iso", SIM_ANCHOR_ISO)
+                    put("destination", scenario.destination)
+                    put("mode", scenario.transitMode)
+                    put("arrival_time_iso", scenario.anchorIso)
                 },
             )
             onPartial(listOf(thinking.signed(), toolUse))
             response(model, listOf(thinking.signed(), toolUse), stopReason = "tool_use")
         }
         2 -> {
-            val thinking = streamThinking(THINK_ALARM.random(), onPartial)
+            val thinking = streamThinking(alarmThought(), onPartial)
             val toolUse = ContentBlock.ToolUse(
                 id = SIM_ALARM_ID,
                 name = "set_alarm",
                 input = buildJsonObject {
-                    put("time_iso", SIM_WAKE_ISO)
+                    put("time_iso", scenario.wakeIso)
                     put("label", "Morning alarm")
-                    put("reason", "45 min prep + transit to ${SIM_DESTINATION.substringBefore(",")}, arriving ${SIM_ANCHOR_ISO.take(16).replace("T", " ")} UTC")
+                    put(
+                        "reason",
+                        "${scenario.prepMinutes} min prep + transit to ${scenario.destination.substringBefore(",")}, " +
+                            "arriving ${scenario.anchorIso.take(16).replace("T", " ")} UTC",
+                    )
                 },
             )
             onPartial(listOf(thinking.signed(), toolUse))
@@ -91,9 +102,32 @@ class FakeAnthropicClient : AnthropicMessages {
         }
         else -> { // turn is an unbounded call counter; every turn past the scripted 3 lands here
             val thinking = streamThinking(THINK_DONE.random(), onPartial)
-            val text = streamText(ANSWERS.random(), listOf(thinking.signed()), onPartial)
+            val text = streamText(finalAnswer(), listOf(thinking.signed()), onPartial)
             response(model, listOf(thinking.signed(), text))
         }
+    }
+
+    private fun commuteThought(): String {
+        val place = scenario.destination.substringBefore(",")
+        return COMMUTE_THOUGHT_TEMPLATES.random()
+            .replace("%anchor%", scenario.anchorLabel)
+            .replace("%place%", place)
+    }
+
+    private fun alarmThought(): String = ALARM_THOUGHT_TEMPLATES.random()
+        .replace("%commute%", scenario.commuteMinutes.toString())
+        .replace("%prep%", scenario.prepMinutes.toString())
+        .replace("%rawWake%", scenario.rawWakeLabel)
+        .replace("%wake%", scenario.wakeLabel)
+
+    private fun finalAnswer(): String {
+        val place = scenario.destination.substringBefore(",")
+        return ANSWER_TEMPLATES.random()
+            .replace("%wake%", scenario.wakeLabel)
+            .replace("%anchor%", scenario.anchorLabel)
+            .replace("%place%", place)
+            .replace("%commute%", scenario.commuteMinutes.toString())
+            .replace("%prep%", scenario.prepMinutes.toString())
     }
 
     private suspend fun injectStreamingError(
@@ -157,6 +191,23 @@ class FakeAnthropicClient : AnthropicMessages {
         usage = Usage(),
     )
 
+    /** One self-contained planning scenario: a destination, an anchor event to be on time for, and
+     *  the wake time it resolves to. Picked once per [FakeAnthropicClient] instance (i.e. once per
+     *  AI turn) so a single run's calendar → commute → alarm steps stay narratively consistent,
+     *  while different turns (a base plan vs. a later replan, each its own fresh instance) land on
+     *  genuinely different destinations/times instead of the same hardcoded one every time. */
+    private data class Scenario(
+        val destination: String,
+        val transitMode: String,
+        val anchorIso: String,
+        val anchorLabel: String,
+        val commuteMinutes: Int,
+        val prepMinutes: Int,
+        val rawWakeLabel: String,
+        val wakeLabel: String,
+        val wakeIso: String,
+    )
+
     companion object {
         private const val TAG = "FakeAnthropicClient"
         private const val SIM_SIGNATURE = "sim-sig"
@@ -167,14 +218,68 @@ class FakeAnthropicClient : AnthropicMessages {
         private const val BURST_PAUSE_MS = 280L
         private const val ERROR_RATE = 0.10f
 
-        // Fictional planning scenario: 8:45 in-person meeting, Paris.
         private const val SIM_START_ISO = "2025-12-17T00:00:00Z"
         private const val SIM_END_ISO = "2025-12-18T00:00:00Z"
-        private const val SIM_ANCHOR_ISO = "2025-12-17T08:45:00Z"
-        private const val SIM_WAKE_ISO = "2025-12-17T07:30:00Z"
         private const val SIM_LAT = "48.8566"
         private const val SIM_LNG = "2.3522"
-        private const val SIM_DESTINATION = "Tour Montparnasse, Paris"
+
+        private val SCENARIOS = listOf(
+            Scenario(
+                destination = "Tour Montparnasse, Paris",
+                transitMode = "TRANSIT",
+                anchorIso = "2025-12-17T08:45:00Z",
+                anchorLabel = "8:45 in-person meeting",
+                commuteMinutes = 22,
+                prepMinutes = 45,
+                rawWakeLabel = "7:38",
+                wakeLabel = "7:30",
+                wakeIso = "2025-12-17T07:30:00Z",
+            ),
+            Scenario(
+                destination = "Gare de Lyon, Paris",
+                transitMode = "TRANSIT",
+                anchorIso = "2025-12-17T07:15:00Z",
+                anchorLabel = "7:15 train departure",
+                commuteMinutes = 20,
+                prepMinutes = 30,
+                rawWakeLabel = "6:25",
+                wakeLabel = "6:10",
+                wakeIso = "2025-12-17T06:10:00Z",
+            ),
+            Scenario(
+                destination = "La Défense, Paris",
+                transitMode = "TRANSIT",
+                anchorIso = "2025-12-17T09:00:00Z",
+                anchorLabel = "9:00 all-hands",
+                commuteMinutes = 32,
+                prepMinutes = 40,
+                rawWakeLabel = "7:48",
+                wakeLabel = "7:35",
+                wakeIso = "2025-12-17T07:35:00Z",
+            ),
+            Scenario(
+                destination = "Le Marais, Paris",
+                transitMode = "WALKING",
+                anchorIso = "2025-12-17T10:30:00Z",
+                anchorLabel = "10:30 client meeting",
+                commuteMinutes = 25,
+                prepMinutes = 35,
+                rawWakeLabel = "9:30",
+                wakeLabel = "9:20",
+                wakeIso = "2025-12-17T09:20:00Z",
+            ),
+            Scenario(
+                destination = "Charles de Gaulle Airport T2E, Roissy",
+                transitMode = "TRANSIT",
+                anchorIso = "2025-12-17T06:20:00Z",
+                anchorLabel = "6:20 flight check-in",
+                commuteMinutes = 48,
+                prepMinutes = 60,
+                rawWakeLabel = "4:32",
+                wakeLabel = "4:20",
+                wakeIso = "2025-12-17T04:20:00Z",
+            ),
+        )
 
         private val THINK_READ_CAL = listOf(
             "Let me check the calendar for the next 24 hours to find the first hard anchor — any event you must be on time for. " +
@@ -188,18 +293,18 @@ class FakeAnthropicClient : AnthropicMessages {
                 "I'll ignore all-day events unless they're the only thing on the schedule.",
         )
 
-        private val THINK_COMMUTE = listOf(
-            "The calendar shows an 8:45 in-person meeting. I need the commute duration so I can work backwards " +
+        private val COMMUTE_THOUGHT_TEMPLATES = listOf(
+            "The calendar shows a %anchor%. I need the commute duration so I can work backwards " +
                 "to the required departure time. Querying by transit from the current location, arriving a few minutes early.",
-            "There's an 8:45 anchor at the office. Let me estimate the commute via transit — I want to arrive " +
-                "with a couple of minutes to spare, so I'll target 8:43 as the arrival time.",
+            "There's a %anchor% at %place%. Let me estimate the commute — I want to arrive " +
+                "with a couple of minutes to spare.",
         )
 
-        private val THINK_ALARM = listOf(
-            "Transit comes in at about 22 minutes. I need to depart by 8:23, so waking at 7:40 gives me 45 minutes of " +
-                "preparation. The nearest 90-minute light-sleep window lands at 7:30 — within the ±15 min snap tolerance. Using 7:30.",
-            "Commute is roughly 26 minutes. Departure at 8:19, minus 45 minutes prep time, gives a 7:34 raw wake time. " +
-                "The sleep cycle places a light-sleep moment at 7:30, well within tolerance. Setting the alarm there.",
+        private val ALARM_THOUGHT_TEMPLATES = listOf(
+            "Transit comes in at about %commute% minutes. Waking at %rawWake% gives me %prep% minutes of " +
+                "preparation. The nearest 90-minute light-sleep window lands at %wake% — within the ±15 min snap tolerance. Using %wake%.",
+            "Commute is roughly %commute% minutes. Minus %prep% minutes of prep time gives a %rawWake% raw wake time. " +
+                "The sleep cycle places a light-sleep moment at %wake%, well within tolerance. Setting the alarm there.",
         )
 
         private val THINK_DONE = listOf(
@@ -207,13 +312,13 @@ class FakeAnthropicClient : AnthropicMessages {
             "Done.",
         )
 
-        private val ANSWERS = listOf(
-            "SUMMARY: Wake at 7:30 to make your 8:45 meeting\n\n" +
-                "Set a **7:30** alarm for your 8:45 in-person at ${SIM_DESTINATION.substringBefore(",")}. " +
-                "Transit is ~22 min; I added 45 min of preparation time and snapped to a light-sleep window.",
-            "SUMMARY: Alarm set for 7:30 — 75 min before your 8:45 anchor\n\n" +
-                "Your **7:30** alarm is set. You have an 8:45 meeting at ${SIM_DESTINATION.substringBefore(",")} (~26 min by transit). " +
-                "I added 45 min prep time and landed on the nearest 90-minute light-sleep window.",
+        private val ANSWER_TEMPLATES = listOf(
+            "SUMMARY: Wake at %wake% to make your %anchor%\n\n" +
+                "Set a **%wake%** alarm for your %anchor% at %place%. " +
+                "Transit is ~%commute% min; I added %prep% min of preparation time and snapped to a light-sleep window.",
+            "SUMMARY: Alarm set for %wake% — ahead of your %anchor%\n\n" +
+                "Your **%wake%** alarm is set. You have a %anchor% at %place% (~%commute% min by transit). " +
+                "I added %prep% min prep time and landed on the nearest 90-minute light-sleep window.",
         )
     }
 }

--- a/app/src/debug/java/fr/bsodium/cron/debug/FakeToolRegistry.kt
+++ b/app/src/debug/java/fr/bsodium/cron/debug/FakeToolRegistry.kt
@@ -8,6 +8,8 @@ import fr.bsodium.cron.ai.wire.ToolDefinition
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * DEBUG-ONLY. Returns a [ToolRegistry] whose tools return canned responses
@@ -37,11 +39,7 @@ object FakeToolRegistry {
                 description = "Geocode an address to lat/lng",
                 response = """{"lat":48.8566,"lng":2.3522}""",
             ),
-            stub(
-                name = "set_alarm",
-                description = "Set an alarm",
-                response = """{"status":"ok"}""",
-            ),
+            setAlarmStub(),
             stub(
                 name = "do_nothing",
                 description = "Skip planning",
@@ -73,5 +71,22 @@ object FakeToolRegistry {
         )
 
         override suspend fun execute(input: JsonElement) = ToolResult(response)
+    }
+
+    /** Unlike every other stub, `set_alarm`'s result has to echo the requested `time_iso` back as
+     *  `alarm_time` — `AiThreadMapper.resolveNewAlarmTime` reads that field to resolve the timeline's
+     *  PREV › NEW headline, so a flat canned "ok" (no side effects, matching every other stub here)
+     *  left every mocked run showing "No alarm set" regardless of what the mock LLM client requested. */
+    private fun setAlarmStub() = object : Tool {
+        override val definition = ToolDefinition(
+            name = "set_alarm",
+            description = "Set an alarm",
+            input_schema = toolSchema(),
+        )
+
+        override suspend fun execute(input: JsonElement): ToolResult {
+            val timeIso = input.jsonObject["time_iso"]?.jsonPrimitive?.content
+            return ToolResult("""{"status":"ok","alarm_time":"$timeIso"}""")
+        }
     }
 }

--- a/app/src/debug/java/fr/bsodium/cron/debug/HistorySeeder.kt
+++ b/app/src/debug/java/fr/bsodium/cron/debug/HistorySeeder.kt
@@ -1,0 +1,335 @@
+package fr.bsodium.cron.debug
+
+import android.content.Context
+import fr.bsodium.cron.ai.wire.ContentBlock
+import fr.bsodium.cron.alarm.AlarmScheduler
+import fr.bsodium.cron.alarm.HardLatestScheduler
+import fr.bsodium.cron.service.SleepSessionService
+import fr.bsodium.cron.session.SessionRepository
+import fr.bsodium.cron.session.db.AiMessageEntity
+import fr.bsodium.cron.session.db.CronDatabase
+import fr.bsodium.cron.session.db.SessionJson
+import fr.bsodium.cron.session.model.ActivityType
+import fr.bsodium.cron.session.model.DayPlan
+import fr.bsodium.cron.session.model.EventData
+import fr.bsodium.cron.session.model.LocationPayload
+import fr.bsodium.cron.session.model.LocationSource
+import fr.bsodium.cron.session.model.SessionEvent
+import fr.bsodium.cron.session.model.SessionStatus
+import fr.bsodium.cron.session.model.SleepStage
+import fr.bsodium.cron.session.model.TriggerType
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * DEBUG-ONLY. Clears every session and writes back a handful of internally-consistent days —
+ * varied plans, replans, and sleep/wake events — so the timeline can be visually reviewed against
+ * realistic data instead of the noise ad hoc manual testing accumulates. Wired from
+ * `DeveloperSettingsScreen`. Writes go through the same [SessionRepository]/[CronDatabase] surfaces
+ * the real app uses (`appendEvent`, direct `aiMessageDao` inserts) — no separate mock path, so the
+ * timeline renders it exactly like real history.
+ */
+object HistorySeeder {
+
+    suspend fun seed(context: Context) {
+        val repo = SessionRepository(context)
+        val db = CronDatabase.get(context)
+
+        // Deleting the DB rows does nothing to a REAL Android alarm already armed from earlier manual testing — AlarmManager is independent of Room, so a stale alarm could still fire later and write into the freshly-seeded fake session; cancel both real schedulers and stop the live sleep-monitoring service for the outgoing session first, so nothing external can write into the DB once synthetic history takes over.
+        repo.findCurrent()?.let { outgoing ->
+            AlarmScheduler(context).cancel(outgoing.date)
+            HardLatestScheduler(context).clear(outgoing.date)
+            repo.cancelAiTurn(outgoing.id)
+        }
+        context.startService(SleepSessionService.stopIntent(context))
+
+        repo.clearAll()
+
+        val tz = TimeZone.currentSystemDefault()
+        val today = Clock.System.now().toLocalDateTime(tz).date
+
+        DAYS.forEachIndexed { index, day ->
+            val date = today.minus(DAYS.size - 1 - index, DateTimeUnit.DAY)
+            seedDay(repo, db, tz, date, day)
+        }
+    }
+
+    private suspend fun seedDay(repo: SessionRepository, db: CronDatabase, tz: TimeZone, date: LocalDate, day: DayScript) {
+        fun at(dayOffset: Int, time: LocalTime): Instant =
+            LocalDateTime(date.plus(dayOffset, DateTimeUnit.DAY), time).toInstant(tz)
+
+        val eveningPlanAt = at(-1, day.eveningPlanTime)
+        val plan = DayPlan(
+            hardLatest = day.hardLatest,
+            wakeWindowStart = day.wakeWindowStart,
+            wakeWindowEnd = day.wakeWindowEnd,
+            commuteBufferMinutes = 25,
+            isFreeDayFallback = false,
+            generatedAt = eveningPlanAt,
+        )
+        val session = repo.createSession(plan, date, tz.id)
+
+        repo.appendEvent(
+            session.id,
+            SessionEvent(
+                trigger = TriggerType.EveningPlan,
+                timestamp = eveningPlanAt,
+                data = EventData.EveningPlan(
+                    timezone = tz.id,
+                    location = LocationPayload(
+                        lat = 48.8566,
+                        lng = 2.3522,
+                        source = LocationSource.Gps,
+                        capturedAt = eveningPlanAt,
+                    ),
+                    isManual = day.manualBase,
+                ),
+            ),
+        )
+
+        var turnIndex = 0
+        for (beat in day.beats) {
+            when (beat) {
+                is Beat.Turn -> {
+                    insertTurn(db, session.id, turnIndex, at(beat.dayOffset, beat.time), beat)
+                    turnIndex++
+                }
+                is Beat.Event -> repo.appendEvent(
+                    session.id,
+                    SessionEvent(trigger = beat.trigger, timestamp = at(beat.dayOffset, beat.time), data = beat.data),
+                )
+            }
+        }
+
+        repo.updateStatus(session.id, day.finalStatus)
+    }
+
+    private suspend fun insertTurn(db: CronDatabase, sessionId: String, turnIndex: Int, at: Instant, turn: Beat.Turn) {
+        val toolId = "seed-$sessionId-$turnIndex"
+        val (toolUse, toolResultContent) = when (val action = turn.action) {
+            is TurnAction.SetAlarm -> ContentBlock.ToolUse(
+                id = toolId,
+                name = "set_alarm",
+                input = buildJsonObject { put("time_iso", action.time.toString()) },
+            ) to """{"alarm_time":"${action.time}"}"""
+            TurnAction.CancelAlarm -> ContentBlock.ToolUse(toolId, "cancel_alarm", buildJsonObject {}) to """{"status":"ok"}"""
+            is TurnAction.DoNothing -> ContentBlock.ToolUse(
+                id = toolId,
+                name = "do_nothing",
+                input = buildJsonObject { put("reason", action.reason) },
+            ) to """{"status":"ok"}"""
+        }
+        val assistantBlocks: List<ContentBlock> = listOf(
+            ContentBlock.Thinking(thinking = turn.thinking),
+            toolUse,
+            ContentBlock.Text(text = "SUMMARY: ${turn.summary}\n\n${turn.body}"),
+        )
+        db.aiMessageDao().insert(
+            AiMessageEntity(
+                sessionId = sessionId,
+                turnIndex = turnIndex,
+                role = "assistant",
+                contentJson = SessionJson.encodeToString(assistantBlocks),
+                createdAt = at.toEpochMilliseconds(),
+            ),
+        )
+        db.aiMessageDao().insert(
+            AiMessageEntity(
+                sessionId = sessionId,
+                turnIndex = turnIndex,
+                role = "user",
+                contentJson = SessionJson.encodeToString<List<ContentBlock>>(
+                    listOf(ContentBlock.ToolResult(tool_use_id = toolId, content = toolResultContent)),
+                ),
+                createdAt = at.toEpochMilliseconds() + TOOL_RESULT_LAG_MS,
+            ),
+        )
+    }
+
+    private const val TOOL_RESULT_LAG_MS = 4_000L
+
+    private sealed interface TurnAction {
+        data class SetAlarm(val time: LocalTime) : TurnAction
+        data object CancelAlarm : TurnAction
+        data class DoNothing(val reason: String) : TurnAction
+    }
+
+    /** One beat in a day's script — either an AI turn (assigned the next turnIndex in order) or a
+     *  plain session event. [dayOffset] is relative to the session's own morning date: -1 is the prior
+     *  evening, 0 is the morning itself. Ordering matters: a turn's inferred [fr.bsodium.cron.ui.screens.home.RunKind]
+     *  comes from whichever event precedes it in time (`AiPlanMapper.buildPlan`), so an event meant to
+     *  motivate a replan must be listed before that replan's turn. */
+    private sealed interface Beat {
+        data class Turn(
+            val dayOffset: Int,
+            val time: LocalTime,
+            val thinking: String,
+            val summary: String,
+            val body: String,
+            val action: TurnAction,
+        ) : Beat
+
+        data class Event(
+            val dayOffset: Int,
+            val time: LocalTime,
+            val trigger: TriggerType,
+            val data: EventData,
+        ) : Beat
+    }
+
+    private data class DayScript(
+        val eveningPlanTime: LocalTime,
+        val manualBase: Boolean,
+        val hardLatest: LocalTime,
+        val wakeWindowStart: LocalTime,
+        val wakeWindowEnd: LocalTime,
+        val beats: List<Beat>,
+        val finalStatus: SessionStatus,
+    )
+
+    private fun time(hour: Int, minute: Int) = LocalTime(hour, minute)
+
+    private val DAYS = listOf(
+        // Day 1 (3 days ago): a calm baseline night — one plan, no replans.
+        DayScript(
+            eveningPlanTime = time(22, 10),
+            manualBase = false,
+            hardLatest = time(8, 0),
+            wakeWindowStart = time(7, 15),
+            wakeWindowEnd = time(7, 45),
+            beats = listOf(
+                Beat.Turn(
+                    dayOffset = -1, time = time(22, 11),
+                    thinking = "Checking tomorrow's calendar for the first hard commitment — an 08:45 meeting, " +
+                        "roughly 25 minutes away by transit.",
+                    summary = "Wake at 07:30 for your 08:45 meeting",
+                    body = "Set a 07:30 alarm — commute is about 25 minutes and I added standard prep time.",
+                    action = TurnAction.SetAlarm(time(7, 30)),
+                ),
+                Beat.Event(0, time(23, 40), TriggerType.SleepOnset, EventData.SleepOnset(screenOffSince = Instant.DISTANT_PAST, rearm = false)),
+                Beat.Event(
+                    0, time(3, 20), TriggerType.MidSleepActivity,
+                    EventData.MidSleepActivity(activityType = ActivityType.Still, screenOn = false, durationSeconds = 45),
+                ),
+                Beat.Event(
+                    0, time(7, 15), TriggerType.WakeWindowOpportunity,
+                    EventData.WakeWindowOpportunity(currentStage = SleepStage.Light, windowStart = time(7, 15), windowEnd = time(7, 45)),
+                ),
+                Beat.Event(0, time(7, 32), TriggerType.OutOfBedConfirmed, EventData.OutOfBedConfirmed(evidence = listOf("accelerometer", "screen_on"))),
+                Beat.Event(0, time(7, 33), TriggerType.AlarmDismissed, EventData.Empty),
+            ),
+            finalStatus = SessionStatus.Complete,
+        ),
+        // Day 2 (2 days ago): a manual evening plan, a schedule change overnight, then a snooze.
+        DayScript(
+            eveningPlanTime = time(21, 50),
+            manualBase = true,
+            hardLatest = time(7, 0),
+            wakeWindowStart = time(6, 0),
+            wakeWindowEnd = time(6, 30),
+            beats = listOf(
+                Beat.Turn(
+                    dayOffset = -1, time = time(21, 51),
+                    thinking = "Replanning now since you asked — reading tomorrow's schedule for the earliest commitment.",
+                    summary = "Wake at 06:45 for your early train",
+                    body = "Set a 06:45 alarm for tomorrow's 07:30 departure — factored in a 30 minute commute.",
+                    action = TurnAction.SetAlarm(time(6, 45)),
+                ),
+                Beat.Event(0, time(23, 10), TriggerType.SleepOnset, EventData.SleepOnset(screenOffSince = Instant.DISTANT_PAST, rearm = false)),
+                Beat.Event(0, time(23, 50), TriggerType.CalendarChange, EventData.CalendarChange(changeType = "event_moved", eventId = "evt-1", affectsFirstEvent = true)),
+                Beat.Turn(
+                    dayOffset = 0, time = time(23, 51),
+                    thinking = "Your first meeting just moved earlier — recalculating the wake window against the new time.",
+                    summary = "Moved your alarm to 06:15",
+                    body = "Your train now leaves earlier, so I moved the alarm up by 30 minutes to keep the same buffer.",
+                    action = TurnAction.SetAlarm(time(6, 15)),
+                ),
+                Beat.Event(
+                    0, time(2, 0), TriggerType.MidSleepActivity,
+                    EventData.MidSleepActivity(activityType = ActivityType.Still, screenOn = false, durationSeconds = 30),
+                ),
+                Beat.Event(0, time(6, 15), TriggerType.AlarmSnoozed, EventData.AlarmInteraction(snoozeDurationMinutes = 9, snoozeCount = 1)),
+                Beat.Turn(
+                    dayOffset = 0, time = time(6, 15),
+                    thinking = "You snoozed once — re-arming a few minutes out rather than a full reschedule.",
+                    summary = "Re-armed for 06:24",
+                    body = "Re-armed the alarm to 06:24 after you snoozed at 06:15 with snooze count = 1.",
+                    action = TurnAction.SetAlarm(time(6, 24)),
+                ),
+                Beat.Event(0, time(6, 25), TriggerType.AlarmDismissed, EventData.Empty),
+                Beat.Event(0, time(6, 26), TriggerType.OutOfBedConfirmed, EventData.OutOfBedConfirmed(evidence = listOf("accelerometer"))),
+            ),
+            finalStatus = SessionStatus.Complete,
+        ),
+        // Day 3 (yesterday): the primary alarm gets missed and the safety alarm has to fire.
+        DayScript(
+            eveningPlanTime = time(22, 30),
+            manualBase = false,
+            hardLatest = time(8, 0),
+            wakeWindowStart = time(6, 45),
+            wakeWindowEnd = time(7, 15),
+            beats = listOf(
+                Beat.Turn(
+                    dayOffset = -1, time = time(22, 31),
+                    thinking = "Standard evening check — nothing on the calendar before 9am tomorrow.",
+                    summary = "Wake at 07:00, no early meetings",
+                    body = "No early commitments tomorrow, so I set a relaxed 07:00 wake time with a full 90-minute sleep-cycle buffer.",
+                    action = TurnAction.SetAlarm(time(7, 0)),
+                ),
+                Beat.Event(0, time(0, 10), TriggerType.SleepOnset, EventData.SleepOnset(screenOffSince = Instant.DISTANT_PAST, rearm = false)),
+                Beat.Event(
+                    0, time(3, 45), TriggerType.MidSleepActivity,
+                    EventData.MidSleepActivity(activityType = ActivityType.Still, screenOn = false, durationSeconds = 60),
+                ),
+                Beat.Event(0, time(8, 0), TriggerType.HardLatestFired, EventData.Empty),
+                Beat.Turn(
+                    dayOffset = 0, time = time(8, 0),
+                    thinking = "The safety alarm already fired — nothing further to schedule right now.",
+                    summary = "Safety alarm handled it",
+                    body = "The primary alarm was missed, so the safety alarm fired at the hard-latest time. No further action needed until tonight's plan.",
+                    action = TurnAction.DoNothing(reason = "Safety alarm already fired; day has started"),
+                ),
+                Beat.Event(0, time(8, 4), TriggerType.AlarmDismissed, EventData.Empty),
+                Beat.Event(0, time(8, 5), TriggerType.OutOfBedConfirmed, EventData.OutOfBedConfirmed(evidence = listOf("screen_on"))),
+            ),
+            finalStatus = SessionStatus.Complete,
+        ),
+        // Day 4 (today): a freshly-settled morning — the current/live session.
+        DayScript(
+            eveningPlanTime = time(22, 0),
+            manualBase = false,
+            hardLatest = time(7, 45),
+            wakeWindowStart = time(6, 45),
+            wakeWindowEnd = time(7, 15),
+            beats = listOf(
+                Beat.Turn(
+                    dayOffset = -1, time = time(22, 1),
+                    thinking = "Checking tomorrow's calendar — first meeting is an 08:15 standup.",
+                    summary = "Wake at 07:15 for your 08:15 standup",
+                    body = "Set a 07:15 alarm — light commute, so I kept prep time standard.",
+                    action = TurnAction.SetAlarm(time(7, 15)),
+                ),
+                Beat.Event(0, time(23, 20), TriggerType.SleepOnset, EventData.SleepOnset(screenOffSince = Instant.DISTANT_PAST, rearm = false)),
+                Beat.Event(
+                    0, time(7, 0), TriggerType.WakeWindowOpportunity,
+                    EventData.WakeWindowOpportunity(currentStage = SleepStage.Light, windowStart = time(7, 0), windowEnd = time(7, 30)),
+                ),
+                Beat.Event(0, time(7, 17), TriggerType.AlarmDismissed, EventData.Empty),
+                Beat.Event(0, time(7, 18), TriggerType.OutOfBedConfirmed, EventData.OutOfBedConfirmed(evidence = listOf("accelerometer", "screen_on"))),
+            ),
+            finalStatus = SessionStatus.Awake,
+        ),
+    )
+}

--- a/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import fr.bsodium.cron.debug.HistorySeeder
 import fr.bsodium.cron.debug.MockApiPrefs
 import fr.bsodium.cron.debug.SleepTestPrefs
 import fr.bsodium.cron.service.SleepSessionService
@@ -50,6 +51,7 @@ fun DeveloperSettingsScreen(onBack: () -> Unit) {
     val sleepPrefs = remember { SleepTestPrefs(context) }
     var fastOnset by remember { mutableStateOf(sleepPrefs.fastOnset) }
     var showClearDialog by remember { mutableStateOf(false) }
+    var showSeedDialog by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
     SettingsDetailScaffold(title = "Developer", onBack = onBack) {
@@ -103,12 +105,12 @@ fun DeveloperSettingsScreen(onBack: () -> Unit) {
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Clear all runs",
+                    text = "Clear all history",
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onBackground,
                 )
                 Text(
-                    text = "Delete every session and its AI messages",
+                    text = "Delete every session, its AI messages, and its events",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -118,6 +120,26 @@ fun DeveloperSettingsScreen(onBack: () -> Unit) {
                     text = "Clear",
                     color = MaterialTheme.colorScheme.error,
                 )
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Seed sample history",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                Text(
+                    text = "Replace every session with 4 days of realistic plans, replans, and sleep events",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            TextButton(onClick = { showSeedDialog = true }) {
+                Text("Seed")
             }
         }
         Row(
@@ -182,8 +204,8 @@ fun DeveloperSettingsScreen(onBack: () -> Unit) {
     if (showClearDialog) {
         AlertDialog(
             onDismissRequest = { showClearDialog = false },
-            title = { Text("Delete all sessions?") },
-            text = { Text("This removes every run, including AI messages and events. This cannot be undone.") },
+            title = { Text("Delete all history?") },
+            text = { Text("This removes every session, including its AI messages and events. This cannot be undone.") },
             confirmButton = {
                 TextButton(onClick = {
                     showClearDialog = false
@@ -194,6 +216,27 @@ fun DeveloperSettingsScreen(onBack: () -> Unit) {
             },
             dismissButton = {
                 TextButton(onClick = { showClearDialog = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+
+    if (showSeedDialog) {
+        AlertDialog(
+            onDismissRequest = { showSeedDialog = false },
+            title = { Text("Replace history with sample data?") },
+            text = { Text("This deletes every existing session and writes back 4 days of synthetic plans, replans, and sleep events for visual testing. This cannot be undone.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showSeedDialog = false
+                    scope.launch { HistorySeeder.seed(context) }
+                }) {
+                    Text("Seed", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSeedDialog = false }) {
                     Text("Cancel")
                 }
             },

--- a/app/src/main/java/fr/bsodium/cron/MainActivity.kt
+++ b/app/src/main/java/fr/bsodium/cron/MainActivity.kt
@@ -158,6 +158,8 @@ class MainActivity : ComponentActivity() {
                 // Pages with a PageAppBar own the status-bar strip; the top edge-fade would two-tone it against the bar's scrolled surfaceContainer shade, so suppress it there.
                 val hasTopAppBar = currentRoute == ROUTE_HISTORY ||
                     currentRoute?.startsWith("settings") == true
+                // Home owns its own top-of-screen occlusion via StickyAlarm's collapse-driven fade (HomeContent.kt) — layering this generic scrim on top produced a visible "double gradient" while scrolling.
+                val showTopScrim = !hasTopAppBar && currentRoute != ROUTE_HOME
                 val fabRegistry = remember { FabRegistry() }
                 val fabChevron = rememberFabChevron()
                 val compactNavPref by settings.compactNavEnabled.collectAsState(initial = false)
@@ -298,7 +300,7 @@ class MainActivity : ComponentActivity() {
                                 }
                                 settingsGraph(navController, tabEnter = tabEnter, tabExit = tabExit)
                             }
-                            EdgeFades(showTopScrim = !hasTopAppBar)
+                            EdgeFades(showTopScrim = showTopScrim, showNavPillClearance = showBottomBar)
                         }
                     }
                 }

--- a/app/src/main/java/fr/bsodium/cron/calendar/CalendarChangeAnalyzer.kt
+++ b/app/src/main/java/fr/bsodium/cron/calendar/CalendarChangeAnalyzer.kt
@@ -22,23 +22,27 @@ class CalendarChangeAnalyzer(
     data class Result(
         val firstEventChanged: Boolean,
         val newSig: String?,
+        /** The first event's own title, threaded out so the timeline can build a human-readable
+         *  summary of what changed instead of just "your first event changed". */
+        val firstEventTitle: String?,
     )
 
     fun analyze(session: SleepSession): Result {
         val tz = TimeZone.of(session.timezone)
-        val currentSig = computeFirstEventSig(session, tz)
+        val first = firstMorningEvent(session, tz)
+        val currentSig = first?.let { "${it.id}|${it.start.toEpochMilliseconds()}|${it.location.orEmpty()}|${it.selfAttendeeStatus}" }
         return Result(
             firstEventChanged = currentSig != session.cachedFirstEventSig,
             newSig = currentSig,
+            firstEventTitle = first?.title,
         )
     }
 
-    private fun computeFirstEventSig(session: SleepSession, timezone: TimeZone): String? {
+    private fun firstMorningEvent(session: SleepSession, timezone: TimeZone): CalendarReader.Event? {
         val dayStart = session.date.atStartOfDayIn(timezone)
         val dayEnd = dayStart + MORNING_WINDOW
         val events = CalendarReader(contentResolver).readEvents(dayStart, dayEnd, allowedRsvpStatuses = allowedRsvpStatuses)
-        val first = events.firstOrNull { !it.allDay } ?: return null
-        return "${first.id}|${first.start.toEpochMilliseconds()}|${first.location.orEmpty()}|${first.selfAttendeeStatus}"
+        return events.firstOrNull { !it.allDay }
     }
 
     companion object {

--- a/app/src/main/java/fr/bsodium/cron/session/SessionRepository.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionRepository.kt
@@ -193,7 +193,18 @@ class SessionRepository(private val context: Context) {
         ))
     }
 
-    suspend fun clearAll(): Int = db.sessionDao().deleteAll()
+    /** Deletes every session, its events, and its AI messages. The `ON DELETE CASCADE` declared on
+     *  [fr.bsodium.cron.session.db.SessionEventEntity]/[fr.bsodium.cron.session.db.AiMessageEntity]'s
+     *  foreign keys is inert here — Room's default `Room.databaseBuilder(...).build()` never enables
+     *  SQLite's `PRAGMA foreign_keys`, so it's never enforced and cascade never fires. Delete the
+     *  children explicitly (order doesn't matter for correctness with FKs unenforced, but children-
+     *  first is the safer habit if that ever changes) rather than rely on a constraint that isn't
+     *  actually active. */
+    suspend fun clearAll(): Int {
+        db.eventDao().deleteAll()
+        db.aiMessageDao().deleteAll()
+        return db.sessionDao().deleteAll()
+    }
 
     companion object {
         private const val TAG = "SessionRepository"

--- a/app/src/main/java/fr/bsodium/cron/session/db/AiMessageDao.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/db/AiMessageDao.kt
@@ -32,4 +32,7 @@ interface AiMessageDao {
 
     @Query("SELECT * FROM ai_messages WHERE sessionId = :sessionId ORDER BY id ASC")
     fun observeBySession(sessionId: String): Flow<List<AiMessageEntity>>
+
+    @Query("DELETE FROM ai_messages")
+    suspend fun deleteAll(): Int
 }

--- a/app/src/main/java/fr/bsodium/cron/session/db/EventDao.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/db/EventDao.kt
@@ -20,4 +20,7 @@ interface EventDao {
 
     @Query("SELECT * FROM session_events WHERE sessionId = :sessionId AND trigger = :trigger ORDER BY id DESC LIMIT 1")
     suspend fun findLatestByTrigger(sessionId: String, trigger: String): SessionEventEntity?
+
+    @Query("DELETE FROM session_events")
+    suspend fun deleteAll(): Int
 }

--- a/app/src/main/java/fr/bsodium/cron/session/model/Events.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/model/Events.kt
@@ -79,6 +79,9 @@ sealed class EventData {
         val changeType: String,
         val eventId: String,
         val affectsFirstEvent: Boolean,
+        /** Defaults to null so an already-persisted event missing this field still deserializes —
+         *  see [fr.bsodium.cron.calendar.CalendarChangeAnalyzer.Result.firstEventTitle]. */
+        val firstEventTitle: String? = null,
     ) : EventData()
 
     @Serializable

--- a/app/src/main/java/fr/bsodium/cron/ui/components/EdgeFades.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/components/EdgeFades.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import fr.bsodium.cron.ui.theme.CronColors
 import fr.bsodium.cron.ui.theme.Spacing
 
@@ -27,12 +28,17 @@ import fr.bsodium.cron.ui.theme.Spacing
  * [showTopScrim] is off for pages with a [PageAppBar]: the app bar already owns the
  * status-bar strip, and its scrolled `surfaceContainer` shade would otherwise show a
  * two-tone band under the `background`-tinted top scrim.
+ *
+ * [showNavPillClearance] is off for routes where the floating nav pill itself is hidden (settings
+ * sub-screens) — without this, every route reserved [Spacing.navBarClearance] worth of scrim
+ * regardless, needlessly dimming/obscuring a pill-less screen's own last few rows of content.
  */
 @Composable
-fun EdgeFades(modifier: Modifier = Modifier, showTopScrim: Boolean = true) {
+fun EdgeFades(modifier: Modifier = Modifier, showTopScrim: Boolean = true, showNavPillClearance: Boolean = true) {
     val background = CronColors.pageBackground
     val statusTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
     val navBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val pillClearance = if (showNavPillClearance) Spacing.navBarClearance else 0.dp
     Box(modifier = modifier.fillMaxSize()) {
         if (showTopScrim) {
             Box(
@@ -47,7 +53,7 @@ fun EdgeFades(modifier: Modifier = Modifier, showTopScrim: Boolean = true) {
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
-                .height(navBottom + Spacing.navBarClearance + Spacing.xxxl)
+                .height(navBottom + pillClearance + Spacing.xxxl)
                 .background(Brush.verticalGradient(listOf(Color.Transparent, background))),
         )
     }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiPlanMapper.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/AiPlanMapper.kt
@@ -28,7 +28,12 @@ sealed interface RunKind {
     data class Replan(val trigger: TriggerType?, val rearm: Boolean = false) : RunKind
 }
 
-/** The tab label for a run. Exhaustive over [RunKind] and [TriggerType]. */
+/** The tab label for a run. Exhaustive over [RunKind] and [TriggerType].
+ *
+ *  The [Replan][RunKind.Replan] cases describe the AI's *response*, not a restatement of the
+ *  triggering event — `TimelineMapper.kt`'s `eventLabel()` renders that event as its own sibling
+ *  timeline row, and the two used to share identical wording (e.g. both "You fell asleep"), which
+ *  read as an unexplained duplicate rather than an event and the plan that responded to it. */
 val RunKind.label: String
     get() = when (this) {
         RunKind.ScheduledBase -> "Planned"
@@ -36,15 +41,15 @@ val RunKind.label: String
         is RunKind.Replan -> when (trigger) {
             null -> "Re-planned"
             TriggerType.EveningPlan -> "Re-planned"
-            TriggerType.CalendarChange -> "Your schedule changed"
-            TriggerType.SleepOnset -> if (rearm) "You fell back asleep" else "You fell asleep"
-            TriggerType.HcStageUpdate -> "Sleep update"
-            TriggerType.MidSleepActivity -> "Movement detected"
-            TriggerType.OutOfBedConfirmed -> "You got up"
-            TriggerType.WakeWindowOpportunity -> "A good moment to wake"
-            TriggerType.AlarmDismissed -> "Alarm dismissed"
-            TriggerType.AlarmSnoozed -> "Alarm snoozed"
-            TriggerType.HardLatestFired -> "Safety alarm fired"
+            TriggerType.CalendarChange -> "Replanned for your schedule"
+            TriggerType.SleepOnset -> if (rearm) "Replanned after falling back asleep" else "Replanned for the night"
+            TriggerType.HcStageUpdate -> "Replanned from sleep data"
+            TriggerType.MidSleepActivity -> "Replanned after movement"
+            TriggerType.OutOfBedConfirmed -> "Replanned after waking"
+            TriggerType.WakeWindowOpportunity -> "Replanned for a better wake time"
+            TriggerType.AlarmDismissed -> "Replanned after dismissing"
+            TriggerType.AlarmSnoozed -> "Replanned after snoozing"
+            TriggerType.HardLatestFired -> "Replanned after the safety alarm"
         }
     }
 
@@ -121,7 +126,9 @@ object AiPlanMapper {
             return String.format(Locale.US, "%02d:%02d", local.hour, local.minute)
         }
 
-        // Built once per turn up front so a later iteration's previousAlarmTime lookup can read an earlier turn's already-computed thread instead of re-decoding it.
+        /** Built once per turn up front (not inline per-iteration) so a later iteration's
+         *  `previousAlarmTime` lookup can read an earlier turn's already-computed thread instead of
+         *  re-decoding it. */
         val orderedTurns = turns.toList()
         val threadsByTurn = orderedTurns.associateWith { threadOf(it) }
 
@@ -139,7 +146,9 @@ object AiPlanMapper {
                 (sourceEvent?.data as? EventData.EveningPlan)?.isManual == true -> RunKind.ManualBase
                 else -> RunKind.ScheduledBase
             }
-            // Skips any intervening turn that didn't resolve a time (e.g. do_nothing) so "before" is always the last turn that actually set one.
+            /** Skips over any intervening turn that didn't resolve a time (e.g. do_nothing), so the
+             *  "before" value is always the last turn that actually set one, not just the immediate
+             *  prior turn. */
             val previousAlarmTime = orderedTurns.take(index).asReversed()
                 .firstNotNullOfOrNull { threadsByTurn.getValue(it).newAlarmTime }
             AiIterationUi(

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
@@ -3,9 +3,11 @@
 package fr.bsodium.cron.ui.screens.home
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.overscroll
+import androidx.compose.foundation.rememberOverscrollEffect
+import androidx.compose.foundation.withoutVisualEffect
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,6 +23,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -32,17 +35,47 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
 import fr.bsodium.cron.session.model.TriggerType
 import fr.bsodium.cron.ui.screens.home.components.ALARM_BAR_HEIGHT
 import fr.bsodium.cron.ui.screens.home.components.CollapsibleAlarmCard
 import fr.bsodium.cron.ui.screens.home.components.HomeGreetingRow
 import fr.bsodium.cron.ui.screens.home.components.NotificationPermissionRow
+import fr.bsodium.cron.ui.screens.home.components.TimelineTrackOverlay
+import fr.bsodium.cron.ui.screens.home.components.rememberTimelineTrackRegistry
 import fr.bsodium.cron.ui.screens.home.components.sessionTimelineItems
 import fr.bsodium.cron.ui.theme.CronColors
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.Spacing
 
 private val ALARM_COLLAPSE_RANGE = 120.dp
+
+/** [StickyAlarm]'s fade overlay's opacity cap while the card is actively collapsing — content
+ *  scrolling underneath stays faintly visible so the collapse transition itself is watchable. */
+private const val MAX_FADE_OVERLAY_ALPHA = 0.5f
+
+/** The cap [StickyAlarm]'s overlay ramps toward once the card has fully settled into its collapsed
+ *  state — high enough to read as solidly occluding, but short of 1f so the `belowFadePx` tail's
+ *  transition into visible timeline content still stays gentle instead of an abrupt
+ *  opaque→transparent cliff (Round 25). */
+private const val MAX_FADE_OVERLAY_SETTLED_ALPHA = 0.85f
+
+/** True once [initialized] is true AND [cardFullHeightPx] has reported a real measured value — false
+ *  only for the mount/settle window, true forever after. Requires both because `HomeViewModel.uiState`
+ *  is `stateIn(..., SharingStarted.WhileSubscribed(5_000), HomeUiState())`: backgrounding Home (e.g.
+ *  behind Settings) for more than 5s cold-restarts the flow to its empty default, and
+ *  `CollapsibleAlarmCard`'s "no alarm" empty state reports its own nonzero height almost immediately —
+ *  gating on height alone would flip `settled` true on that transient wrong height before the real
+ *  data arrives. Suppresses every `animateItem` spec in [sessionTimelineItems] and
+ *  [TimelineTrackOverlay]'s `visible` param until both conditions hold, on every fresh mount (cold
+ *  start, or regaining composition after a Settings round trip) — a later, genuine height change once
+ *  already settled is real reflow and animates normally. */
+@Composable
+private fun rememberTimelineSettled(initialized: Boolean, cardFullHeightPx: Int): Boolean {
+    var settled by remember { mutableStateOf(false) }
+    if (!settled && initialized && cardFullHeightPx > 0) settled = true
+    return settled
+}
 
 @Composable
 internal fun HomePlanContent(
@@ -57,10 +90,13 @@ internal fun HomePlanContent(
     onNavigateToHistory: () -> Unit,
 ) {
     val listState = rememberLazyListState()
+    val sharedOverscrollEffect = rememberOverscrollEffect()
+    val trackRegistry = rememberTimelineTrackRegistry()
     val density = LocalDensity.current
     var cardFullHeightPx by remember { mutableIntStateOf(0) }
     var greetingHeightPx by remember { mutableIntStateOf(0) }
     val reservePx by remember { derivedStateOf { cardFullHeightPx } }
+    val timelineSettled = rememberTimelineSettled(uiState.initialized, cardFullHeightPx)
 
     val collapseSafeTopPx = with(density) { (statusInsetTop + Spacing.sm).roundToPx() }
     val collapseFadePx = with(density) { Spacing.xxl.toPx() }
@@ -76,13 +112,21 @@ internal fun HomePlanContent(
             val info = listState.layoutInfo
             val screenTop = info.visibleItemsInfo.firstOrNull { it.key == "alarm-spacer" }
                 ?.let { it.offset - info.viewportStartOffset }
+            // Keyed off the greeting row's position, not the alarm-spacer's, so occlusion engages as soon as scrolling starts rather than only once the card nears collapse.
+            val greetingTop = info.visibleItemsInfo.firstOrNull { it.key == "greeting" }
+                ?.let { it.offset - info.viewportStartOffset }
+            val gradientAlpha = if (greetingTop == null) {
+                1f
+            } else {
+                ((collapseSafeTopPx - greetingTop).coerceAtLeast(0).toFloat() / collapseFadePx).coerceIn(0f, 1f)
+            }
             if (screenTop == null) {
-                AlarmCollapse(top = collapseSafeTopPx, gradientAlpha = 1f, fraction = 1f, distancePx = collapseRangePx)
+                AlarmCollapse(top = collapseSafeTopPx, gradientAlpha = gradientAlpha, fraction = 1f, distancePx = collapseRangePx)
             } else {
                 val distance = (collapseSafeTopPx - screenTop).coerceAtLeast(0).toFloat()
                 AlarmCollapse(
                     top = maxOf(collapseSafeTopPx, screenTop),
-                    gradientAlpha = (distance / collapseFadePx).coerceIn(0f, 1f),
+                    gradientAlpha = gradientAlpha,
                     fraction = (distance / collapseRangePx).coerceIn(0f, 1f),
                     distancePx = distance,
                 )
@@ -91,13 +135,24 @@ internal fun HomePlanContent(
     }
     AlarmCollapseEffects(listState, collapseState, collapseRangePx, uiState.hapticsEnabled)
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    // One Modifier.overscroll here renders the stretch over both the track and the rows as one subtree; the LazyColumn's withoutVisualEffect() view only drives it (its node attaches once, here) — AndroidX OverscrollRenderedOnTopOfLazyListDecorations sample.
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .overscroll(sharedOverscrollEffect),
+    ) {
+        // One continuous painter behind the whole list; can't gap/re-cap while rows glide/fade since it reads each anchor's live position rather than being sliced per row.
+        TimelineTrackOverlay(
+            registry = trackRegistry,
+            visible = timelineSettled,
+        )
         LazyColumn(
             state = listState,
+            overscrollEffect = sharedOverscrollEffect?.withoutVisualEffect(),
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(
-                // Wider than `end` so the greeting text, day headers, and timeline icons all align to the greeting name's left inset — the single source of truth for that alignment.
-                start = Spacing.xl,
+                // Matches StickyAlarm's own horizontal inset so the greeting, day headers, and timeline icons line up with the alarm card's left edge.
+                start = Spacing.md,
                 end = Spacing.md,
                 top = statusInsetTop + Spacing.md,
                 bottom = navInsetBottom + Spacing.navBarClearance + Spacing.xxxl,
@@ -121,6 +176,9 @@ internal fun HomePlanContent(
             sessionTimelineItems(
                 timeline = uiState.timeline,
                 hasMore = uiState.hasMoreHistory,
+                registry = trackRegistry,
+                newlyArrivedIds = uiState.newlyArrivedIds,
+                suppressEntranceAnimation = !timelineSettled,
                 onOpenAiRun = onOpenAiRun,
                 onNavigateToHistory = onNavigateToHistory,
             )
@@ -157,7 +215,9 @@ private fun BoxScope.StickyAlarm(
     card: @Composable (collapseFraction: () -> Float) -> Unit,
 ) {
     val density = LocalDensity.current
-    val background = CronColors.pageBackground
+    // Capped, not fully opaque, so scrolled-up content stays faintly visible through the fade rather than vanishing abruptly; ramps toward MAX_FADE_OVERLAY_SETTLED_ALPHA once the card stops actively collapsing so the belowFadePx tail's transition stays gentle, in both themes alike.
+    val overlayAlphaCap = lerp(MAX_FADE_OVERLAY_ALPHA, MAX_FADE_OVERLAY_SETTLED_ALPHA, collapse.value.fraction)
+    val background = CronColors.pageBackground.copy(alpha = overlayAlphaCap)
     var visiblePx by remember { mutableIntStateOf(0) }
     val cardBottomPx = safeTopPx + visiblePx
     val belowFadePx = with(density) { Spacing.xxxl.toPx() }
@@ -180,7 +240,7 @@ private fun BoxScope.StickyAlarm(
         modifier = Modifier
             .fillMaxWidth()
             .graphicsLayer { translationY = collapse.value.top.toFloat() }
-            .onSizeChanged { if (it.height != visiblePx) visiblePx = it.height },
+            .onSizeChanged { visiblePx = it.height },
     ) {
         Box(Modifier.padding(horizontal = Spacing.md)) { card { collapse.value.fraction } }
     }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeUiState.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeUiState.kt
@@ -1,0 +1,46 @@
+package fr.bsodium.cron.ui.screens.home
+
+import fr.bsodium.cron.session.model.SleepSegment
+import kotlinx.datetime.LocalTime
+
+data class HomeUiState(
+    val sessionDisplay: SessionDisplayState? = null,
+    val greetingPrefix: String = "Welcome",
+    val greetingName: String? = null,
+    val dateLabel: String = "",
+
+    val aiPlan: AiPlanUi? = null,
+    val timeline: List<TimelineItem> = emptyList(),
+    /** [TimelineItem.id]s that are genuinely new since the last emission of this flow's lifetime —
+     *  the entrance-animation gate (Round 32). Empty on the very first emission (cold start) and on
+     *  any emission that's identical to the previous one (e.g. a Home→Settings→back round trip with
+     *  no underlying data change) — see [diffNewlyArrivedIds]. */
+    val newlyArrivedIds: Set<String> = emptySet(),
+    val hasMoreHistory: Boolean = false,
+    val isRetrying: Boolean = false,
+    /** False until the backing flows have produced their first value — gates the onboarding so it
+     *  doesn't flash over an existing plan during the cold-start load. */
+    val initialized: Boolean = false,
+    /** A plan-affecting setting changed since the last plan was written — offers a re-run. */
+    val settingsChangedSincePlan: Boolean = false,
+    /** The latest AI turn failed (and hasn't been dismissed) — surfaces a dismissible banner. */
+    val aiFailure: AiTurnFailure? = null,
+    /** User preference: fire subtle haptic ticks while the assistant streams. */
+    val hapticsEnabled: Boolean = true,
+    /** User preference: auto-plan and arm alarms each night. Off cancels everything armed. */
+    val autoAlarmsEnabled: Boolean = true,
+    /** The local time the nightly planning run fires — drives the resting screen's "next plan at …" line. */
+    val eveningTriggerTime: LocalTime = LocalTime(20, 0),
+)
+
+/** Why the most recent AI turn ended without updating the plan, for the home failure banner. */
+sealed interface AiTurnFailure {
+    data class BudgetExhausted(val used: Int, val limit: Int) : AiTurnFailure
+    data object MissingApiKey : AiTurnFailure
+    data class Generic(val reason: String?) : AiTurnFailure
+}
+
+data class SleepStatsUi(
+    val durationLabel: String,
+    val segments: List<SleepSegment>,
+)

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeViewModel.kt
@@ -22,7 +22,6 @@ import fr.bsodium.cron.session.model.SessionStatus
 import fr.bsodium.cron.session.model.EventData
 import fr.bsodium.cron.session.model.Instruction
 import fr.bsodium.cron.session.model.SessionEvent
-import fr.bsodium.cron.session.model.SleepSegment
 import fr.bsodium.cron.session.model.TriggerType
 import fr.bsodium.cron.settings.SettingsRepository
 import fr.bsodium.cron.worker.AiTurnWorker
@@ -47,42 +46,19 @@ import kotlinx.datetime.atTime
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 
-data class HomeUiState(
-    val sessionDisplay: SessionDisplayState? = null,
-    val greetingPrefix: String = "Welcome",
-    val greetingName: String? = null,
-    val dateLabel: String = "",
+/** `timelineFlow`'s emitted value (Round 32) — the display-bound [capped] timeline plus which ids in
+ *  it are genuinely new since the previous emission. A local pairing, not a field on [CappedTimeline]
+ *  itself, which stays purely about truncation and is used standalone elsewhere. */
+private data class TimelineFlowResult(val capped: CappedTimeline, val newlyArrivedIds: Set<String>)
 
-    val aiPlan: AiPlanUi? = null,
-    val timeline: List<TimelineItem> = emptyList(),
-    val hasMoreHistory: Boolean = false,
-    val isRetrying: Boolean = false,
-    /** False until the backing flows have produced their first value — gates the onboarding so it
-     *  doesn't flash over an existing plan during the cold-start load. */
-    val initialized: Boolean = false,
-    /** A plan-affecting setting changed since the last plan was written — offers a re-run. */
-    val settingsChangedSincePlan: Boolean = false,
-    /** The latest AI turn failed (and hasn't been dismissed) — surfaces a dismissible banner. */
-    val aiFailure: AiTurnFailure? = null,
-    /** User preference: fire subtle haptic ticks while the assistant streams. */
-    val hapticsEnabled: Boolean = true,
-    /** User preference: auto-plan and arm alarms each night. Off cancels everything armed. */
-    val autoAlarmsEnabled: Boolean = true,
-    /** The local time the nightly planning run fires — drives the resting screen's "next plan at …" line. */
-    val eveningTriggerTime: LocalTime = LocalTime(20, 0),
-)
-
-/** Why the most recent AI turn ended without updating the plan, for the home failure banner. */
-sealed interface AiTurnFailure {
-    data class BudgetExhausted(val used: Int, val limit: Int) : AiTurnFailure
-    data object MissingApiKey : AiTurnFailure
-    data class Generic(val reason: String?) : AiTurnFailure
+/** Stateful wrapper around [diffNewlyArrivedIds] — the one piece of mutable bookkeeping the diff
+ *  itself doesn't need to carry. Held as a [HomeViewModel] field specifically because it must survive
+ *  Home's own composition being torn down and rebuilt (see the field's own KDoc at its declaration). */
+private class NewlyArrivedIdTracker {
+    private var previousIds: Set<String>? = null
+    fun diff(currentIds: Set<String>): Set<String> =
+        diffNewlyArrivedIds(currentIds, previousIds).also { previousIds = currentIds }
 }
-
-data class SleepStatsUi(
-    val durationLabel: String,
-    val segments: List<SleepSegment>,
-)
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class HomeViewModel(application: Application) : AndroidViewModel(application) {
@@ -169,6 +145,13 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         )
     }
 
+    /** Diffs each [timelineFlow] emission's ids against the previous one to find genuinely new
+     *  arrivals. Held here, a plain ViewModel field, so it survives Home's own composition being torn
+     *  down and rebuilt (e.g. a Home→Settings→back round trip disposes `HomePlanContent`'s
+     *  remember-scoped state, but never this ViewModel — see `MainActivity.kt`'s
+     *  `popUpTo(ROUTE_HOME) { inclusive = false }`). */
+    private val newlyArrivedIdTracker = NewlyArrivedIdTracker()
+
     private val timelineFlow = combine(
         sessionFlow.map { it?.id }.distinctUntilChanged(),
         aiPlanFlow,
@@ -176,19 +159,46 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         StreamingTurnStore.active,
         _historicalSessions,
     ) { sessionId, plan, events, streaming, history ->
+        val dedupedHistory = if (sessionId != null && plan != null) {
+            history.filter { it.sessionId != sessionId }
+        } else {
+            history
+        }
+        /** A fresh session's own turn 0 never has an intra-session previous time to compare
+         *  against, so carry over the most recent older session's own last resolved alarm time —
+         *  `dedupedHistory` is guaranteed most-recent-session-first (`SessionDao.findPaginated`
+         *  orders by `createdAt DESC`), so the first match is the right one. */
+        val carryOverPrev: LocalTime? = dedupedHistory.firstNotNullOfOrNull { session ->
+            session.iterations.lastOrNull { it.thread.newAlarmTime != null }?.thread?.newAlarmTime
+        }
         val currentSession = if (sessionId != null && plan != null) {
+            val patchedIterations = if (carryOverPrev != null && plan.iterations.isNotEmpty()) {
+                val first = plan.iterations.first()
+                if (first.previousAlarmTime == null) {
+                    listOf(first.copy(previousAlarmTime = carryOverPrev)) + plan.iterations.drop(1)
+                } else {
+                    plan.iterations
+                }
+            } else {
+                plan.iterations
+            }
             TimelineSession(
                 sessionId = sessionId,
-                iterations = plan.iterations,
+                iterations = patchedIterations,
                 events = events,
                 streamingTurnIndex = streaming?.takeIf { it.sessionId == sessionId }?.turnIndex,
             )
-        } else null
-        val dedupedHistory = if (currentSession != null) {
-            history.filter { it.sessionId != currentSession.sessionId }
-        } else history
+        } else {
+            null
+        }
         val allSessions = listOfNotNull(currentSession) + dedupedHistory
-        capTimeline(buildTimeline(allSessions))
+        val rawItems = buildTimeline(allSessions)
+        /** Diffed on the uncapped id set, before `capTimeline` truncates: a genuinely new item is
+         *  always sorted near the front and effectively never truncated away, and comparing against
+         *  the previous *uncapped* set means an old item that scrolls back into the cap window
+         *  purely because the cap boundary shifted is correctly not misreported as new. */
+        val newlyArrived = newlyArrivedIdTracker.diff(rawItems.mapTo(mutableSetOf()) { it.id })
+        TimelineFlowResult(capped = capTimeline(rawItems), newlyArrivedIds = newlyArrived)
     }.flowOn(Dispatchers.Default)
 
     private val statusFlow = combine(
@@ -229,8 +239,9 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             dateLabel = formatDateLabel(display.session, status.autoAlarmsEnabled),
 
             aiPlan = plan,
-            timeline = timeline.items,
-            hasMoreHistory = timeline.truncated || moreHistoryAvailable,
+            timeline = timeline.capped.items,
+            newlyArrivedIds = timeline.newlyArrivedIds,
+            hasMoreHistory = timeline.capped.truncated || moreHistoryAvailable,
             isRetrying = status.isRetrying,
             initialized = true,
             settingsChangedSincePlan = status.settingsChanged && plan != null,

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/PlanDetailScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/PlanDetailScreen.kt
@@ -3,7 +3,10 @@ package fr.bsodium.cron.ui.screens.home
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -70,6 +73,12 @@ fun PlanDetailScreen(
                 hapticsEnabled = hapticsEnabled,
             )
 
+            /** Read explicitly rather than guessing a flat bottom padding — a 3-button nav bar and a
+             *  gesture nav bar differ enough in height that a single guessed constant cleared one but
+             *  not the other, leaving the assistant shape uncleared once the thinking timeline is
+             *  expanded and scrolled to the bottom. Layered on top of Scaffold's own `innerPadding`,
+             *  which only reserves top/side safe-drawing insets. */
+            val navBarBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
             Column(
                 modifier = Modifier
                     .fillMaxSize()
@@ -77,7 +86,7 @@ fun PlanDetailScreen(
                     .nestedScroll(pullConnection)
                     .verticalScroll(scrollState)
                     .padding(horizontal = Spacing.xl)
-                    .padding(bottom = Spacing.xxxl),
+                    .padding(bottom = navBarBottom + Spacing.xxxxl),
             ) {
                 AiThinkingThread(
                     thread = iteration.thread,

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/TimelineMapper.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/TimelineMapper.kt
@@ -3,16 +3,12 @@ package fr.bsodium.cron.ui.screens.home
 import fr.bsodium.cron.session.model.EventData
 import fr.bsodium.cron.session.model.SessionEvent
 import fr.bsodium.cron.session.model.TriggerType
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
-import kotlinx.datetime.toJavaLocalDate
 import kotlinx.datetime.toLocalDateTime
-import java.time.LocalDate as JavaLocalDate
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
-import java.util.Locale
 
 /** One item in the vertical timeline. Ordered reverse-chronologically (latest first). */
 sealed interface TimelineItem {
@@ -34,16 +30,23 @@ sealed interface TimelineItem {
         val trigger: TriggerType,
         val label: String,
         val detail: String?,
+        /** The substring of [detail] to render bold — the key fact in a subtext line, e.g.
+         *  "9 extra minutes" in "You get to sleep for 9 extra minutes" — so `EventNode.kt` can
+         *  highlight it without a markup language. Always non-null exactly when [detail] is. */
+        val detailEmphasis: String? = null,
     ) : TimelineItem {
         override val id = "event-${trigger.name}-${timestamp.toEpochMilliseconds()}"
     }
 
-    /** A day boundary marker, inserted wherever consecutive items' local dates differ. */
+    /** A day-boundary marker, inserted wherever consecutive items' local dates differ. Purely a
+     *  decorative sticky row (`sessionTimelineItems` renders it via `stickyHeader`, never a track
+     *  anchor) — it must stay invisible to segment/cap/asleep-state logic (see [timelineAsleepStates]
+     *  and `SessionTimeline.kt`'s segment-boundary derivation), which is what a day boundary being a
+     *  *structural* break used to get wrong (Round 18): a sleep session spanning midnight had its
+     *  asleep state reset and its track split into two capped segments exactly at the boundary. */
     data class DayHeader(
         val date: LocalDate,
         override val timestamp: Instant,
-        val weekdayLabel: String,
-        val dateLabel: String,
     ) : TimelineItem {
         override val id = "day-$date"
     }
@@ -89,9 +92,20 @@ fun capTimeline(items: List<TimelineItem>, cap: Int = TIMELINE_ITEM_CAP): Capped
     return CappedTimeline(items = result, truncated = totalContent > cap)
 }
 
+/** Diffs [currentIds] against [previousIds] to find ids genuinely new since the last check —
+ *  the basis for the timeline's entrance-animation gating (Round 32). [previousIds] is `null`
+ *  exactly once, the very first check of the caller's lifetime (true cold start), and that call
+ *  always returns [emptySet]: there's no reference point yet, and the first load must render fully
+ *  static, never an animated reveal. This is deliberately a pure function, not `remember`-scoped
+ *  Compose state — a `remember` resets every time the timeline's composition is torn down and
+ *  rebuilt (e.g. a Home→Settings→back round trip), which is exactly the class of bug this replaces
+ *  (see `HomeViewModel.NewlyArrivedIdTracker`, which holds the actual `previousIds` across calls at
+ *  the ViewModel layer, which survives that navigation). */
+fun diffNewlyArrivedIds(currentIds: Set<String>, previousIds: Set<String>?): Set<String> =
+    if (previousIds == null) emptySet() else currentIds - previousIds
+
 fun buildTimeline(sessions: List<TimelineSession>): List<TimelineItem> {
     val items = mutableListOf<TimelineItem>()
-    val tz = TimeZone.currentSystemDefault()
 
     for (session in sessions) {
         val aiTurnTimestamps = session.iterations.mapNotNull { it.ranAtEpochMs }.toSet()
@@ -110,11 +124,13 @@ fun buildTimeline(sessions: List<TimelineSession>): List<TimelineItem> {
         for (event in session.events) {
             if (event.trigger !in SHOWN_TRIGGERS) continue
             if (event.trigger == TriggerType.EveningPlan) continue
+            val detail = eventDetail(event.trigger, event.data)
             items += TimelineItem.Event(
                 timestamp = event.timestamp,
                 trigger = event.trigger,
                 label = eventLabel(event.trigger),
-                detail = eventDetail(event.trigger, event.data),
+                detail = detail?.text,
+                detailEmphasis = detail?.emphasis,
             )
         }
     }
@@ -131,18 +147,27 @@ fun buildTimeline(sessions: List<TimelineSession>): List<TimelineItem> {
         }
     }
 
-    // Defensive: a data-layer race can occasionally surface the same event twice; the LazyColumn key must be unique regardless, so collapse duplicates here rather than crash the UI.
-    return insertDayHeaders(withLatest, tz).distinctBy { it.id }
+    // Defensive: a data-layer race can occasionally surface the same underlying event twice; the LazyColumn key must be unique regardless, so collapse duplicates here rather than let a rare data race crash the UI.
+    return insertDayHeaders(withLatest).distinctBy { it.id }
 }
 
-/** Threads a [TimelineItem.DayHeader] in front of the first item of each local day. */
-private fun insertDayHeaders(items: List<TimelineItem>, tz: TimeZone): List<TimelineItem> {
+/** Threads a [TimelineItem.DayHeader] in front of the first item of each local day — except today's:
+ *  the user already knows it's today, so that header would be pure redundancy (Round 27). Purely a
+ *  sticky decoration in the rendered list otherwise (see [TimelineItem.DayHeader]'s KDoc) — inserting
+ *  it here doesn't by itself affect segment/cap/asleep-state logic, which all explicitly skip past
+ *  `DayHeader`s. [lastDate] still tracks today's date even though no header gets emitted for it, so
+ *  the boundary into the *next* (non-today) date is still detected and gets its own header. */
+private fun insertDayHeaders(items: List<TimelineItem>): List<TimelineItem> {
+    val tz = TimeZone.currentSystemDefault()
+    val today = Clock.System.now().toLocalDateTime(tz).date
     var lastDate: LocalDate? = null
     return buildList {
         for (item in items) {
             val date = item.timestamp.toLocalDateTime(tz).date
             if (date != lastDate) {
-                add(dayHeader(date, tz))
+                if (date != today) {
+                    add(TimelineItem.DayHeader(date = date, timestamp = date.atStartOfDayIn(tz)))
+                }
                 lastDate = date
             }
             add(item)
@@ -150,26 +175,27 @@ private fun insertDayHeaders(items: List<TimelineItem>, tz: TimeZone): List<Time
     }
 }
 
-private fun dayHeader(date: LocalDate, tz: TimeZone): TimelineItem.DayHeader {
-    val today = JavaLocalDate.now()
-    val javaDate = date.toJavaLocalDate()
-    val relativeLabel = when (ChronoUnit.DAYS.between(javaDate, today)) {
-        0L -> "Today"
-        1L -> "Yesterday"
-        // locale-default weekday name is intentional here (human-language); any other day gap (unbounded)
-        else -> javaDate.format(DateTimeFormatter.ofPattern("EEEE", Locale.getDefault()))
+/** For each item in [items] (reverse-chronological, latest first), whether the user was asleep
+ *  immediately after that item, moving forward in time (toward index 0). Derived purely from the
+ *  already-shown SleepOnset/OutOfBedConfirmed rows — no raw session-event access needed. A
+ *  [TimelineItem.DayHeader] is a no-op here (Round 18 fix, kept): it must never reset the flag, since
+ *  most sleep sessions span midnight. */
+fun timelineAsleepStates(items: List<TimelineItem>): List<Boolean> {
+    val result = MutableList(items.size) { false }
+    var asleep = false
+    for (i in items.indices.reversed()) {
+        when (val item = items[i]) {
+            is TimelineItem.Event -> when (item.trigger) {
+                TriggerType.SleepOnset -> asleep = true
+                TriggerType.OutOfBedConfirmed -> asleep = false
+                else -> {} // every other trigger leaves the asleep/awake state unchanged
+            }
+            is TimelineItem.AiRun -> {}
+            is TimelineItem.DayHeader -> {}
+        }
+        result[i] = asleep
     }
-    // locale-default uppercasing of a human-language label, purely for the header's display styling
-    val weekdayLabel = relativeLabel.uppercase(Locale.getDefault())
-    // locale-default month abbreviation is intentional here (human-language)
-    val dateLabel = javaDate.format(DateTimeFormatter.ofPattern("d MMM", Locale.getDefault()))
-        .uppercase(Locale.getDefault())
-    return TimelineItem.DayHeader(
-        date = date,
-        timestamp = date.atStartOfDayIn(tz),
-        weekdayLabel = weekdayLabel,
-        dateLabel = dateLabel,
-    )
+    return result
 }
 
 private fun eventLabel(trigger: TriggerType): String = when (trigger) {
@@ -185,10 +211,28 @@ private fun eventLabel(trigger: TriggerType): String = when (trigger) {
     TriggerType.MidSleepActivity -> "Movement detected"
 }
 
-private fun eventDetail(trigger: TriggerType, data: EventData): String? = when {
+/** [text] is a full subtext sentence for [TimelineItem.Event.detail]; [emphasis] is the substring of
+ *  it that should render bold — e.g. "You get to sleep for 9 extra minutes" / "9 extra minutes" for a
+ *  snooze (Round 28 — this replaced a separate detail chip, which had no room to say more than the
+ *  bare fact, with a subtext line that can say what happened *and* highlight the fact that matters). */
+private data class EventDetail(val text: String, val emphasis: String)
+
+private fun eventDetail(trigger: TriggerType, data: EventData): EventDetail? = when {
+    // Deterministic, not AI-generated — snoozeDurationMinutes phrased as the upside to the user rather than a bare "N minutes added".
     trigger == TriggerType.AlarmSnoozed && data is EventData.AlarmInteraction ->
-        data.snoozeDurationMinutes?.let { "${it} min" }
-    trigger == TriggerType.CalendarChange && data is EventData.CalendarChange ->
-        data.changeType.replaceFirstChar { it.uppercase(Locale.ROOT) }
+        data.snoozeDurationMinutes?.let { minutes ->
+            val amount = if (minutes == 1) "1 extra minute" else "$minutes extra minutes"
+            EventDetail(text = "You get to sleep for $amount", emphasis = amount)
+        }
+    // `firstEventTitle` is real calendar data, used directly whenever present; `changeType` is a raw backend identifier, not human-readable text, so it's never interpolated into the subtext.
+    trigger == TriggerType.CalendarChange && data is EventData.CalendarChange -> {
+        val title = data.firstEventTitle
+        if (data.affectsFirstEvent && title != null) {
+            EventDetail(text = "$title on your calendar changed", emphasis = title)
+        } else {
+            val subject = if (data.affectsFirstEvent) "first event" else "calendar"
+            EventDetail(text = "Your $subject changed", emphasis = subject)
+        }
+    }
     else -> null
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiRunHeroGalleryPreviews.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/AiRunHeroGalleryPreviews.kt
@@ -1,0 +1,165 @@
+package fr.bsodium.cron.ui.screens.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import fr.bsodium.cron.session.model.TriggerType
+import fr.bsodium.cron.ui.screens.home.AiIterationUi
+import fr.bsodium.cron.ui.screens.home.AiThreadUi
+import fr.bsodium.cron.ui.screens.home.RunKind
+import fr.bsodium.cron.ui.screens.home.TimelineItem
+import fr.bsodium.cron.ui.theme.CronColors
+import fr.bsodium.cron.ui.theme.CronTheme
+import fr.bsodium.cron.ui.theme.Spacing
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalTime
+
+/** Every hero-slot state `AiRunNode`'s title `when` (SessionTimeline.kt) can actually produce, plus
+ *  the demoted (non-latest) row shape, gathered in one gallery so a headline-logic change — the
+ *  streaming NO_ALARM_LABEL flash, the PREV›NEW / NEW-only / PREV-only(standing) / neither branches,
+ *  the mocked "Test plan" label — can be screened across all of them at once. */
+@PreviewLightDark
+@Composable
+internal fun AiRunHeroGalleryPreview() {
+    CronTheme {
+        val registry = rememberTimelineTrackRegistry()
+        Box(modifier = Modifier.fillMaxSize().background(CronColors.pageBackground)) {
+            TimelineTrackOverlay(registry = registry)
+            Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                GallerySectionLabel("Latest hero states")
+                AiRunNode(
+                    item = latestRun("prev-new", newAlarmTime = LocalTime(7, 15), previousAlarmTime = LocalTime(7, 45)),
+                    registry = registry,
+                    isSegmentTop = true,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    onClick = {},
+                )
+                AiRunNode(
+                    item = latestRun("new-only", newAlarmTime = LocalTime(6, 40), previousAlarmTime = null, kind = RunKind.ScheduledBase),
+                    registry = registry,
+                    isSegmentTop = false,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    onClick = {},
+                )
+                AiRunNode(
+                    // A cancel/do_nothing turn: no new time, but a prior one stands — never re-shown as a redundant "PREV › PREV" pair, just the standing time alone.
+                    item = latestRun("prev-only-standing", newAlarmTime = null, previousAlarmTime = LocalTime(7, 45)),
+                    registry = registry,
+                    isSegmentTop = false,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    onClick = {},
+                )
+                AiRunNode(
+                    // The rare settled first-run do-nothing: nothing ever resolved — the one case that legitimately shows the static NO_ALARM_LABEL literal.
+                    item = latestRun("no-alarm-settled", newAlarmTime = null, previousAlarmTime = null, kind = RunKind.ManualBase),
+                    registry = registry,
+                    isSegmentTop = false,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    onClick = {},
+                )
+                AiRunNode(
+                    // Streaming with nothing resolved yet: must show a blank placeholder, not a flash of NO_ALARM_LABEL that then gets replaced once the real value streams in.
+                    item = latestRun(
+                        "streaming",
+                        newAlarmTime = null,
+                        previousAlarmTime = null,
+                        kind = RunKind.Replan(TriggerType.AlarmSnoozed),
+                        isStreaming = true,
+                    ),
+                    registry = registry,
+                    isSegmentTop = false,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    onClick = {},
+                )
+                AiRunNode(
+                    item = latestRun("mocked", newAlarmTime = LocalTime(7, 0), previousAlarmTime = null, isMocked = true),
+                    registry = registry,
+                    isSegmentTop = false,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    onClick = {},
+                )
+                GallerySectionLabel("Demoted (non-latest) rows")
+                AiRunNode(
+                    item = demotedRun("demoted-interior", kind = RunKind.Replan(TriggerType.CalendarChange)),
+                    registry = registry,
+                    isSegmentTop = false,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    onClick = {},
+                )
+                AiRunNode(
+                    item = demotedRun("demoted-cap", kind = RunKind.ScheduledBase),
+                    registry = registry,
+                    isSegmentTop = false,
+                    isSegmentBottom = true,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    onClick = {},
+                )
+            }
+        }
+    }
+}
+
+private fun latestRun(
+    id: String,
+    newAlarmTime: LocalTime?,
+    previousAlarmTime: LocalTime?,
+    kind: RunKind = RunKind.Replan(TriggerType.CalendarChange),
+    isStreaming: Boolean = false,
+    isMocked: Boolean = false,
+) = TimelineItem.AiRun(
+    timestamp = Instant.fromEpochMilliseconds(0L),
+    iteration = AiIterationUi(
+        turnIndex = 0,
+        timeLabel = "23:14",
+        kind = kind,
+        thread = AiThreadUi(
+            turnIndex = 0,
+            summary = if (isStreaming) "Thinking..." else "Thought for 8s",
+            process = emptyList(),
+            response = "Moved alarm to reflect your updated schedule.",
+            newAlarmTime = newAlarmTime,
+            isStreaming = isStreaming,
+            isMocked = isMocked,
+        ),
+        previousAlarmTime = previousAlarmTime,
+        // A relative-time timestamp, not epoch 0 — the latest row's kicker suffix always renders "Xm/Xd ago" with no recency threshold, so a literal 1970 epoch would read as an absurd "20641d ago" instead of "just now".
+        ranAtEpochMs = System.currentTimeMillis(),
+    ),
+    sessionId = id,
+    isStreaming = isStreaming,
+    isLatest = true,
+)
+
+private fun demotedRun(id: String, kind: RunKind) = TimelineItem.AiRun(
+    timestamp = Instant.fromEpochMilliseconds(0L),
+    iteration = AiIterationUi(
+        turnIndex = 0,
+        timeLabel = "21:30",
+        kind = kind,
+        thread = AiThreadUi(turnIndex = 0, summary = "Thought for 5s", process = emptyList(), response = null),
+        ranAtEpochMs = 0L,
+    ),
+    sessionId = id,
+    isStreaming = false,
+    isLatest = false,
+)

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/DayHeader.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/DayHeader.kt
@@ -1,70 +1,188 @@
+@file:OptIn(androidx.compose.ui.text.ExperimentalTextApi::class)
+
 package fr.bsodium.cron.ui.screens.home.components
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.WavyProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontVariation
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import fr.bsodium.cron.R
 import fr.bsodium.cron.ui.screens.home.TimelineItem
+import fr.bsodium.cron.ui.theme.CronColors
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.CronTypography
 import fr.bsodium.cron.ui.theme.Spacing
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.toJavaLocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.Locale
 
-/** Day-boundary heading between timeline sections — an oversized wide word ("TODAY") outdented past
- *  the node gutter, paired with a small mono date figure, so it reads as its own display beat rather
- *  than another row in the gutter-aligned list below it. */
+/** `wght`/`wdth` for [DayHeaderLabel]'s big day-of-month digit — Roboto Flex is a genuine variable
+ *  font (the same file [fr.bsodium.cron.ui.theme.CountdownFontFamily] already draws on), pinned to a
+ *  bold, clearly-condensed-but-not-crushed pair. Every header renders at this one fixed pair — no
+ *  active/inactive distinction to interpolate between. */
+private const val NUMBER_WEIGHT = 900
+private const val NUMBER_WIDTH = 42f
+
+/** Vertical squash applied to the big day-of-month digit (Round 26 — "flatten it vertically") via
+ *  `graphicsLayer`, the same paint-time-only scale technique `CollapsibleAlarmCard`'s clock digits
+ *  already use elsewhere in this app. Purely visual — [CronTypography.timelineDayNumber]'s own
+ *  `lineHeight` is separately tightened so the row's layout height keeps pace with the now
+ *  shorter-*looking* glyph instead of leaving dead space beneath it. */
+private const val NUMBER_VERTICAL_SQUASH = 0.8f
+
+/** Height of the wavy divider's own container — enough room for its amplitude to read as a visible
+ *  wiggle without ballooning into a thick decorative band. */
+private val DIVIDER_HEIGHT = 6.dp
+
+/** Distance between wave peaks for the divider below — shorter than
+ *  [WavyProgressIndicatorDefaults.LinearDeterminateWavelength] (40dp, tuned for a full-width progress
+ *  bar) so a few full waves still read across this narrower, block-width divider. */
+private val DIVIDER_WAVELENGTH = 20.dp
+
+private val numberFontFamily: FontFamily = FontFamily(
+    Font(
+        R.font.roboto_flex,
+        variationSettings = FontVariation.Settings(
+            FontVariation.weight(NUMBER_WEIGHT),
+            FontVariation.Setting("wdth", NUMBER_WIDTH),
+        ),
+    ),
+)
+
+/** The day-boundary label itself — a calendar-tear-off pairing: a colossal bold day-of-month digit,
+ *  vertically flattened, with the full month name and a relative-day label sharing the line
+ *  underneath it — month right-aligned under the number, the relative label opposite it on the far
+ *  left — closed off by a thin wavy divider matching the block's own width, "an underline under the
+ *  month text," not a full-width rule (that would read as splitting the timeline itself;
+ *  [DayHeaderRow] confines this whole block to the gutter's right). Every header renders identically,
+ *  no per-frame scroll tracking. */
+@Composable
+internal fun DayHeaderLabel(date: LocalDate, modifier: Modifier = Modifier) {
+    val density = LocalDensity.current
+    Column(modifier = modifier) {
+        Text(
+            text = dayOfMonthLabel(date),
+            style = CronTypography.timelineDayNumber.copy(fontFamily = numberFontFamily),
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier
+                .align(Alignment.End)
+                // Bottom-anchored (not center) so the squash doesn't leave symmetric dead space above and below the glyph; CronTypography.timelineDayNumber's tightened lineHeight controls the remaining gap below.
+                .graphicsLayer { scaleY = NUMBER_VERTICAL_SQUASH; transformOrigin = TransformOrigin(0.5f, 1f) },
+        )
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = relativeDayLabel(date),
+                style = CronTypography.timelineDayActiveLabel,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = monthLabel(date),
+                style = CronTypography.timelineDayMonth,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        // A real Material 3 Expressive component, not a hand-rolled wave (see docs/color-roles.md) — pinned at progress=1 draws one continuous wavy line across its own width; amplitude is forced constant (the default fades near 100% progress) and waveSpeed=0 keeps it static, avoiding a second perpetually-running animation.
+        LinearWavyProgressIndicator(
+            progress = { 1f },
+            modifier = Modifier
+                .padding(top = Spacing.xs)
+                .fillMaxWidth()
+                .height(DIVIDER_HEIGHT),
+            color = MaterialTheme.colorScheme.outlineVariant,
+            trackColor = MaterialTheme.colorScheme.outlineVariant,
+            stroke = Stroke(width = with(density) { 1.dp.toPx() }, cap = StrokeCap.Round),
+            stopSize = 0.dp,
+            amplitude = { 1f },
+            wavelength = DIVIDER_WAVELENGTH,
+            waveSpeed = 0.dp,
+        )
+    }
+}
+
+/** Day-boundary heading, rendered as a plain in-flow `sessionTimelineItems` row — no anchor of its
+ *  own (unlike an `Event`/`AiRun` row), no special pin behavior, no backdrop. Reserves [NODE_GUTTER]
+ *  on the left — without it, [DayHeaderLabel]'s divider/content could extend far enough left to
+ *  visually overlap the timeline track itself, since this row otherwise has nothing else forcing
+ *  that reservation the way every anchor row's own gutter `Box` does — so the whole label block,
+ *  divider included, stays confined to the content area right of the track. Every header renders
+ *  identically, with no live "which section am I in" tracking — an earlier pinned-overlay/active-day
+ *  design was dropped after live testing found it glitchy and a genuine on-device performance cost,
+ *  with no cheaper way to keep the same tracking. */
 @Composable
 internal fun DayHeaderRow(item: TimelineItem.DayHeader, modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(top = Spacing.xxl, bottom = Spacing.sm),
-        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+            // end = Spacing.md matches TimelineNode's own row inset — without it, the right-aligned number/month would sit closer to the screen edge than every anchor row's own trailing time label.
+            .padding(top = Spacing.xs, bottom = Spacing.sm, end = Spacing.md),
     ) {
-        // alignByBaseline, not verticalAlignment = Bottom — the two faces have different descender depths, so box-bottom alignment leaves their baselines visibly offset.
-        Text(
-            text = item.weekdayLabel,
-            style = CronTypography.timelineDayHeader,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.alignByBaseline(),
-        )
-        Text(
-            text = item.dateLabel,
-            style = CronTypography.labelMonoSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.alignByBaseline(),
-        )
+        // NODE_GUTTER alone would start the label flush with the gutter's own right edge; clearing titleSpacer (Spacing.md, TimelineNode.kt) past that lines this label's text up with the rest of the timeline's text indent.
+        Spacer(Modifier.width(NODE_GUTTER + Spacing.md))
+        DayHeaderLabel(date = item.date, modifier = Modifier.weight(1f))
     }
 }
 
-@Preview(showBackground = true, name = "Day header")
+// locale-default full month name is intentional here (human-language)
+private fun monthLabel(date: LocalDate): String =
+    date.toJavaLocalDate().format(DateTimeFormatter.ofPattern("MMMM", Locale.getDefault())).uppercase(Locale.getDefault())
+
+private fun dayOfMonthLabel(date: LocalDate): String = date.dayOfMonth.toString()
+
+/** "Today"/"Tomorrow"/"Two days ago" for a date near now, falling back to the locale-default weekday
+ *  name beyond that window — shared with [DayHeaderLabel]'s month line. Also looks *forward*
+ *  (`-1L -> "Tomorrow"`) since a session can span into a future-looking plan entry. Every branch
+ *  (including the locale weekday name) is already naturally capitalized, so this never uppercases
+ *  the result. */
+private fun relativeDayLabel(date: LocalDate): String {
+    val today = java.time.LocalDate.now()
+    val javaDate = date.toJavaLocalDate()
+    return when (ChronoUnit.DAYS.between(javaDate, today)) {
+        0L -> "Today"
+        1L -> "Yesterday"
+        2L -> "Two days ago"
+        -1L -> "Tomorrow"
+        // locale-default weekday name is intentional here (human-language); any other day gap (unbounded)
+        else -> javaDate.format(DateTimeFormatter.ofPattern("EEEE", Locale.getDefault()))
+    }
+}
+
+@PreviewLightDark
 @Composable
 private fun DayHeaderRowPreview() {
     CronTheme {
-        Column {
+        Column(modifier = Modifier.fillMaxSize().background(CronColors.pageBackground)) {
             DayHeaderRow(
-                item = TimelineItem.DayHeader(
-                    date = LocalDate(2026, 7, 3),
-                    timestamp = Instant.fromEpochMilliseconds(0),
-                    weekdayLabel = "TODAY",
-                    dateLabel = "3 JUL",
-                ),
+                item = TimelineItem.DayHeader(date = LocalDate(2026, 7, 3), timestamp = Instant.fromEpochMilliseconds(0)),
                 modifier = Modifier.padding(horizontal = Spacing.md),
             )
             DayHeaderRow(
-                item = TimelineItem.DayHeader(
-                    date = LocalDate(2026, 6, 30),
-                    timestamp = Instant.fromEpochMilliseconds(0),
-                    weekdayLabel = "YESTERDAY",
-                    dateLabel = "30 JUN",
-                ),
+                item = TimelineItem.DayHeader(date = LocalDate(2026, 6, 30), timestamp = Instant.fromEpochMilliseconds(0)),
                 modifier = Modifier.padding(horizontal = Spacing.md),
             )
         }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/EventNode.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/EventNode.kt
@@ -1,0 +1,107 @@
+package fr.bsodium.cron.ui.screens.home.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
+import fr.bsodium.cron.ui.screens.home.TimelineItem
+import fr.bsodium.cron.ui.theme.CronTypography
+import fr.bsodium.cron.ui.theme.Spacing
+import fr.bsodium.cron.ui.theme.TightTextStyle
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import java.util.Locale
+
+@Composable
+internal fun EventNode(
+    item: TimelineItem.Event,
+    registry: TimelineTrackRegistry,
+    isSegmentTop: Boolean,
+    isSegmentBottom: Boolean,
+    isAsleepAbove: Boolean,
+    isAsleepBelow: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val accent = item.trigger.timelineAccent()
+    /** `isAsleepAbove || isAsleepBelow`, not `isAsleepAbove` alone: [TimelineTrackOverlay]'s
+     *  `buildSleepPills` nests a transition cap inside the sleep pill's rounded end on EITHER
+     *  edge — a sleep-onset cap (asleepAbove=true) *and* a wake-up cap (asleepBelow=true) both get
+     *  the pill's cap extended past their own center, but `isAsleepAbove` alone is only true for
+     *  the onset direction. A wake-up cap like `OutOfBedConfirmed` has `asleepAbove=false` even
+     *  though it sits visually inside the dark pill from the sleep side below it — the OR catches
+     *  both. */
+    val isCapNestedInSleepPill = isAsleepAbove || isAsleepBelow
+    val anchorContainer = accent.capContainerColor(isAsleep = isCapNestedInSleepPill)
+    val onAnchorContainer = accent.capOnContainerColor(isAsleep = isCapNestedInSleepPill)
+    val tz = TimeZone.currentSystemDefault()
+    val local = item.timestamp.toLocalDateTime(tz)
+    val timeText = String.format(Locale.US, "%02d:%02d", local.hour, local.minute)
+    val detail = item.detail
+    val emphasis = item.detailEmphasis
+
+    TimelineNode(
+        id = item.id,
+        registry = registry,
+        anchor = TimelineAnchor.Icon(
+            symbol = triggerSymbol(item.trigger),
+            tint = onAnchorContainer,
+            containerColor = anchorContainer,
+            valence = item.trigger.timelineValence(),
+        ),
+        isSegmentTop = isSegmentTop,
+        isSegmentBottom = isSegmentBottom,
+        isAsleepAbove = isAsleepAbove,
+        isAsleepBelow = isAsleepBelow,
+        verticalPadding = Spacing.md,
+        modifier = modifier,
+        title = {
+            Text(
+                text = item.label,
+                style = CronTypography.timelineRowTitle,
+                color = contentColor,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        status = {
+            Text(
+                text = timelineTimeLabel(item.timestamp.toEpochMilliseconds(), timeText),
+                style = CronTypography.timelineRowTime,
+                color = contentColor,
+            )
+        },
+        // A subtext line with the one fact that matters bolded, styled `outline` (secondary detail, not competing with the title/time color); `.merge(TightTextStyle)` removes Android's default font-padding leading, since passing an explicit `style` bypasses `LocalTextStyle` entirely.
+        content = detail?.let { text ->
+            emphasis?.let {
+                {
+                    Text(
+                        text = emphasized(text, it),
+                        style = MaterialTheme.typography.bodyMedium.merge(TightTextStyle),
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+        },
+    )
+}
+
+/** [text] with the [emphasis] substring rendered bold — falls back to plain [text] if [emphasis]
+ *  isn't actually found in it (defensive: the two always come from the same call site in
+ *  `TimelineMapper.kt`'s `eventDetail`, but nothing enforces that at the type level). */
+private fun emphasized(text: String, emphasis: String): AnnotatedString = buildAnnotatedString {
+    val start = text.indexOf(emphasis)
+    if (start < 0) {
+        append(text)
+        return@buildAnnotatedString
+    }
+    append(text.substring(0, start))
+    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(emphasis) }
+    append(text.substring(start + emphasis.length))
+}

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/LatestAnchor.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/LatestAnchor.kt
@@ -1,76 +1,41 @@
-@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
-
 package fr.bsodium.cron.ui.screens.home.components
 
-import android.graphics.Matrix
-import android.graphics.Path
-import android.graphics.RectF
-import androidx.compose.animation.core.Animatable
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.MaterialShapes
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.asComposePath
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.graphics.shapes.Morph
-import androidx.graphics.shapes.toPath
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.MaterialSymbol
 import fr.bsodium.cron.ui.theme.Symbol
 
-internal val LATEST_ANCHOR_SIZE = 32.dp
-private val LATEST_GLYPH_SIZE = 20.dp
+private val LATEST_GLYPH_SIZE = 18.dp
 
-/** The single latest AI run's anchor: a filled Material shape (docs/expressive.md shape vocabulary)
- *  that morphs in from a plain circle once on entry, instead of the icon-in-a-dot every other node
- *  uses — the newest row visibly "arrives". It settles and holds; no continuous motion once arrived,
- *  since this row can sit on screen for hours between plans. */
+/** The single latest AI run's foreground: just the glyph. The morphing shape it sits on is filled
+ *  by [TimelineTrackOverlay]'s socket carve (a shared `Morph`/progress hoisted in [TimelineNode]) —
+ *  track-matched via `trackAccentColor` (Round 27) rather than a flat `primaryContainer` — so the
+ *  carve and the surface are one thing that can't drift — see docs/color-roles.md Round 14. [isAsleep]
+ *  picks the paired `trackOnAccentColor` for this glyph so it stays correctly paired with whichever
+ *  fill the overlay actually painted underneath it. The morph fills [FLUSH_ANCHOR_SIZE] (Latest is
+ *  always a cap) like every other cap anchor; only this glyph stays its own size. */
 @Composable
-internal fun LatestAnchor(symbol: MaterialSymbol, modifier: Modifier = Modifier) {
-    val fillColor = MaterialTheme.colorScheme.primary
-    val glyphColor = MaterialTheme.colorScheme.onPrimary
-    val morph = remember { Morph(MaterialShapes.Circle, MaterialShapes.Cookie9Sided) }
-    val progress = remember { Animatable(0f) }
-    val path = remember { Path() }
-    val matrix = remember { Matrix() }
-    val arriveSpec = MaterialTheme.motionScheme.slowSpatialSpec<Float>()
-    LaunchedEffect(Unit) { progress.animateTo(1f, arriveSpec) }
-
-    Box(modifier = modifier.size(LATEST_ANCHOR_SIZE), contentAlignment = Alignment.Center) {
-        Canvas(modifier = Modifier.size(LATEST_ANCHOR_SIZE)) {
-            path.rewind()
-            morph.toPath(progress.value.coerceIn(0f, 1f), path)
-            val bounds = RectF()
-            path.computeBounds(bounds, true)
-            val span = maxOf(bounds.width(), bounds.height())
-            if (span > 0f) {
-                val scale = size.minDimension / span
-                matrix.reset()
-                matrix.setScale(scale, scale)
-                matrix.postTranslate(
-                    (size.width - bounds.width() * scale) / 2f - bounds.left * scale,
-                    (size.height - bounds.height() * scale) / 2f - bounds.top * scale,
-                )
-                path.transform(matrix)
-                drawPath(path.asComposePath(), color = fillColor)
-            }
-        }
-        Symbol(symbol = symbol, contentDescription = null, tint = glyphColor, size = LATEST_GLYPH_SIZE)
+internal fun LatestAnchor(symbol: MaterialSymbol, isAsleep: Boolean, modifier: Modifier = Modifier) {
+    Box(modifier = modifier.size(FLUSH_ANCHOR_SIZE), contentAlignment = Alignment.Center) {
+        Symbol(
+            symbol = symbol,
+            contentDescription = null,
+            tint = trackOnAccentColor(isAsleep),
+            size = LATEST_GLYPH_SIZE,
+        )
     }
 }
 
-@Preview(showBackground = true, name = "Latest anchor — arrival")
+@Preview(showBackground = true, name = "Latest anchor — glyph")
 @Composable
 private fun LatestAnchorPreview() {
     CronTheme {
-        LatestAnchor(symbol = MaterialSymbol.Schedule)
+        LatestAnchor(symbol = MaterialSymbol.Schedule, isAsleep = false)
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/OldPlanFooter.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/OldPlanFooter.kt
@@ -62,7 +62,7 @@ internal fun OldPlanFooter(
 
 /** A coarse "X ago" string from [epochMs], re-ticked each minute so it stays current while viewed. */
 @Composable
-private fun rememberRelativeAgo(epochMs: Long): String {
+internal fun rememberRelativeAgo(epochMs: Long): String {
     val now by produceState(initialValue = Clock.System.now().toEpochMilliseconds()) {
         while (true) {
             delay(60_000L)

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/SessionTimeline.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/SessionTimeline.kt
@@ -2,77 +2,105 @@
 
 package fr.bsodium.cron.ui.screens.home.components
 
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.ui.Alignment
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import fr.bsodium.cron.ui.screens.home.RunKind
 import fr.bsodium.cron.ui.screens.home.TimelineItem
+import fr.bsodium.cron.ui.screens.home.timelineAsleepStates
+import fr.bsodium.cron.ui.theme.CronColors
 import fr.bsodium.cron.ui.theme.CronTypography
 import fr.bsodium.cron.ui.theme.MaterialSymbol
 import fr.bsodium.cron.ui.theme.Radius
 import fr.bsodium.cron.ui.theme.Spacing
 import fr.bsodium.cron.ui.theme.Symbol
+import fr.bsodium.cron.ui.theme.TightTextStyle
+import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toJavaLocalDate
 import kotlinx.datetime.toLocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.Locale
-
-private val ARROW_ICON_SIZE = 18.dp
 
 internal fun LazyListScope.sessionTimelineItems(
     timeline: List<TimelineItem>,
     hasMore: Boolean,
+    registry: TimelineTrackRegistry,
+    newlyArrivedIds: Set<String> = emptySet(),
+    // Forces every row's animateItem specs to null while the timeline's own composition is still settling after a fresh mount (see HomeContent.kt's rememberTimelineSettled), so cold-start/navigation never replays an entrance animation for unchanged data.
+    suppressEntranceAnimation: Boolean = false,
     onOpenAiRun: (turnIndex: Int, sessionId: String) -> Unit,
     onNavigateToHistory: () -> Unit,
 ) {
+    val asleepStates = timelineAsleepStates(timeline)
+    // A DayHeader is purely decorative (never a track anchor) — the true segment/cap boundary is the first/last REAL row, skipping headers, not the raw list ends.
+    val firstAnchorIndex = timeline.indexOfFirst { it !is TimelineItem.DayHeader }
+    val lastAnchorIndex = timeline.indexOfLast { it !is TimelineItem.DayHeader }
+
     item(key = "timeline-top-spacer") {
         Spacer(Modifier.height(Spacing.xxxl))
     }
 
-    items(
-        count = timeline.size,
-        key = { timeline[it].id },
-        contentType = { timeline[it]::class },
-    ) { index ->
-        val item = timeline[index]
-        // A day header renders no connector of its own, so the node on either side is a fresh segment boundary, same as the list's true first/last row.
-        val isFirst = index == 0 || timeline[index - 1] is TimelineItem.DayHeader
-        val isLast = index == timeline.lastIndex || timeline[index + 1] is TimelineItem.DayHeader
-        val placementSpec = MaterialTheme.motionScheme.defaultSpatialSpec<IntOffset>()
-        val fadeSpec = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
-
+    timeline.forEachIndexed { index, item ->
         when (item) {
-            is TimelineItem.AiRun -> AiRunNode(
-                item = item,
-                isFirst = isFirst,
-                isLast = isLast,
-                onClick = { onOpenAiRun(item.iteration.turnIndex, item.sessionId) },
-                modifier = Modifier.animateItem(fadeInSpec = fadeSpec, placementSpec = placementSpec, fadeOutSpec = fadeSpec),
-            )
-            is TimelineItem.Event -> EventNode(
-                item = item,
-                isFirst = isFirst,
-                isLast = isLast,
-                modifier = Modifier.animateItem(fadeInSpec = fadeSpec, placementSpec = placementSpec, fadeOutSpec = fadeSpec),
-            )
-            is TimelineItem.DayHeader -> DayHeaderRow(
-                item = item,
-                modifier = Modifier.animateItem(fadeInSpec = fadeSpec, placementSpec = placementSpec, fadeOutSpec = fadeSpec),
-            )
+            // A plain in-flow row; every header renders identically today (see DayHeaderRow's KDoc) and shares the same animateItem choreography as the AiRun/Event rows below it.
+            is TimelineItem.DayHeader -> item(key = item.id, contentType = TimelineItem.DayHeader::class) {
+                DayHeaderRow(item = item, modifier = gatedAnimateItem(suppressEntranceAnimation))
+            }
+            is TimelineItem.AiRun -> item(key = item.id, contentType = TimelineItem.AiRun::class) {
+                AiRunNode(
+                    item = item,
+                    registry = registry,
+                    isSegmentTop = index == firstAnchorIndex,
+                    isSegmentBottom = index == lastAnchorIndex,
+                    isAsleepAbove = asleepStates[index],
+                    isAsleepBelow = asleepStates.getOrNull(index + 1) ?: asleepStates[index],
+                    isNewlyArrived = item.id in newlyArrivedIds,
+                    onClick = { onOpenAiRun(item.iteration.turnIndex, item.sessionId) },
+                    // zIndex ahead of animateItem: normal paint order would draw a newly-arrived latest row under the still-demoting previous latest row while its placement slide is in flight; painting the incoming hero on top removes that overlap source.
+                    modifier = Modifier
+                        .zIndex(if (item.isLatest) 1f else 0f)
+                        .then(gatedAnimateItem(suppressEntranceAnimation)),
+                )
+            }
+            is TimelineItem.Event -> item(key = item.id, contentType = TimelineItem.Event::class) {
+                EventNode(
+                    item = item,
+                    registry = registry,
+                    isSegmentTop = index == firstAnchorIndex,
+                    isSegmentBottom = index == lastAnchorIndex,
+                    isAsleepAbove = asleepStates[index],
+                    isAsleepBelow = asleepStates.getOrNull(index + 1) ?: asleepStates[index],
+                    modifier = gatedAnimateItem(suppressEntranceAnimation),
+                )
+            }
         }
     }
 
@@ -91,67 +119,200 @@ internal fun LazyListScope.sessionTimelineItems(
     }
 }
 
+/** The shared `animateItem` shape every row in [sessionTimelineItems] uses, including
+ *  [TimelineItem.DayHeader] rows — [suppress] forces every spec to null (a fresh mount still
+ *  settling, see `HomeContent.kt`'s `rememberTimelineSettled`). `fastSpatialSpec`/`fastEffectsSpec`
+ *  (not `default*`): inserting one row at the top of a long timeline reflows every row below it at
+ *  once, and a *default* spatial spring's longer settle plus Expressive's bounce, played across a
+ *  dozen-plus simultaneously-reflowing rows, reads as the whole timeline "scaling"/rubber-banding
+ *  into place rather than a crisp single insertion; `fast*` keeps the same spring family but
+ *  shortens the window where that's visible. */
+@Composable
+private fun LazyItemScope.gatedAnimateItem(suppress: Boolean): Modifier {
+    val placementSpec = MaterialTheme.motionScheme.fastSpatialSpec<IntOffset>()
+    val fadeSpec = MaterialTheme.motionScheme.fastEffectsSpec<Float>()
+    return Modifier.animateItem(
+        fadeInSpec = if (suppress) null else fadeSpec,
+        placementSpec = if (suppress) null else placementSpec,
+        fadeOutSpec = if (suppress) null else fadeSpec,
+    )
+}
+
+/** The color that identifies each track — a *fill* for both tracks, not an outline. The awake track
+ *  uses `colorScheme.surfaceContainerHigh`, a modest step up from the page background —
+ *  `TimelineTrackOverlay.kt`'s spine is separately tuned to stay visible against it.
+ *
+ *  The asleep track uses `colorScheme.secondary` — a bold, deliberately prominent solid fill so the
+ *  sleep stretch still reads as dark/prominent rather than a blended tint (this app's flat-design
+ *  rule rules out a literal shadow/elevation for "the sleep track should feel raised"). Kept off
+ *  `primary` specifically to free up the primary palette for other timeline elements (the AI-run
+ *  family) without a same-hue collision against the sleep track itself — see `docs/color-roles.md`. */
+@Composable
+internal fun trackColorFor(isAsleep: Boolean): Color {
+    val scheme = MaterialTheme.colorScheme
+    return if (isAsleep) {
+        scheme.secondary
+    } else {
+        scheme.surfaceContainerHigh
+    }
+}
+
+/** The single fill/tint pair every anchor's socket uses, regardless of accent, trigger, or item
+ *  kind — secondary-family on the sleep track, primary-family on the awake track: everything on
+ *  that track consistently uses that one palette, rather than a scattered mix of per-accent hues,
+ *  cross-track "borrowed" colors, and one-off escape hatches.
+ *
+ *  Deliberately *not* the same literal role as [trackColorFor] on the sleep side: [trackColorFor]'s
+ *  own asleep fill is already the bold `secondary` solid, so an anchor using that identical role
+ *  would be visually indistinguishable from the track itself, reading as "just a glyph floating on
+ *  the pill, no shape." `secondaryContainer` stays in the same secondary family while actually
+ *  contrasting against a `secondary`-filled track, the same relationship the awake side already has
+ *  for free (`primary` accent against the awake track's neutral `surfaceContainerHigh` fill). */
+@Composable
+internal fun trackAccentColor(isAsleep: Boolean): Color =
+    if (isAsleep) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.primary
+
+/** [trackAccentColor]'s paired foreground — always the M3-guaranteed `on*` role for whichever fill
+ *  [trackAccentColor] resolved to. */
+@Composable
+internal fun trackOnAccentColor(isAsleep: Boolean): Color =
+    if (isAsleep) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onPrimary
+
 @Composable
 internal fun AiRunNode(
     item: TimelineItem.AiRun,
-    isFirst: Boolean,
-    isLast: Boolean,
+    registry: TimelineTrackRegistry,
+    isSegmentTop: Boolean,
+    isSegmentBottom: Boolean,
+    isAsleepAbove: Boolean,
+    isAsleepBelow: Boolean,
     onClick: () -> Unit,
+    // Whether this row's own id is genuinely new since HomeViewModel's last emission (see TimelineMapper.kt's diffNewlyArrivedIds) — only meaningful for the Latest row, gating its Circle→Cookie9Sided arrival morph, since a plain isLatest check alone is also true on a fresh mount with no new data.
+    isNewlyArrived: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val scheme = MaterialTheme.colorScheme
     val iter = item.iteration
     val symbol = if (iter.thread.isMocked) MaterialSymbol.Code else runSymbol(iter.kind)
-    // Every AI run shares the primary family (docs/expressive.md "AI runs → primary"); the latest one steps up to its own morphing hero anchor.
+    val atCap = isSegmentTop || isSegmentBottom || (!isAsleepAbove && isAsleepBelow) || (isAsleepAbove && !isAsleepBelow)
+    /** `isAsleepAbove || isAsleepBelow`, not `isAsleepAbove` alone: a transition cap gets nested
+     *  inside the sleep pill's rounded end on EITHER edge ([TimelineTrackOverlay]'s
+     *  `buildSleepPills`), but `isAsleepAbove` is only true for the sleep-onset direction — a
+     *  wake-up-direction cap needs the same treatment, see [EventNode]'s own
+     *  `isCapNestedInSleepPill`. */
+    val isCapNestedInSleepPill = isAsleepAbove || isAsleepBelow
+    /** A cap anchor's socket always matches whichever track it sits on ([trackAccentColor]/
+     *  [trackOnAccentColor]). The `!atCap` case's `primaryContainer`/`onPrimaryContainer` is never
+     *  actually seen — [TimelineNode]'s `effectiveAnchor` normalization discards and overrides any
+     *  non-cap `Icon`'s tint/container with its own track-matched interior treatment — but stays
+     *  here as a placeholder rather than `null`/a TODO. */
     val anchor = when {
         item.isStreaming -> TimelineAnchor.Loader
         item.isLatest -> TimelineAnchor.Latest(symbol)
-        else -> TimelineAnchor.Icon(symbol = symbol, tint = scheme.onPrimaryContainer, containerColor = scheme.primaryContainer)
+        else -> TimelineAnchor.Icon(
+            symbol = symbol,
+            tint = if (atCap) trackOnAccentColor(isCapNestedInSleepPill) else scheme.onPrimaryContainer,
+            containerColor = if (atCap) trackAccentColor(isCapNestedInSleepPill) else scheme.primaryContainer,
+            valence = iter.kind.timelineValence(),
+        )
     }
     val contentColor = scheme.onSurfaceVariant
-    // The resolved alarm time is the "key fact" headline; a cancel/do_nothing turn has none, so it falls back to the AI's prose outcome instead of a time pair.
+    // The alarm time this run resolved to is the "key fact" headline; a cancel/do_nothing turn has no new time, so it falls back to the standing prevTime, then a static label — never the AI's own prose (see the title `when` below), which stays confined to the content slot instead.
     val newTime = iter.thread.newAlarmTime.takeIf { item.isLatest }
     val prevTime = iter.previousAlarmTime.takeIf { item.isLatest }
-    val heroHeadline = iter.thread.summary?.takeIf { item.isLatest && it.isNotBlank() }
+    /** While streaming, `thread.summary` is still-growing live token text (fine for the "thinking"
+     *  pill elsewhere) — never bound into this `maxLines=2` ellipsis headline, or it visibly jitters
+     *  and truncates mid-sentence as tokens arrive. Same gate `AiThreadMapper` applies to `answer`;
+     *  while streaming this falls back to the stable, non-moving systemMessage kicker below. */
+    val heroHeadline = iter.thread.summary?.takeIf { item.isLatest && !item.isStreaming && it.isNotBlank() }
+    /** Base plans can be many hours old (the evening plan vs. a replan minutes ago read very
+     *  differently) so they get a relative "X ago"; replans are usually close together, where an
+     *  exact clock time is more useful for correlating with nearby rows. */
+    val kickerSuffix = if (item.isLatest) {
+        when (iter.kind) {
+            RunKind.ScheduledBase, RunKind.ManualBase -> iter.ranAtEpochMs?.let { "· ${rememberRelativeAgo(it)}" }
+            is RunKind.Replan -> "· at ${iter.timeLabel}"
+        }
+    } else {
+        null
+    }
+    val kickerText = listOfNotNull(iter.systemMessage, kickerSuffix).joinToString(" ")
+    val density = LocalDensity.current
 
     TimelineNode(
+        id = item.id,
+        registry = registry,
         anchor = anchor,
-        isFirst = isFirst,
-        isLast = isLast,
+        isSegmentTop = isSegmentTop,
+        isSegmentBottom = isSegmentBottom,
+        isAsleepAbove = isAsleepAbove,
+        isAsleepBelow = isAsleepBelow,
+        isNewlyArrived = isNewlyArrived,
         onClick = onClick,
         modifier = modifier,
         verticalPadding = if (item.isLatest) Spacing.lg else Spacing.md,
         title = {
-            if (item.isLatest) {
-                Column(verticalArrangement = Arrangement.spacedBy(Spacing.xxs)) {
-                    // Shares the countdown card's `primary` fill so the newest run visually rhymes with it; a plain on-role pairing, not a nested-container case (docs/color-roles.md).
+            /** A row that has NEVER been latest only ever shows the single-line demoted branch
+             *  below — reserving hero-sized height on it too (not just a row actually transitioning
+             *  away from latest) forced every historical row into a taller box than its one line
+             *  needed, offsetting it from the anchor. `remember(item.id)` captures whether THIS row
+             *  was latest at its first composition and never un-sets, since `isLatest` only ever
+             *  transitions true→false, never the reverse. */
+            val everLatest = remember(item.id) { item.isLatest }
+            /** The demoted (single-line) state is shorter than the hero (kicker + time) state;
+             *  without reserving the hero's height here, the Crossfade instantly resizes the Row
+             *  and — since the Row centers its children vertically — the whole anchor/title visibly
+             *  re-centers the moment a run gets superseded. Only applies to a row that could ever
+             *  actually be in the hero state. */
+            val heroMinHeight = remember(density) {
+                with(density) {
+                    CronTypography.timelineHeroKicker.lineHeight.toDp() + HERO_KICKER_GAP +
+                        CronTypography.timelineHeroTimeNew.lineHeight.toDp()
+                }
+            }
+            // Fades the hero headline ↔ plain system-message swap instead of cutting instantly, pairing with TimelineNode's animated anchor-radius shrink; heightIn lives on this wrapping Box (not Crossfade, which has no contentAlignment and top-aligns internally) so centering the demoted text belongs here.
+            Box(
+                modifier = if (everLatest) Modifier.heightIn(min = heroMinHeight) else Modifier,
+                contentAlignment = Alignment.CenterStart,
+            ) {
+            Crossfade(
+                targetState = item.isLatest,
+                animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
+                label = "ai-run-hero-demote",
+            ) { isLatest ->
+            if (isLatest) {
+                Column(verticalArrangement = Arrangement.spacedBy(HERO_KICKER_GAP)) {
+                    // Shares the countdown card's `primary` fill so the newest run visually rhymes with it — touches only the neutral page background, so this is a plain on-role pairing, not a nested-container case (docs/color-roles.md).
                     Text(
-                        text = iter.systemMessage.uppercase(Locale.US),
+                        text = kickerText.uppercase(Locale.US),
                         style = CronTypography.timelineHeroKicker,
                         color = scheme.primary,
                         maxLines = 1,
                         softWrap = false,
                         overflow = TextOverflow.Ellipsis,
                     )
+                    // TimelineNode's anchor and trailing-arrow Boxes align to this exact line via RowScope.alignBy, rather than a hand-computed padding offset that requires guessing the kicker's rendered height.
+                    Box(modifier = Modifier.declareCenterAs(HeroHeadlineCenter)) {
                     when {
-                        // A real change: show it as a PREV › NEW pair, NEW bolder — the key fact at a glance, not a prose sentence.
+                        // A streaming turn is seeded before its set_alarm result arrives, so both times are transiently null — showing NO_ALARM_LABEL would flash then immediately replace, reading as a glitch; reserve the line's height with an invisible placeholder instead.
+                        newTime == null && prevTime == null && item.isStreaming ->
+                            Text(text = " ", style = CronTypography.timelineHeroTimeNew, color = Color.Transparent)
+                        // A real change: show it as a PREV › NEW pair, NEW bold italic — the key fact at a glance, not a prose sentence.
                         newTime != null && prevTime != null && prevTime != newTime -> Row(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
                         ) {
                             Text(text = prevTime.asClock(), style = CronTypography.timelineHeroTimePrev)
                             Text(text = "›", style = CronTypography.timelineHeroTimePrev, color = contentColor)
-                            Text(text = newTime.asClock(), style = CronTypography.timelineHeroTitle)
+                            Text(text = newTime.asClock(), style = CronTypography.timelineHeroTimeNew)
                         }
-                        // No prior time to compare against, or it didn't change — the pair would just read as a redundant "7:30 › 7:30".
-                        newTime != null -> Text(text = newTime.asClock(), style = CronTypography.timelineHeroTitle)
-                        // No new time at all (cancel/do_nothing) — falls back to the AI's own outcome sentence.
-                        else -> Text(
-                            text = heroHeadline ?: iter.systemMessage,
-                            style = CronTypography.timelineHeroTitle,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                        // No prior time to compare against, or it didn't actually change — the pair would just read as a redundant "7:30 › 7:30".
+                        newTime != null -> Text(text = newTime.asClock(), style = CronTypography.timelineHeroTimeNew)
+                        // No new time at all (cancel/do_nothing) but a prior one exists — the alarm stands as-is, still a time fact, never the AI's prose.
+                        prevTime != null -> Text(text = prevTime.asClock(), style = CronTypography.timelineHeroTimeNew)
+                        // Nothing resolved at all (rare first-run do-nothing) — a static literal, never AI-generated text, so the big slot can never overflow with long prose.
+                        else -> Text(text = NO_ALARM_LABEL, style = CronTypography.timelineHeroTimeNew)
+                    }
                     }
                 }
             } else {
@@ -164,39 +325,32 @@ internal fun AiRunNode(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
+            }
+            }
         },
         status = {
-            if (item.isLatest) {
-                // The tap-through affordance belongs in this trailing, vertically-centered slot, not inline with the headline.
-                Symbol(symbol = MaterialSymbol.ArrowForward, contentDescription = null, tint = contentColor, size = ARROW_ICON_SIZE)
+            Crossfade(
+                targetState = item.isLatest,
+                animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
+                label = "ai-run-status-demote",
+            ) { isLatest ->
+            if (isLatest) {
+                // status is the row's trailing, vertically-centered slot by construction, so the tap-through arrow belongs here; weight=700 uses Symbol's own wght axis to actually thicken the stroke, not just size the glyph up.
+                Symbol(symbol = MaterialSymbol.ArrowForward, contentDescription = null, tint = contentColor, size = 18.dp, weight = 700)
             } else {
                 Text(
-                    text = iter.timeLabel,
-                    style = CronTypography.labelMonoSmall,
+                    text = iter.ranAtEpochMs?.let { timelineTimeLabel(it, iter.timeLabel) } ?: iter.timeLabel,
+                    style = CronTypography.timelineRowTime,
                     color = contentColor,
                     maxLines = 1,
                     softWrap = false,
                 )
             }
-        },
-        content = if (item.isLatest) {
-            {
-                Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-                    Text(
-                        text = "Latest · ${iter.timeLabel}",
-                        style = CronTypography.labelMonoSmall,
-                        color = contentColor,
-                    )
-                    // Only when the headline above is a time — the prose-fallback headline already IS this summary, so showing it again here would duplicate it.
-                    if (newTime != null && heroHeadline != null) {
-                        Text(
-                            text = heroHeadline,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = contentColor,
-                        )
-                    }
-                }
             }
+        },
+        // The headline above is now exclusively a time fact or NO_ALARM_LABEL, never heroHeadline, so this can't duplicate it; "Latest · HH:MM" moved into the kicker's kickerSuffix. `.merge(TightTextStyle)` — see EventNode.kt's `content` KDoc for why an explicit style needs this directly rather than an ambient provider.
+        content = if (item.isLatest && heroHeadline != null) {
+            { Text(text = heroHeadline, style = MaterialTheme.typography.bodyMedium.merge(TightTextStyle), color = contentColor) }
         } else {
             null
         },
@@ -205,55 +359,26 @@ internal fun AiRunNode(
 
 private fun LocalTime.asClock(): String = String.format(Locale.US, "%02d:%02d", hour, minute)
 
-@Composable
-internal fun EventNode(
-    item: TimelineItem.Event,
-    isFirst: Boolean,
-    isLast: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    val contentColor = MaterialTheme.colorScheme.onSurfaceVariant
-    val accent = item.trigger.timelineAccent()
-    val accentContainer = accent.containerColor()
-    val onAccentContainer = accent.onContainerColor()
-    val tz = TimeZone.currentSystemDefault()
-    val local = item.timestamp.toLocalDateTime(tz)
-    val timeText = String.format(Locale.US, "%02d:%02d", local.hour, local.minute)
+private const val NO_ALARM_LABEL = "No alarm set"
 
-    TimelineNode(
-        anchor = TimelineAnchor.Icon(
-            symbol = triggerSymbol(item.trigger),
-            tint = onAccentContainer,
-            containerColor = accentContainer,
-        ),
-        isFirst = isFirst,
-        isLast = isLast,
-        verticalPadding = Spacing.md,
-        modifier = modifier,
-        title = {
-            Text(
-                text = item.label,
-                style = CronTypography.timelineRowTitle,
-                color = contentColor,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        },
-        status = {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (item.detail != null) {
-                    MonoPill(text = item.detail, containerColor = accentContainer, contentColor = onAccentContainer)
-                }
-                Text(
-                    text = timeText,
-                    style = CronTypography.labelMonoSmall,
-                    color = contentColor,
-                )
-            }
-        },
-    )
+/** Gap between the hero kicker caption and its own headline — matches [TimelineNode]'s `content`
+ *  slot gap (`Spacing.xxs`) so the kicker hugs the headline as tightly as the subtext does. Also the
+ *  basis for [heroMinHeight] below, which references this constant rather than a hardcoded number so
+ *  the two can't drift out of sync. */
+private val HERO_KICKER_GAP = Spacing.xxs
+
+/** A recent (within [RECENT_THRESHOLD_MS]) row shows "12m ago" instead of its clock time — the day
+ *  header already gives date context for anything older, so absolute [absoluteLabel] stays legible
+ *  past the cutoff. [rememberRelativeAgo] (a state-holding, self-re-ticking @Composable) is always
+ *  called, never skipped based on the threshold — conditionally calling a remember/produceState-
+ *  backed composable across recompositions is the kind of thing that can desync its internal state
+ *  from the slot table; picking the *string* to display, not the composable to call, sidesteps it. */
+@Composable
+internal fun timelineTimeLabel(epochMs: Long, absoluteLabel: String): String {
+    val relative = rememberRelativeAgo(epochMs)
+    val elapsedMs = Clock.System.now().toEpochMilliseconds() - epochMs
+    return if (elapsedMs < RECENT_THRESHOLD_MS) relative else absoluteLabel
 }
+
+private const val RECENT_THRESHOLD_MS = 60 * 60 * 1000L
 

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/SessionTimelinePreviews.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/SessionTimelinePreviews.kt
@@ -1,24 +1,37 @@
 package fr.bsodium.cron.ui.screens.home.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import fr.bsodium.cron.session.model.TriggerType
 import fr.bsodium.cron.ui.screens.home.AiIterationUi
 import fr.bsodium.cron.ui.screens.home.AiThreadUi
 import fr.bsodium.cron.ui.screens.home.ProcessItem
 import fr.bsodium.cron.ui.screens.home.RunKind
 import fr.bsodium.cron.ui.screens.home.TimelineItem
+import fr.bsodium.cron.ui.screens.home.timelineAsleepStates
+import fr.bsodium.cron.ui.theme.CronColors
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.Spacing
-import kotlinx.datetime.Clock
-import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
+
+private fun previewDayHeader(dateOffsetDays: Int): TimelineItem.DayHeader {
+    val ts = Instant.fromEpochMilliseconds(System.currentTimeMillis() - dateOffsetDays * 86_400_000L)
+    return TimelineItem.DayHeader(date = ts.toLocalDateTime(TimeZone.currentSystemDefault()).date, timestamp = ts)
+}
 
 private fun previewIteration(
     turn: Int,
@@ -40,24 +53,14 @@ private fun previewIteration(
     ranAtEpochMs = System.currentTimeMillis(),
 )
 
-private fun previewDayHeader(dateOffsetDays: Int, weekdayLabel: String, dateLabel: String): TimelineItem.DayHeader {
-    val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
-    return TimelineItem.DayHeader(
-        date = today.plus(dateOffsetDays, DateTimeUnit.DAY),
-        timestamp = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
-        weekdayLabel = weekdayLabel,
-        dateLabel = dateLabel,
-    )
-}
-
-@Preview(showBackground = true, name = "Timeline — full example")
+@PreviewLightDark
 @Composable
 private fun SessionTimelinePreview() {
     val now = Instant.fromEpochMilliseconds(System.currentTimeMillis())
     val yesterday = Instant.fromEpochMilliseconds(System.currentTimeMillis() - 86_400_000L)
     val twoDaysAgo = Instant.fromEpochMilliseconds(System.currentTimeMillis() - 172_800_000L)
     val timeline = listOf(
-        previewDayHeader(0, "TODAY", "3 JUL"),
+        previewDayHeader(0),
         TimelineItem.AiRun(
             timestamp = now,
             iteration = previewIteration(
@@ -74,7 +77,8 @@ private fun SessionTimelinePreview() {
             timestamp = now,
             trigger = TriggerType.AlarmSnoozed,
             label = "Alarm snoozed",
-            detail = "9 min",
+            detail = "You get to sleep for 9 extra minutes",
+            detailEmphasis = "9 extra minutes",
         ),
         TimelineItem.AiRun(
             timestamp = now,
@@ -113,7 +117,7 @@ private fun SessionTimelinePreview() {
             isStreaming = false,
             isLatest = false,
         ),
-        previewDayHeader(-1, "YESTERDAY", "2 JUL"),
+        previewDayHeader(1),
         TimelineItem.Event(
             timestamp = yesterday,
             trigger = TriggerType.OutOfBedConfirmed,
@@ -163,7 +167,7 @@ private fun SessionTimelinePreview() {
             isStreaming = false,
             isLatest = false,
         ),
-        previewDayHeader(-2, "MONDAY", "1 JUL"),
+        previewDayHeader(2),
         TimelineItem.Event(
             timestamp = twoDaysAgo,
             trigger = TriggerType.HardLatestFired,
@@ -182,25 +186,86 @@ private fun SessionTimelinePreview() {
             isLatest = false,
         ),
     )
+    val asleepStates = timelineAsleepStates(timeline)
+    val firstAnchorIndex = timeline.indexOfFirst { it !is TimelineItem.DayHeader }
+    val lastAnchorIndex = timeline.indexOfLast { it !is TimelineItem.DayHeader }
     CronTheme {
-        Column(modifier = Modifier.padding(horizontal = Spacing.xl)) {
-            timeline.forEachIndexed { index, item ->
-                val isFirst = index == 0 || timeline[index - 1] is TimelineItem.DayHeader
-                val isLast = index == timeline.lastIndex || timeline[index + 1] is TimelineItem.DayHeader
-                when (item) {
-                    is TimelineItem.AiRun -> AiRunNode(
-                        item = item,
-                        isFirst = isFirst,
-                        isLast = isLast,
-                        onClick = {},
-                    )
-                    is TimelineItem.Event -> EventNode(
-                        item = item,
-                        isFirst = isFirst,
-                        isLast = isLast,
-                    )
-                    is TimelineItem.DayHeader -> DayHeaderRow(item = item)
+        val registry = rememberTimelineTrackRegistry()
+        Box(modifier = Modifier.fillMaxSize().background(CronColors.pageBackground)) {
+            TimelineTrackOverlay(registry = registry)
+            Column(modifier = Modifier.padding(horizontal = Spacing.xl)) {
+                timeline.forEachIndexed { index, item ->
+                    val isSegmentTop = index == firstAnchorIndex
+                    val isSegmentBottom = index == lastAnchorIndex
+                    val isAsleepAbove = asleepStates[index]
+                    val isAsleepBelow = asleepStates.getOrNull(index + 1) ?: asleepStates[index]
+                    when (item) {
+                        is TimelineItem.AiRun -> AiRunNode(
+                            item = item,
+                            registry = registry,
+                            isSegmentTop = isSegmentTop,
+                            isSegmentBottom = isSegmentBottom,
+                            isAsleepAbove = isAsleepAbove,
+                            isAsleepBelow = isAsleepBelow,
+                            onClick = {},
+                        )
+                        is TimelineItem.Event -> EventNode(
+                            item = item,
+                            registry = registry,
+                            isSegmentTop = isSegmentTop,
+                            isSegmentBottom = isSegmentBottom,
+                            isAsleepAbove = isAsleepAbove,
+                            isAsleepBelow = isAsleepBelow,
+                        )
+                        is TimelineItem.DayHeader -> DayHeaderRow(item = item)
+                    }
                 }
+            }
+        }
+    }
+}
+
+/** Interactive: tap to toggle the run between latest (hero PREV › NEW) and superseded (plain row) so
+ *  the Animation Inspector can scrub the `ai-run-hero-demote` crossfade + the anchor's radius shrink.
+ *  See docs/animation-previews.md's interactive-preview pattern. */
+@PreviewLightDark
+@Composable
+private fun AiRunNodeHeroDemotePreview() {
+    val now = Instant.fromEpochMilliseconds(System.currentTimeMillis())
+    CronTheme {
+        var isLatest by remember { mutableStateOf(true) }
+        val registry = rememberTimelineTrackRegistry()
+        Box(modifier = Modifier.fillMaxSize().background(CronColors.pageBackground).clickable { isLatest = !isLatest }) {
+            TimelineTrackOverlay(registry = registry)
+            Column(modifier = Modifier.padding(horizontal = Spacing.xl)) {
+                AiRunNode(
+                    item = TimelineItem.AiRun(
+                        timestamp = now,
+                        iteration = AiIterationUi(
+                            turnIndex = 2,
+                            timeLabel = "07:15",
+                            kind = RunKind.Replan(TriggerType.CalendarChange),
+                            thread = AiThreadUi(
+                                turnIndex = 2,
+                                summary = "Moved alarm to 07:15 — your first meeting shifted to 09:00.",
+                                process = emptyList(),
+                                response = "Moved alarm to 07:15 — your first meeting shifted to 09:00.",
+                                newAlarmTime = LocalTime(7, 15),
+                            ),
+                            previousAlarmTime = LocalTime(7, 45),
+                            ranAtEpochMs = System.currentTimeMillis(),
+                        ),
+                        sessionId = "s1",
+                        isStreaming = false,
+                        isLatest = isLatest,
+                    ),
+                    registry = registry,
+                    isSegmentTop = true,
+                    isSegmentBottom = true,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    onClick = {},
+                )
             }
         }
     }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ShapePathBuilders.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/ShapePathBuilders.kt
@@ -1,0 +1,66 @@
+package fr.bsodium.cron.ui.screens.home.components
+
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.asComposePath
+import androidx.graphics.shapes.Morph
+import androidx.graphics.shapes.RoundedPolygon
+import androidx.graphics.shapes.toPath
+
+/** Builds a [Morph]'s outline at [progress] as a Compose [Path], scaled into a [diameterPx]-wide
+ *  square centered at ([cx], [cy]). [scratch] is a caller-owned, reused [android.graphics.Path] so the
+ *  morph animation doesn't allocate one per frame. Shared by the Latest socket carve here and (before
+ *  Round 13) the anchor's own fill, kept a single source so the two can't drift. */
+internal fun buildMorphPath(
+    morph: Morph,
+    progress: Float,
+    cx: Float,
+    cy: Float,
+    diameterPx: Float,
+    scratch: android.graphics.Path,
+): Path {
+    scratch.rewind()
+    morph.toPath(progress.coerceIn(0f, 1f), scratch)
+    val bounds = android.graphics.RectF()
+    scratch.computeBounds(bounds, true)
+    val span = maxOf(bounds.width(), bounds.height())
+    if (span <= 0f) return Path()
+    val scale = diameterPx / span
+    val matrix = android.graphics.Matrix().apply {
+        setScale(scale, scale)
+        postTranslate(
+            cx - (bounds.left + bounds.width() / 2f) * scale,
+            cy - (bounds.top + bounds.height() / 2f) * scale,
+        )
+    }
+    scratch.transform(matrix)
+    return scratch.asComposePath()
+}
+
+/** Builds a static [RoundedPolygon]'s outline as a Compose [Path], scaled into a [diameterPx]-wide
+ *  square centered at ([cx], [cy]). Sibling to [buildMorphPath] — the same measure-and-scale technique,
+ *  but for a fixed silhouette (valence shape), so there's no progress/rewind: the polygon never changes
+ *  frame to frame. [scratch] is reused to avoid a per-draw allocation. */
+internal fun buildPolygonPath(
+    polygon: RoundedPolygon,
+    cx: Float,
+    cy: Float,
+    diameterPx: Float,
+    scratch: android.graphics.Path,
+): Path {
+    scratch.rewind()
+    polygon.toPath(scratch)
+    val bounds = android.graphics.RectF()
+    scratch.computeBounds(bounds, true)
+    val span = maxOf(bounds.width(), bounds.height())
+    if (span <= 0f) return Path()
+    val scale = diameterPx / span
+    val matrix = android.graphics.Matrix().apply {
+        setScale(scale, scale)
+        postTranslate(
+            cx - (bounds.left + bounds.width() / 2f) * scale,
+            cy - (bounds.top + bounds.height() / 2f) * scale,
+        )
+    }
+    scratch.transform(matrix)
+    return scratch.asComposePath()
+}

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineAnchorRegistry.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineAnchorRegistry.kt
@@ -1,0 +1,99 @@
+package fr.bsodium.cron.ui.screens.home.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.graphics.shapes.Morph
+import androidx.graphics.shapes.RoundedPolygon
+
+/** The silhouette an anchor carves into the track. [Circle] covers every cap plain/loader anchor and
+ *  a cap neutral-valence icon; [Pill] is every INTERIOR (non-cap) anchor's shape — a horizontal
+ *  capsule, full [TimelineNode]'s `FLUSH_ANCHOR_SIZE` wide but only its own (animated) content
+ *  diameter tall by default, drawn as a plain `drawRoundRect` whose corner radius and height both
+ *  animate off [Pill.pressProgress]. Deliberately plain geometry, not a `Morph` — morphing between
+ *  two shapes with mismatched vertex topology and non-uniformly rescaling the *mid-interpolation*
+ *  outline to fit the growing rect produces a visibly broken bowtie/"butterfly" silhouette at
+ *  in-between press values, which a full capsule shrinking its corner radius toward a rounded-square
+ *  avoids entirely. [Polygon] is a static valence silhouette (Flower for positive, Diamond for
+ *  negative) carved at a fixed shape, reserved for cap anchors only; [MorphShape] is a live
+ *  Circle→(some Material shape) morph, whose [progress] is read live at draw time so the overlay's
+ *  socket animates in lockstep with the driving spring — used both for the Latest run's
+ *  Circle→Cookie9Sided arrival and a clickable cap anchor's Circle→Cookie6Sided press morph (a
+ *  same-vertex-count, same-family pair, so it doesn't hit the Pill/Square mismatch above). Kept a
+ *  sealed set so a new shape is an exhaustive-`when` compile error, not a silent fallthrough. */
+sealed interface AnchorShape {
+    data object Circle : AnchorShape
+
+    /** [pressProgress] defaults to "unpressed, non-interactive" (always-0) — only a clickable
+     *  [TimelineNode] row (`AiRunNode`) supplies a real one; `EventNode`'s rows are never clickable and
+     *  stay at the default, rendering the plain capsule unconditionally. */
+    data class Pill(val pressProgress: () -> Float = { 0f }) : AnchorShape
+    data class Polygon(val polygon: RoundedPolygon) : AnchorShape
+    data class MorphShape(val morph: Morph, val progress: () -> Float) : AnchorShape
+}
+
+/** Everything [TimelineTrackOverlay] needs about one anchor except its live position (kept in a
+ *  separate map so a per-frame position update doesn't churn this). Reported by [TimelineNode] on
+ *  (re)composition. `asleepAbove`/`asleepBelow` describe the track gaps immediately above/below the
+ *  anchor; the overlay derives sleep-pill caps from them. */
+data class AnchorDescriptor(
+    val contentRadiusPx: Float,
+    val shape: AnchorShape,
+    val accentColor: Color,
+    val isSegmentTop: Boolean,
+    val isSegmentBottom: Boolean,
+    val asleepAbove: Boolean,
+    val asleepBelow: Boolean,
+)
+
+/** Wraps a row's [LayoutCoordinates] handle — deliberately reference-identity-only (no custom
+ *  `equals`/`hashCode`), so a fresh instance on every [TimelineTrackRegistry.setPosition] call always
+ *  registers as a genuine change to the backing `mutableStateMapOf`, even on frames where Compose
+ *  happens to hand back a coordinates object that's `==` to the previous one — that keeps the overlay
+ *  redrawing every layout pass, matching the zero-lag design [TimelineTrackOverlay] relies on for
+ *  ordinary scrolling. See that file's KDoc (Round 35) for why the *value* itself is never cached: this
+ *  wrapper only carries the *handle*, queried fresh at draw time via [LayoutCoordinates.positionInWindow]. */
+class AnchorPosition(val coordinates: LayoutCoordinates)
+
+/** Shared handle the rows write into and [TimelineTrackOverlay] reads. [positions] hold a live
+ *  [LayoutCoordinates] handle per row (Round 35 — previously a cached `Offset` snapshot, which could go
+ *  numerically stale mid-transition; see [TimelineTrackOverlay]'s KDoc), queried fresh at draw time, not
+ *  a value computed once at registration; descriptors change only when the list does. Both keyed by the
+ *  stable [TimelineItem.id]. */
+@Stable
+class TimelineTrackRegistry {
+    val positions = mutableStateMapOf<String, AnchorPosition>()
+    val descriptors = mutableStateMapOf<String, AnchorDescriptor>()
+
+    /** Plain (non-State) set — deliberately NOT observed, just a side-table that survives a row
+     *  being disposed/recomposed by scrolling off-screen and back, unlike a per-row `remember`. See
+     *  [markEnteredOnce]. */
+    private val enteredIds = mutableSetOf<String>()
+
+    fun setPosition(id: String, coordinates: LayoutCoordinates) {
+        positions[id] = AnchorPosition(coordinates)
+    }
+
+    fun setDescriptor(id: String, descriptor: AnchorDescriptor) {
+        if (descriptors[id] != descriptor) descriptors[id] = descriptor
+    }
+
+    fun remove(id: String) {
+        positions.remove(id)
+        descriptors.remove(id)
+        // Deliberately NOT removed from enteredIds — a row scrolled off-screen and disposed must not replay its entrance animation when it scrolls back into view and recomposes fresh.
+    }
+
+    /** Returns `true` the first time [id] is ever checked, `false` every time after — used to play a
+     *  newly-arrived row's entrance animation exactly once per row identity for the lifetime of this
+     *  registry (i.e. this screen instance), even though scrolling the row off-screen and back disposes
+     *  and recomposes its composable, which would otherwise replay a per-row `remember`-held animation
+     *  state every time. */
+    fun markEnteredOnce(id: String): Boolean = enteredIds.add(id)
+}
+
+@Composable
+internal fun rememberTimelineTrackRegistry(): TimelineTrackRegistry = remember { TimelineTrackRegistry() }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineEventGalleryPreviews.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineEventGalleryPreviews.kt
@@ -1,0 +1,89 @@
+package fr.bsodium.cron.ui.screens.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import fr.bsodium.cron.session.model.TriggerType
+import fr.bsodium.cron.ui.screens.home.TimelineItem
+import fr.bsodium.cron.ui.theme.CronColors
+import fr.bsodium.cron.ui.theme.CronTheme
+import fr.bsodium.cron.ui.theme.CronTypography
+import fr.bsodium.cron.ui.theme.Spacing
+import kotlinx.datetime.Instant
+
+/** Exhaustive galleries over every [TriggerType] as a real [EventNode] — the exact scenario that
+ *  produced Rounds 18-20's cap/interior contrast bugs (a `*Container` role or a pill fill blending
+ *  into whichever track it sat on) was only ever caught one event at a time, live on-device. These
+ *  render the full matrix — every trigger, both tracks, both cap and interior sizing — in one place,
+ *  in both themes via `@PreviewLightDark`, so a future color/shape change can be screened here first.
+ *
+ *  Each row independently sets `isSegmentTop` to force cap/interior sizing (`TimelineNode`'s `atCap`
+ *  is a pure function of one row's own four flags, not its neighbors — no real segment continuity is
+ *  needed for this). The awake and asleep examples each get their own [TimelineTrackRegistry] so
+ *  `TimelineTrackOverlay`'s sleep-pill derivation (which infers the pill's open/close points from
+ *  asleep-state transitions within *one* segment) sees a clean, uniformly-asleep or uniformly-awake
+ *  block instead of a spurious half-open pill at the seam between two hand-built groups. */
+@PreviewLightDark
+@Composable
+internal fun EventCapGalleryPreview() {
+    CronTheme {
+        Column(modifier = Modifier.fillMaxSize().background(CronColors.pageBackground)) {
+            EventGalleryTrackBlock(sectionLabel = "Cap anchors — awake track", isAsleep = false, atCap = true)
+            EventGalleryTrackBlock(sectionLabel = "Cap anchors — sleep track", isAsleep = true, atCap = true)
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+internal fun EventInteriorGalleryPreview() {
+    CronTheme {
+        Column(modifier = Modifier.fillMaxSize().background(CronColors.pageBackground)) {
+            EventGalleryTrackBlock(sectionLabel = "Interior pills — awake track", isAsleep = false, atCap = false)
+            EventGalleryTrackBlock(sectionLabel = "Interior pills — sleep track", isAsleep = true, atCap = false)
+        }
+    }
+}
+
+@Composable
+internal fun EventGalleryTrackBlock(sectionLabel: String, isAsleep: Boolean, atCap: Boolean) {
+    val registry = rememberTimelineTrackRegistry()
+    GallerySectionLabel(sectionLabel)
+    Box {
+        TimelineTrackOverlay(registry = registry)
+        Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+            TriggerType.entries.forEach { trigger ->
+                EventNode(
+                    item = TimelineItem.Event(
+                        timestamp = Instant.fromEpochMilliseconds(0L),
+                        trigger = trigger,
+                        label = trigger.name,
+                        detail = null,
+                    ),
+                    registry = registry,
+                    isSegmentTop = atCap,
+                    isSegmentBottom = false,
+                    isAsleepAbove = isAsleep,
+                    isAsleepBelow = isAsleep,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun GallerySectionLabel(text: String) {
+    Text(
+        text = text,
+        style = CronTypography.labelMonoSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = Spacing.lg, bottom = Spacing.xs, start = NODE_GUTTER + Spacing.md),
+    )
+}

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineNode.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineNode.kt
@@ -2,11 +2,10 @@
 
 package fr.bsodium.cron.ui.screens.home.components
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,67 +19,146 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.material3.LocalTextStyle
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.layout.HorizontalAlignmentLine
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.graphics.shapes.Morph
 import fr.bsodium.cron.ui.components.bleedHorizontally
-import fr.bsodium.cron.ui.theme.CronTheme
-import fr.bsodium.cron.ui.theme.CronTypography
+import fr.bsodium.cron.ui.theme.CronColors
 import fr.bsodium.cron.ui.theme.MaterialSymbol
 import fr.bsodium.cron.ui.theme.Spacing
 import fr.bsodium.cron.ui.theme.Symbol
-import fr.bsodium.cron.ui.theme.TightTextStyle
 
-internal val NODE_GUTTER = 40.dp
-private val TRACK_WIDTH = 1.5.dp
-private val PLAIN_DOT_SIZE = 8.dp
-private val ICON_DOT_SIZE = 24.dp
+internal val NODE_GUTTER = 48.dp
+
+/** Custom alignment line (Round 29) declared by the Latest hero's headline specifically — not a
+ *  built-in text baseline, since the hero's title also contains a kicker caption above the headline,
+ *  and letting Compose's automatic baseline propagation bubble up through that nesting risks merging
+ *  the wrong descendant's line. Only the headline itself ever declares this one (see
+ *  [Modifier.declareCenterAs]), so there's never more than one candidate value to merge — the merge
+ *  function is unreachable in practice. [TimelineNode]'s anchor and trailing-arrow Boxes align their
+ *  own centers to whatever value the title's descendant declares, via `RowScope.alignBy`, replacing
+ *  an earlier hand-computed padding offset that required guessing the kicker's exact rendered height
+ *  and didn't hold up on-device ("the alignment fix didn't work at all"). */
+internal val HeroHeadlineCenter = HorizontalAlignmentLine(merger = { old, _ -> old })
+
+/** Declares [line]'s value — for a `RowScope.alignBy` ancestor further up the tree — as exactly this
+ *  composable's own vertical center. Lets a non-Text composable (a Box, a Symbol's Canvas) act as the
+ *  thing another sibling aligns to, or as the thing that reads another descendant's declared line
+ *  (see [HeroHeadlineCenter]'s own use on the hero headline). */
+internal fun Modifier.declareCenterAs(line: HorizontalAlignmentLine): Modifier = layout { measurable, constraints ->
+    val placeable = measurable.measure(constraints)
+    layout(placeable.width, placeable.height, mapOf(line to placeable.height / 2)) {
+        placeable.place(0, 0)
+    }
+}
+
+/** Carved-socket tube width. Grown across rounds so every anchor fits with real padding and an
+ *  end-cap anchor can nest a meaningfully-sized concentric disc — see the end-cap radius logic in
+ *  [TimelineTrackOverlay]. Internal so the overlay and [LatestAnchor] can reference it. */
+internal val TRACK_WIDTH = Spacing.xxxxl
+
+/** Margin left uncarved between a cap anchor's own content disc and the track's edge — just the
+ *  track's own calmer color showing through around the anchor. Doubled from 2dp to 4dp (Round 18) so
+ *  a non-circular cap silhouette (Flower/Diamond) has real breathing room instead of nesting flush
+ *  against the stadium's rounded end, which read as cramped/jagged for anything but a plain circle.
+ *  Internal so [TimelineTrackOverlay] sizes the end-cap disc against it. */
+internal val CAP_ANCHOR_PADDING = Spacing.xs
+
+/** The one content diameter every cap anchor's disc/socket uses — sized so `contentRadius +
+ *  CAP_ANCHOR_PADDING == halfTrack` exactly, i.e. flush to the track's rounded end with
+ *  [CAP_ANCHOR_PADDING] of rim showing on every side. Deriving all four anchor types
+ *  (Plain/Icon/Loader/Latest) from this single formula makes the "no overflow past the track edge"
+ *  invariant structural: a future change to [TRACK_WIDTH] or [CAP_ANCHOR_PADDING] can't reintroduce
+ *  overflow — the stadium's own cap radius stays `halfTrack` regardless, so the anchor simply nests
+ *  with a wider or narrower rim inside that same cap. Internal so [LatestAnchor] shares it. */
+internal val FLUSH_ANCHOR_SIZE = TRACK_WIDTH - CAP_ANCHOR_PADDING * 2
+
+/** Interior (non-cap) anchors shrink to this diameter, leaving a wider rim of bare track around them
+ *  than a cap anchor — the Google-Maps transit read where a line's terminus/interchange station is a
+ *  bigger dot than the stops between. 24dp against [TRACK_WIDTH] = 40dp is an 8dp rim per side, clearly
+ *  smaller/nested versus [FLUSH_ANCHOR_SIZE]'s 4dp, not a rounding difference. The glyph itself
+ *  ([ICON_GLYPH_SIZE]) doesn't shrink — it just occupies more of its own smaller disc. */
+internal val INTERIOR_ANCHOR_SIZE = 24.dp
 private val ICON_GLYPH_SIZE = 18.dp
-private val LOADER_DOT_SIZE = 28.dp
 
-sealed interface TimelineAnchor {
+internal sealed interface TimelineAnchor {
     data object Plain : TimelineAnchor
     data class Icon(
         val symbol: MaterialSymbol,
         val tint: Color? = null,
         val containerColor: Color? = null,
+        val valence: TimelineValence = TimelineValence.Neutral,
     ) : TimelineAnchor
 
     data object Loader : TimelineAnchor
 
-    /** The single latest AI run — a morphing Material shape instead of a plain circle, sized up so
-     *  the newest entry reads first at a glance. */
+    /** The single latest AI run — a morphing Material shape instead of a plain circle, distinguished
+     *  by its animated silhouette. It shares the regular AI run's `primaryContainer` fill (the morph,
+     *  not a bolder color, is what sets it apart). Only nests at the cap size/shape when it's
+     *  genuinely a segment cap — `isLatest` does NOT guarantee `isSegmentTop`: an `Event` timestamped
+     *  more recently than the latest AI run (e.g. an alarm dismissed after last night's plan ran)
+     *  sorts above it, making the "latest" run an interior row despite the name. `TimelineNode`
+     *  normalizes it to a plain interior `Icon` in that case — see `effectiveAnchor`. */
     data class Latest(val symbol: MaterialSymbol) : TimelineAnchor
 }
 
-private fun TimelineAnchor.diameter(): Dp = when (this) {
-    TimelineAnchor.Plain -> PLAIN_DOT_SIZE
-    is TimelineAnchor.Icon -> ICON_DOT_SIZE
-    TimelineAnchor.Loader -> LOADER_DOT_SIZE
-    is TimelineAnchor.Latest -> LATEST_ANCHOR_SIZE
+/** Every anchor's full outer footprint is its own content disc plus [CAP_ANCHOR_PADDING] on each
+ *  side — the Row's layout height, and the box whose measured center the overlay carves its socket
+ *  at. The footprint always reserves the full [TRACK_WIDTH] (== [FLUSH_ANCHOR_SIZE] +
+ *  [CAP_ANCHOR_PADDING] × 2 by construction) so the Row height doesn't jump as an anchor
+ *  shrinks/grows between interior and cap; only the drawn content disc varies. */
+private fun TimelineAnchor.footprintDiameter(): Dp = FLUSH_ANCHOR_SIZE + CAP_ANCHOR_PADDING * 2
+
+/** A cap anchor (segment top/bottom, or a sleep sub-track's own onset/wake) nests flush against the
+ *  track's rounded end at [FLUSH_ANCHOR_SIZE]; every interior anchor shrinks to [INTERIOR_ANCHOR_SIZE].
+ *  Same two-size rule for all four anchor types — no per-type exception. */
+private fun contentDiameterFor(atCap: Boolean): Dp = if (atCap) FLUSH_ANCHOR_SIZE else INTERIOR_ANCHOR_SIZE
+
+/** The accent color the overlay fills this anchor's socket with — the visible disc for
+ *  [TimelineAnchor.Plain]/[TimelineAnchor.Icon]; the same color [TimelineAnchor.Loader]/
+ *  [TimelineAnchor.Latest] self-paint their content in on top of, so there's no seam. Every branch
+ *  now resolves through `trackAccentColor` (Round 27 — see its KDoc in `SessionTimeline.kt`): a
+ *  cap/interior [TimelineAnchor.Icon] or [TimelineAnchor.Plain] without its own `containerColor`
+ *  falls back to it directly, and [TimelineAnchor.Loader]/[TimelineAnchor.Latest] (previously a
+ *  flat hardcoded `primaryContainer` regardless of track) now use it too, so the spinner/hero morph
+ *  never clashes with the sleep track the way a fixed `primary`-family fill could. */
+@Composable
+private fun TimelineAnchor.socketAccentColor(isAsleep: Boolean): Color = when (this) {
+    TimelineAnchor.Plain -> trackAccentColor(isAsleep)
+    is TimelineAnchor.Icon -> containerColor ?: trackAccentColor(isAsleep)
+    TimelineAnchor.Loader -> trackAccentColor(isAsleep)
+    is TimelineAnchor.Latest -> trackAccentColor(isAsleep)
 }
 
 @Composable
 internal fun TimelineNode(
+    id: String,
+    registry: TimelineTrackRegistry,
     anchor: TimelineAnchor,
-    isFirst: Boolean,
-    isLast: Boolean,
+    isSegmentTop: Boolean,
+    isSegmentBottom: Boolean,
+    isAsleepAbove: Boolean,
+    isAsleepBelow: Boolean,
+    // Whether this row is genuinely new since the ViewModel's last emission — gates the Latest anchor's Circle→Cookie9Sided arrival morph, alongside registry.markEnteredOnce (a defensive second guard: isNewlyArrived alone doesn't rule out a row disposing/recomposing via rapid scroll churn within the same "new" window).
+    isNewlyArrived: Boolean = false,
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
     verticalPadding: Dp = Spacing.md,
@@ -88,18 +166,135 @@ internal fun TimelineNode(
     status: (@Composable () -> Unit)? = null,
     content: (@Composable () -> Unit)? = null,
 ) {
-    val ruleColor = MaterialTheme.colorScheme.surfaceContainerHighest
-    val anchorDiam = anchor.diameter()
-    // The Row's CenterVertically sizes it to max(anchorDiam, titleHeight); since anchorDiam typically >= titleHeight, the anchor sits at its own center = verticalPadding + anchorDiam/2.
-    val anchorCenter = verticalPadding + anchorDiam / 2
+    /** A cap anchor keeps the flush size; an interior one shrinks. Latest is always a segment top,
+     *  so it evaluates true with no special-casing (Google-Maps "first station is bigger"). */
+    val atCap = isSegmentTop || isSegmentBottom ||
+        (!isAsleepAbove && isAsleepBelow) || (isAsleepAbove && !isAsleepBelow)
+    /** An interior Icon anchor drops its semantic accent/valence entirely — shape and color both
+     *  fall back to the track-matched treatment below, rather than threading an `atCap` check
+     *  separately through the shape `when`, the socket color, and the glyph tint;
+     *  `socketAccentColor`'s `containerColor ?: trackAccentColor(...)` fallback just does the right
+     *  thing without knowing about `atCap` itself. A non-cap Latest anchor (see its own KDoc —
+     *  `isLatest` doesn't guarantee `isSegmentTop`) is converted into a plain interior Icon for the
+     *  same reason: "only cap anchors get custom shapes" applies to the morph as much as the
+     *  valence polygons, so it's normalized through the identical Icon path. */
+    val effectiveAnchor = when {
+        anchor is TimelineAnchor.Icon && !atCap -> anchor.copy(
+            tint = trackOnAccentColor(isAsleepAbove),
+            containerColor = null,
+            valence = TimelineValence.Neutral,
+        )
+        anchor is TimelineAnchor.Latest && !atCap -> TimelineAnchor.Icon(
+            symbol = anchor.symbol,
+            tint = trackOnAccentColor(isAsleepAbove),
+            containerColor = null,
+            valence = TimelineValence.Neutral,
+        )
+        else -> anchor
+    }
+    val anchorDiam = effectiveAnchor.footprintDiameter()
+    val titleSpacer = Spacing.md
+    val accentColor = effectiveAnchor.socketAccentColor(isAsleep = isAsleepAbove)
+    val targetRadiusPx = with(LocalDensity.current) { contentDiameterFor(atCap).toPx() / 2 }
+    /** Animates the size change so a row that stops being a cap (superseded by an insertion)
+     *  visibly shrinks instead of snapping; the *animated* value is what gets reported into the
+     *  registry. */
+    val contentRadiusPx by animateFloatAsState(
+        targetValue = targetRadiusPx,
+        animationSpec = MaterialTheme.motionScheme.defaultSpatialSpec(),
+        label = "anchor-radius",
+    )
 
-    // The Latest anchor is visually heavier, so it gets a bigger gap to the title; content below (same left edge as the title) must track the same value or the two columns drift apart.
-    val titleSpacer = if (anchor is TimelineAnchor.Latest) Spacing.md else Spacing.xs
+    /** Hoisted above the shape derivation (not down by the Surface below) so a clickable row's
+     *  shape itself can react to press, rather than a whole-row scale transform that visually
+     *  decouples from this overlay-drawn socket. Harmless to compute even when `onClick` is null —
+     *  `pressed` just never turns true without a `Surface.onClick` feeding these events. */
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed by interactionSource.collectIsPressedAsState()
+    /** `fastSpatialSpec`, checked against the actual token values
+     *  (`androidx.compose.material3.tokens.ExpressiveMotionTokens`): fast is dampingRatio=0.6 /
+     *  stiffness=800 vs slow's 0.8 / 200 — genuinely more underdamped (more overshoot) as well as
+     *  quicker to settle, i.e. "faster and bouncier." */
+    val pressMorphProgress by animateFloatAsState(
+        targetValue = if (pressed) 1f else 0f,
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        label = "timeline-node-press-morph",
+    )
+
+    /** The Latest morph's progress is hoisted here and exposed to the overlay via the reported
+     *  `AnchorShape.MorphShape` so the socket carve animates in lockstep with the row's arrival.
+     *  Gated below on [isNewlyArrived] (survives navigation, unlike a bare composition check) *and*
+     *  `registry.markEnteredOnce` (a defensive second guard against rapid scroll-churn
+     *  disposing/recomposing this row within the same "new" window) — an unconditional effect here
+     *  would replay this morph on every fresh mount regardless of whether the row is actually new
+     *  data. */
+    val latestMorph = remember { Morph(MaterialShapes.Circle, MaterialShapes.Cookie9Sided) }
+    /** Unconditional (not short-circuited by the `&&` below) so this composable call happens the
+     *  same way on every recomposition regardless of the other flags — Compose's slot table expects
+     *  the same sequence of composable calls call-over-call, not one gated behind a boolean that can
+     *  itself change between recompositions. */
+    val enteredOnce = remember(id) { registry.markEnteredOnce(id) }
+    val playsArrival = isNewlyArrived && atCap && anchor is TimelineAnchor.Latest && enteredOnce
+    val latestProgress = remember(id) { Animatable(if (playsArrival) 0f else 1f) }
+    if (anchor is TimelineAnchor.Latest && atCap) {
+        val arriveSpec = MaterialTheme.motionScheme.slowSpatialSpec<Float>()
+        LaunchedEffect(id) {
+            if (playsArrival) latestProgress.animateTo(1f, arriveSpec) else latestProgress.snapTo(1f)
+        }
+    }
+    /** A clickable Neutral cap's plain Circle morphs toward this distinct silhouette while
+     *  pressed — Cookie6Sided rather than Latest's own Cookie9Sided so the two "selected" cues stay
+     *  visually distinguishable. At `pressMorphProgress == 0` this renders pixel-identical to a
+     *  plain Circle, so it's safe to use unconditionally for every clickable cap. */
+    val pressCapMorph = remember { Morph(MaterialShapes.Circle, MaterialShapes.Cookie6Sided) }
+    val isClickable = onClick != null
+    /** A clickable interior Pill needs no Morph of its own — its press target is a plain
+     *  `drawRoundRect` whose corner radius and height both animate off `pressMorphProgress`
+     *  directly in `TimelineTrackOverlay.kt`; see [AnchorShape.Pill]'s KDoc for why a Morph-based
+     *  approach here produces a broken "butterfly" mid-press silhouette. */
+    val shape = remember(effectiveAnchor, latestMorph, pressCapMorph, atCap, isClickable) {
+        when (effectiveAnchor) {
+            is TimelineAnchor.Latest -> AnchorShape.MorphShape(latestMorph) { latestProgress.value }
+            // A non-cap Icon is already normalized to Neutral valence above, so the Neutral branch is reached by every interior anchor — gated on atCap since a genuinely Neutral CAP anchor must stay a circle, only an interior one becomes a pill.
+            is TimelineAnchor.Icon -> when (effectiveAnchor.valence) {
+                TimelineValence.Positive -> AnchorShape.Polygon(MaterialShapes.Flower)
+                // Triangle's centroid sits below its bounding-box center, so a glyph centered on the bbox reads as sitting too high; Diamond (a square rotated 45°) is symmetric on both axes, so bbox-centering is also visual-centering — still reads sharper/"less positive" than Flower/Circle.
+                TimelineValence.Negative -> AnchorShape.Polygon(MaterialShapes.Diamond)
+                TimelineValence.Neutral -> when {
+                    atCap && isClickable -> AnchorShape.MorphShape(pressCapMorph) { pressMorphProgress }
+                    atCap -> AnchorShape.Circle
+                    isClickable -> AnchorShape.Pill(pressProgress = { pressMorphProgress })
+                    else -> AnchorShape.Pill()
+                }
+            }
+            TimelineAnchor.Plain -> when {
+                atCap && isClickable -> AnchorShape.MorphShape(pressCapMorph) { pressMorphProgress }
+                atCap -> AnchorShape.Circle
+                isClickable -> AnchorShape.Pill(pressProgress = { pressMorphProgress })
+                else -> AnchorShape.Pill()
+            }
+            TimelineAnchor.Loader -> AnchorShape.Circle
+        }
+    }
+
+    SideEffect {
+        registry.setDescriptor(
+            id,
+            AnchorDescriptor(
+                contentRadiusPx = contentRadiusPx,
+                shape = shape,
+                accentColor = accentColor,
+                isSegmentTop = isSegmentTop,
+                isSegmentBottom = isSegmentBottom,
+                asleepAbove = isAsleepAbove,
+                asleepBelow = isAsleepBelow,
+            ),
+        )
+    }
+    DisposableEffect(id) { onDispose { registry.remove(id) } }
 
     val inner = @Composable {
         Column(modifier = Modifier.fillMaxWidth()) {
-            // includeFontPadding=true shifts the visual glyph center above the circle center; TightTextStyle strips it.
-            CompositionLocalProvider(LocalTextStyle provides LocalTextStyle.current.merge(TightTextStyle)) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -107,25 +302,43 @@ internal fun TimelineNode(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Box(
-                    // The Latest anchor's title can wrap past its own height (unlike every other row) — top-align it there so it stays flush with anchorCenter instead of drifting to the taller row's true center, which would desync the drawn track line.
+                    // The Latest anchor's title can wrap past the anchor's own height, unlike every other row — align to HeroHeadlineCenter rather than the row's whole-height center so it lines up with the headline specifically; alignBy has Compose measure the real value instead of a hand-computed offset.
                     modifier = Modifier
                         .width(NODE_GUTTER)
-                        .let { if (anchor is TimelineAnchor.Latest) it.align(Alignment.Top) else it },
+                        .let { if (anchor is TimelineAnchor.Latest) it.alignBy { measured -> measured.measuredHeight / 2 } else it },
                     contentAlignment = Alignment.Center,
                 ) {
-                    AnchorCircle(anchor)
+                    Box(
+                        modifier = Modifier
+                            .size(anchorDiam)
+                            // Registers the live LayoutCoordinates handle, not a computed Offset — see TimelineTrackOverlay.kt's KDoc for why a cached snapshot can go stale mid-transition; the overlay queries it fresh at draw time.
+                            .onGloballyPositioned { coords -> registry.setPosition(id, coords) },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        AnchorContent(effectiveAnchor, isAsleep = isAsleepAbove)
+                    }
                 }
                 Spacer(Modifier.width(titleSpacer))
-                Box(modifier = Modifier.weight(1f).wrapContentHeight()) { title() }
-                if (status != null) status()
+                Box(
+                    modifier = Modifier.weight(1f).wrapContentHeight()
+                        .let { if (anchor is TimelineAnchor.Latest) it.alignBy(HeroHeadlineCenter) else it },
+                ) { title() }
+                if (status != null) {
+                    Box(
+                        // Same HeroHeadlineCenter alignment as the anchor gutter above, so the trailing arrow (the Latest row's only status content while latest) lines up with the headline too, not the row's whole-height center.
+                        modifier = Modifier.let {
+                            if (anchor is TimelineAnchor.Latest) it.alignBy { measured -> measured.measuredHeight / 2 } else it
+                        },
+                    ) { status() }
+                }
             }
-            }
+            // Text in title()/status()/content() always passes an explicit `style`, which bypasses LocalTextStyle entirely — font-padding leading fixes belong on each style itself (CronTypography's timeline roles are built on `tight` directly in Type.kt; ad hoc bodyMedium uses merge TightTextStyle locally, see EventNode.kt/SessionTimeline.kt), not a CompositionLocalProvider here.
             if (content != null) {
                 Box(
                     modifier = Modifier.padding(
                         start = NODE_GUTTER + titleSpacer,
                         end = Spacing.md,
-                        top = Spacing.sm,
+                        top = Spacing.xxs,
                     ),
                 ) { content() }
             }
@@ -133,33 +346,14 @@ internal fun TimelineNode(
         }
     }
 
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .drawBehind {
-                if (isFirst && isLast) return@drawBehind
-                val cx = (NODE_GUTTER / 2).toPx()
-                val center = anchorCenter.toPx()
-                val top = if (isFirst) center else 0f
-                val bottom = if (isLast) center else size.height
-                drawLine(ruleColor, Offset(cx, top), Offset(cx, bottom), TRACK_WIDTH.toPx(), StrokeCap.Round)
-            },
-    ) {
+    Box(modifier = modifier.fillMaxWidth()) {
         if (onClick != null) {
-            val interactionSource = remember { MutableInteractionSource() }
-            val pressed by interactionSource.collectIsPressedAsState()
-            val pressScale by animateFloatAsState(
-                targetValue = if (pressed) 0.98f else 1f,
-                animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-                label = "timeline-node-press-scale",
-            )
             Surface(
                 onClick = onClick,
                 interactionSource = interactionSource,
-                // Bleeds the tap/ripple target to the screen edges past HomeContent's LazyColumn contentPadding; the compensating padding below keeps inner() at its original position.
+                // Bleeds the tap/ripple target to the true screen edges past HomeContent's LazyColumn contentPadding (compensating padding below keeps inner() in place); no scale/graphicsLayer here — press feedback lives entirely in the anchor's own shape morph, which the overlay draws at its true registered position.
                 modifier = Modifier
                     .fillMaxWidth()
-                    .graphicsLayer { scaleX = pressScale; scaleY = pressScale }
                     .bleedHorizontally(Spacing.xl),
                 color = Color.Transparent,
                 contentColor = MaterialTheme.colorScheme.onSurface,
@@ -172,132 +366,25 @@ internal fun TimelineNode(
     }
 }
 
+/** Draws only the anchor's own foreground — the glyph or loading indicator — on top of the socket
+ *  the overlay already filled behind it. Plain has no foreground: the overlay's accent disc *is* the
+ *  dot. Transparent background throughout; the container disc is the overlay's job now. */
 @Composable
-private fun AnchorCircle(anchor: TimelineAnchor) {
+private fun AnchorContent(anchor: TimelineAnchor, isAsleep: Boolean) {
     when (anchor) {
-        TimelineAnchor.Plain -> {
-            Box(
-                modifier = Modifier
-                    .size(PLAIN_DOT_SIZE)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.outlineVariant),
-            )
-        }
-        is TimelineAnchor.Icon -> {
-            val bg = anchor.containerColor ?: MaterialTheme.colorScheme.surfaceContainerHigh
-            val fg = anchor.tint ?: MaterialTheme.colorScheme.onSurfaceVariant
-            Box(
-                modifier = Modifier
-                    .size(ICON_DOT_SIZE)
-                    .clip(CircleShape)
-                    .background(bg),
-                contentAlignment = Alignment.Center,
-            ) {
-                Symbol(
-                    symbol = anchor.symbol,
-                    contentDescription = null,
-                    tint = fg,
-                    size = ICON_GLYPH_SIZE,
-                )
-            }
-        }
-        TimelineAnchor.Loader -> {
-            ContainedLoadingIndicator(
-                modifier = Modifier.size(LOADER_DOT_SIZE),
-                containerShape = CircleShape,
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                indicatorColor = MaterialTheme.colorScheme.primary,
-            )
-        }
-        is TimelineAnchor.Latest -> LatestAnchor(symbol = anchor.symbol)
-    }
-}
-
-@Preview(showBackground = true, name = "Anchor states")
-@Composable
-private fun TimelineNodeAnchorsPreview() {
-    CronTheme {
-        Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
-            TimelineNode(
-                anchor = TimelineAnchor.Loader,
-                isFirst = true,
-                isLast = false,
-                title = { Text("Replanning...", style = MaterialTheme.typography.bodyMedium) },
-                status = { Text("07:16", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-            )
-            TimelineNode(
-                anchor = TimelineAnchor.Icon(MaterialSymbol.Snooze),
-                isFirst = false,
-                isLast = false,
-                title = { Text("Alarm snoozed", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-                status = {
-                    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm), verticalAlignment = Alignment.CenterVertically) {
-                        MonoPill("9 min")
-                        Text("07:15", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    }
-                },
-            )
-            TimelineNode(
-                anchor = TimelineAnchor.Icon(
-                    symbol = MaterialSymbol.Schedule,
-                    tint = MaterialTheme.colorScheme.primary,
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                ),
-                isFirst = false,
-                isLast = false,
-                onClick = {},
-                title = { Text("Planned", style = MaterialTheme.typography.bodyMedium) },
-                status = { Text("Latest · 23:14", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-            )
-            TimelineNode(
-                anchor = TimelineAnchor.Plain,
-                isFirst = false,
-                isLast = false,
-                title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-                status = { Text("23:40", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-            )
-            TimelineNode(
-                anchor = TimelineAnchor.Icon(MaterialSymbol.Bedtime),
-                isFirst = false,
-                isLast = true,
-                title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-                status = { Text("22:30", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-            )
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "Node with content area")
-@Composable
-private fun TimelineNodeWithContentPreview() {
-    CronTheme {
-        Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
-            TimelineNode(
-                anchor = TimelineAnchor.Icon(
-                    symbol = MaterialSymbol.Schedule,
-                    tint = MaterialTheme.colorScheme.primary,
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                ),
-                isFirst = true,
-                isLast = false,
-                onClick = {},
-                title = { Text("Planned", style = MaterialTheme.typography.bodyMedium) },
-                status = { Text("Latest · 23:14", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-                content = {
-                    Text(
-                        "Set alarm for 07:45. You have an 08:30 standup.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                },
-            )
-            TimelineNode(
-                anchor = TimelineAnchor.Icon(MaterialSymbol.Bedtime),
-                isFirst = false,
-                isLast = true,
-                title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-                status = { Text("23:40", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-            )
-        }
+        TimelineAnchor.Plain -> Unit
+        is TimelineAnchor.Icon -> Symbol(
+            symbol = anchor.symbol,
+            contentDescription = null,
+            tint = anchor.tint ?: MaterialTheme.colorScheme.onSurfaceVariant,
+            size = ICON_GLYPH_SIZE,
+        )
+        TimelineAnchor.Loader -> ContainedLoadingIndicator(
+            modifier = Modifier.size(FLUSH_ANCHOR_SIZE),
+            containerShape = CircleShape,
+            containerColor = trackAccentColor(isAsleep),
+            indicatorColor = trackOnAccentColor(isAsleep),
+        )
+        is TimelineAnchor.Latest -> LatestAnchor(symbol = anchor.symbol, isAsleep = isAsleep)
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineNodePreviews.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineNodePreviews.kt
@@ -1,0 +1,157 @@
+package fr.bsodium.cron.ui.screens.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import fr.bsodium.cron.ui.theme.CronColors
+import fr.bsodium.cron.ui.theme.CronTheme
+import fr.bsodium.cron.ui.theme.CronTypography
+import fr.bsodium.cron.ui.theme.MaterialSymbol
+import fr.bsodium.cron.ui.theme.Spacing
+
+@PreviewLightDark
+@Composable
+private fun TimelineNodeAnchorsPreview() {
+    CronTheme {
+        val registry = rememberTimelineTrackRegistry()
+        Box(modifier = Modifier.fillMaxSize().background(CronColors.pageBackground)) {
+            TimelineTrackOverlay(registry = registry)
+            Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                TimelineNode(
+                    id = "loader",
+                    registry = registry,
+                    anchor = TimelineAnchor.Loader,
+                    isSegmentTop = true,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    title = { Text("Replanning...", style = MaterialTheme.typography.bodyMedium) },
+                    status = { Text("07:16", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                )
+                TimelineNode(
+                    id = "snooze",
+                    registry = registry,
+                    // Negative valence → Triangle silhouette, interior (smaller) size.
+                    anchor = TimelineAnchor.Icon(MaterialSymbol.Snooze, valence = TimelineValence.Negative),
+                    isSegmentTop = false,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    title = { Text("Alarm snoozed", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                    status = {
+                        Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm), verticalAlignment = Alignment.CenterVertically) {
+                            MonoPill("9 min")
+                            Text("07:15", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    },
+                )
+                TimelineNode(
+                    id = "gotup",
+                    registry = registry,
+                    // Positive valence → Flower silhouette, interior size.
+                    anchor = TimelineAnchor.Icon(MaterialSymbol.DirectionsWalk, valence = TimelineValence.Positive),
+                    isSegmentTop = false,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    title = { Text("You got up", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                    status = { Text("07:50", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                )
+                TimelineNode(
+                    id = "planned",
+                    registry = registry,
+                    // Interior (isSegmentTop/Bottom both false) — TimelineNode's own normalization discards this tint/containerColor and substitutes the track-crossed pill treatment regardless, same as real production AiRunNode/EventNode rows.
+                    anchor = TimelineAnchor.Icon(symbol = MaterialSymbol.Schedule),
+                    isSegmentTop = false,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    onClick = {},
+                    title = { Text("Planned", style = MaterialTheme.typography.bodyMedium) },
+                    status = { Text("Latest · 23:14", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                )
+                // The onset row itself: awake above, asleep below — the sleep pill opens its own rounded cap right at this anchor.
+                TimelineNode(
+                    id = "onset",
+                    registry = registry,
+                    anchor = TimelineAnchor.Plain,
+                    isSegmentTop = false,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = true,
+                    title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                    status = { Text("23:40", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                )
+                TimelineNode(
+                    id = "evening",
+                    registry = registry,
+                    anchor = TimelineAnchor.Icon(MaterialSymbol.Bedtime),
+                    isSegmentTop = false,
+                    isSegmentBottom = true,
+                    isAsleepAbove = true,
+                    isAsleepBelow = true,
+                    title = { Text("Evening plan", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                    status = { Text("22:30", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                )
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun TimelineNodeWithContentPreview() {
+    CronTheme {
+        val registry = rememberTimelineTrackRegistry()
+        Box(modifier = Modifier.fillMaxSize().background(CronColors.pageBackground)) {
+            TimelineTrackOverlay(registry = registry)
+            Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                TimelineNode(
+                    id = "planned",
+                    registry = registry,
+                    // Cap anchor (isSegmentTop = true) — mirrors AiRunNode's real solid-role treatment for a cap icon (primary/onPrimary), not the washed-out primaryContainer/onPrimaryContainer a *Container role reads as against the track (docs/color-roles.md).
+                    anchor = TimelineAnchor.Icon(
+                        symbol = MaterialSymbol.Schedule,
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        containerColor = MaterialTheme.colorScheme.primary,
+                    ),
+                    isSegmentTop = true,
+                    isSegmentBottom = false,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    onClick = {},
+                    title = { Text("Planned", style = MaterialTheme.typography.bodyMedium) },
+                    status = { Text("Latest · 23:14", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                    content = {
+                        Text(
+                            "Set alarm for 07:45. You have an 08:30 standup.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                )
+                TimelineNode(
+                    id = "asleep",
+                    registry = registry,
+                    anchor = TimelineAnchor.Icon(MaterialSymbol.Bedtime),
+                    isSegmentTop = false,
+                    isSegmentBottom = true,
+                    isAsleepAbove = false,
+                    isAsleepBelow = false,
+                    title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                    status = { Text("23:40", style = CronTypography.labelMonoSmall, color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineTrackOverlay.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineTrackOverlay.kt
@@ -1,0 +1,339 @@
+package fr.bsodium.cron.ui.screens.home.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+
+/** Thickness of the center-line spine — thin, a detail line rather than another track. */
+private val SPINE_WIDTH = 2.dp
+
+/** Buffer added to each anchor's content radius to open a gap in the spine around that anchor. */
+private val SPINE_GAP = 8.dp
+
+/** How much of `onSurfaceVariant` blends into the awake spine — the rest is the track's own fill
+ *  (Round 23: reverted the Round 21/22 outline-stroke track back to a plain fill, so the spine now
+ *  needs to visibly stand out against that fill rather than against a hairline boundary. Blending
+ *  toward `onSurfaceVariant` — the M3 role calibrated to read clearly on top of surface-family
+ *  tones, which `surfaceContainerHigh` is — gives the line real presence without the earlier
+ *  background-blend approach, which only worked when the track itself was a near-invisible stroke). */
+private const val AWAKE_SPINE_BLEND = 0.45f
+
+/** How much of `onSecondary` blends into the asleep spine — still a minority (subtle, "closer to
+ *  the background" than a full-strength line), but more than the awake blend so it keeps a touch
+ *  more presence ("elevated") against the bolder, darker sleep track. `onSecondary` (not `onPrimary`)
+ *  since Round 21 moved the sleep track itself from `primary` to `secondary`. */
+private const val ASLEEP_SPINE_BLEND = 0.4f
+
+/** Corner radius (as a fraction of a fully-pressed [AnchorShape.Pill]'s square footprint width) a
+ *  pressed Pill's `drawRoundRect` shrinks toward — matches `MaterialShapes.Square`'s own rounding
+ *  (`CornerRounding(radius = 0.3f)` on a unit `RoundedPolygon.rectangle`, read from the M3 source),
+ *  so the plain-geometry replacement (Round 27.10) still lands on a recognizably "rounded square"
+ *  corner rather than an arbitrary guess. */
+private const val SQUARE_CORNER_FRACTION = 0.3f
+
+/** The whole timeline track, painted once behind every row. Reads live anchor geometry from
+ *  [registry] and draws one continuous set of paths — a round-capped background stadium per segment,
+ *  continuous sleep pills, and each anchor's accent socket on top. Because the track is a single
+ *  painter rather than a slice per row, it can't gap or re-cap while rows glide/fade in and out: the
+ *  caps simply track the top/bottom anchor's live position. See docs/color-roles.md Round 13.
+ *
+ *  Every draw call below fills at full, constant opacity — no scroll-derived fade-in, since elements
+ *  must stay fully visible as long as any part of them is on screen. A row disposing while still
+ *  visually on-screen can still cause a visible pop; see [computePlacedAnchors]' KDoc for the current
+ *  state of that issue.
+ *
+ *  Overscroll stretch is rendered by a single `Modifier.overscroll` on the parent Box that wraps
+ *  both this overlay and the LazyColumn, so the track and the row content it sits under stretch as
+ *  one subtree, with no shear. See the AndroidX `OverscrollRenderedOnTopOfLazyListDecorations`
+ *  sample for the canonical single-render pattern.
+ *
+ *  [registry]'s anchor positions are live [LayoutCoordinates] handles ([AnchorPosition]), queried
+ *  fresh at draw time in [computePlacedAnchors] rather than cached — a cached `Offset` goes stale
+ *  across any nav transition that scales/fades the subtree without retriggering layout (a
+ *  draw-phase-only `graphicsLayer` transform, as `MainActivity.kt`'s tab transitions use), since each
+ *  row's `onGloballyPositioned` only fires once, at its own placement frame. See docs/color-roles.md
+ *  for the full history. The flush-to-screen-edge flash on a new arrival is covered in
+ *  [drawSegment]'s KDoc. */
+@Composable
+internal fun TimelineTrackOverlay(
+    registry: TimelineTrackRegistry,
+    modifier: Modifier = Modifier,
+    visible: Boolean = true,
+) {
+    val awakeColor = trackColorFor(isAsleep = false)
+    val asleepColor = trackColorFor(isAsleep = true)
+    // A minority blend toward a role that reads on the track's own fill — a hint of a line, not a drawn boundary; a by-eye starting point, adjust if it doesn't read live.
+    val awakeSpineColor = lerp(awakeColor, MaterialTheme.colorScheme.onSurfaceVariant, AWAKE_SPINE_BLEND)
+    val asleepSpineColor = lerp(asleepColor, MaterialTheme.colorScheme.onSecondary, ASLEEP_SPINE_BLEND)
+    val scratch = remember { android.graphics.Path() }
+    var overlayCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .onGloballyPositioned { overlayCoordinates = it }
+            .drawBehind {
+                // Read directly in the draw phase (not via derivedStateOf) so a position change redraws the same frame with no recomposition round-trip; see computePlacedAnchors.
+                if (visible) {
+                    val placed = computePlacedAnchors(registry, overlayCoordinates)
+                    drawTrack(placed, awakeColor, asleepColor, awakeSpineColor, asleepSpineColor, scratch)
+                }
+            },
+    )
+}
+
+private class PlacedAnchor(val id: String, val descriptor: AnchorDescriptor, val cx: Float, val cy: Float)
+
+private class SleepPill(val top: Float, val bottom: Float, val roundTop: Boolean, val roundBottom: Boolean)
+
+/** Reads every currently-registered anchor's live position and returns it. Returns an empty list
+ *  while this overlay's own coordinates aren't attached yet (the first frame or two of any mount).
+ *
+ *  Every position is queried live from the stored [LayoutCoordinates] handle ([AnchorPosition]) at
+ *  call time, never cached, so a draw-phase call always reflects the current coordinate system. Uses
+ *  [LayoutCoordinates.localPositionOf] to map the anchor's own local center directly into the
+ *  overlay's local space in one step — a window-space delta would get double-scaled inside
+ *  `MainActivity.kt`'s nav transition. Draws only what's currently registered; a disposed row's
+ *  position is not cached or filtered against scroll state. This means a row disposing while still
+ *  visually on-screen can flicker — an open issue, see docs/color-roles.md for prior attempts. A fix
+ *  should control `LazyColumn`'s own beyond-viewport composition margin directly rather than caching
+ *  or second-guessing its disposal decisions from outside. */
+private fun computePlacedAnchors(
+    registry: TimelineTrackRegistry,
+    overlayCoordinates: LayoutCoordinates?,
+): List<PlacedAnchor> {
+    val overlay = overlayCoordinates?.takeIf { it.isAttached } ?: return emptyList()
+    return registry.descriptors.keys.mapNotNull { id ->
+        val descriptor = registry.descriptors[id] ?: return@mapNotNull null
+        val coords = registry.positions[id]?.coordinates?.takeIf { it.isAttached } ?: return@mapNotNull null
+        val center = Offset(coords.size.width / 2f, coords.size.height / 2f)
+        val local = overlay.localPositionOf(coords, center)
+        PlacedAnchor(id, descriptor, local.x, local.y)
+    }
+}
+
+private fun DrawScope.drawTrack(
+    placed: List<PlacedAnchor>,
+    awakeColor: Color,
+    asleepColor: Color,
+    awakeSpineColor: Color,
+    asleepSpineColor: Color,
+    scratch: android.graphics.Path,
+) {
+    if (placed.isEmpty()) return
+
+    val halfTrack = TRACK_WIDTH.toPx() / 2
+    // Every anchor centers in the same fixed-width gutter; averaging their x's is order-independent and self-corrects if one row's position lands a frame stale.
+    val trackCenterX = placed.map { it.cx }.average().toFloat()
+    val corner = CornerRadius(halfTrack)
+
+    drawSegment(
+        anchors = placed.sortedBy { it.cy },
+        trackCenterX = trackCenterX,
+        halfTrack = halfTrack,
+        corner = corner,
+        awakeColor = awakeColor,
+        asleepColor = asleepColor,
+        awakeSpineColor = awakeSpineColor,
+        asleepSpineColor = asleepSpineColor,
+        scratch = scratch,
+    )
+}
+
+/** [roundTop]/[roundBottom] — a cap only rounds when the segment's true end is confirmed on-screen;
+ *  otherwise the track runs flush to the viewport edge, implying it continues off-screen.
+ *
+ *  Driven by `descriptor.isSegmentTop`/`isSegmentBottom`, computed fresh from `uiState.timeline` on
+ *  every recomposition (`SessionTimeline.kt`'s `firstAnchorIndex`/`lastAnchorIndex`), so it never
+ *  races with scrolling — scrolling doesn't change `uiState.timeline` at all. A narrow case (a stale
+ *  reading right after a new anchor is prepended and hasn't registered yet, flushing the track to the
+ *  screen edge under the alarm card) is real but rare and not yet addressed; see docs/color-roles.md
+ *  for prior attempts and why they made things worse. */
+private fun DrawScope.drawSegment(
+    anchors: List<PlacedAnchor>,
+    trackCenterX: Float,
+    halfTrack: Float,
+    corner: CornerRadius,
+    awakeColor: Color,
+    asleepColor: Color,
+    awakeSpineColor: Color,
+    asleepSpineColor: Color,
+    scratch: android.graphics.Path,
+) {
+    val top = anchors.first()
+    val bottom = anchors.last()
+    val roundTop = top.descriptor.isSegmentTop
+    val roundBottom = bottom.descriptor.isSegmentBottom
+    // Cap edge sits a full halfTrack beyond the terminal anchor's center (not at it) so the anchor nests concentrically inside the cap's rounded corner.
+    val bgTop = if (roundTop) top.cy - halfTrack else 0f
+    val bgBottom = if (roundBottom) bottom.cy + halfTrack else size.height
+    val left = trackCenterX - halfTrack
+    val right = trackCenterX + halfTrack
+
+    // Plain fill; the sleep pills drawn after naturally cover their own range, no separate "subtract" geometry needed. See trackColorFor's KDoc for the fill-vs-outline history.
+    drawPath(cappedRect(left, bgTop, right, bgBottom, roundTop, roundBottom, corner), awakeColor)
+
+    val pills = buildSleepPills(anchors, bgTop, bgBottom, roundTop, roundBottom, halfTrack)
+    pills.forEach { pill ->
+        drawPath(cappedRect(left, pill.top, right, pill.bottom, pill.roundTop, pill.roundBottom, corner), asleepColor)
+    }
+
+    // Spine layered like the fills above: awake color across the whole segment, then each sleep pill's own stretch overpainted in the asleep color.
+    drawSpine(anchors, bgTop, bgBottom, trackCenterX, awakeSpineColor)
+    pills.forEach { pill ->
+        drawSpine(anchors, pill.top, pill.bottom, trackCenterX, asleepSpineColor)
+    }
+
+    anchors.forEach { anchor ->
+        drawSocket(anchor, scratch)
+    }
+}
+
+/** Draws the thin center-line "spine" down [trackCenterX] across [top]..[bottom], leaving a
+ *  [SPINE_GAP]-buffered gap around each anchor's own drawn shape so the line never runs through a
+ *  socket. Called once per segment for the awake stretch, then once per sleep pill (with that pill's
+ *  own extent) so the asleep color overpaints its sub-range — the same whole-then-overlay layering the
+ *  background/sleep-pill fills already use. */
+private fun DrawScope.drawSpine(
+    anchors: List<PlacedAnchor>,
+    top: Float,
+    bottom: Float,
+    trackCenterX: Float,
+    color: Color,
+) {
+    val gap = SPINE_GAP.toPx()
+    val strokeWidth = SPINE_WIDTH.toPx()
+    // Draws the complement of every in-range anchor's gap-range within [top, bottom].
+    var cursor = top
+    anchors
+        .filter { it.cy in top..bottom }
+        .forEach { anchor ->
+            val gapRadius = anchor.descriptor.contentRadiusPx + gap
+            val gapStart = anchor.cy - gapRadius
+            val gapEnd = anchor.cy + gapRadius
+            if (gapStart > cursor) {
+                drawLine(color, Offset(trackCenterX, cursor), Offset(trackCenterX, gapStart), strokeWidth, StrokeCap.Round)
+            }
+            cursor = maxOf(cursor, gapEnd)
+        }
+    if (bottom > cursor) {
+        drawLine(color, Offset(trackCenterX, cursor), Offset(trackCenterX, bottom), strokeWidth, StrokeCap.Round)
+    }
+}
+
+/** Fills one anchor's socket with its accent. A cap anchor's content radius is already flush
+ *  (`== halfTrack - CAP_ANCHOR_PADDING`), so a circular socket fills the track to the same thin rim
+ *  everywhere — no cap-only inflation needed. The Latest morph is bounded within the same flush
+ *  diameter by [buildMorphPath]'s scale-to-fit, so it nests just as flush without ever overflowing.
+ *  An interior [AnchorShape.Pill] is full [TimelineNode]'s `FLUSH_ANCHOR_SIZE` wide (matching a cap
+ *  anchor's own width, per spec) but only `2 × contentRadiusPx` tall by default — a plain
+ *  `drawRoundRect` capsule whose height grows to meet that width and whose corner radius shrinks
+ *  toward [SQUARE_CORNER_FRACTION] of that width as [AnchorShape.Pill.pressProgress] goes 0→1, so an
+ *  unpressed/non-clickable Pill (always `pressProgress() == 0`) renders the exact same full capsule
+ *  either way. */
+private fun DrawScope.drawSocket(anchor: PlacedAnchor, scratch: android.graphics.Path) {
+    val d = anchor.descriptor
+    when (val shape = d.shape) {
+        AnchorShape.Circle -> drawCircle(d.accentColor, radius = d.contentRadiusPx, center = Offset(anchor.cx, anchor.cy))
+        is AnchorShape.Pill -> {
+            val pillWidth = FLUSH_ANCHOR_SIZE.toPx()
+            val pressed = shape.pressProgress().coerceIn(0f, 1f)
+            val pillHeight = lerp(d.contentRadiusPx * 2, pillWidth, pressed)
+            val cornerRadius = lerp(pillHeight / 2f, pillWidth * SQUARE_CORNER_FRACTION, pressed)
+            drawRoundRect(
+                color = d.accentColor,
+                topLeft = Offset(anchor.cx - pillWidth / 2f, anchor.cy - pillHeight / 2f),
+                size = Size(pillWidth, pillHeight),
+                cornerRadius = CornerRadius(cornerRadius),
+            )
+        }
+        is AnchorShape.Polygon -> drawPath(
+            buildPolygonPath(shape.polygon, anchor.cx, anchor.cy, d.contentRadiusPx * 2, scratch),
+            d.accentColor,
+        )
+        is AnchorShape.MorphShape -> drawPath(
+            buildMorphPath(shape.morph, shape.progress(), anchor.cx, anchor.cy, d.contentRadiusPx * 2, scratch),
+            d.accentColor,
+        )
+    }
+}
+
+/** Walks a segment's anchors top→bottom and emits one rounded pill per contiguous asleep run. A run
+ *  open above the topmost visible anchor (or still open below the bottom one) extends to [bgTop]/
+ *  [bgBottom] and only rounds there if that edge is a real segment cap — so a sleep stretch continues
+ *  seamlessly off the visible range instead of capping mid-scroll. */
+private fun buildSleepPills(
+    anchors: List<PlacedAnchor>,
+    bgTop: Float,
+    bgBottom: Float,
+    roundTop: Boolean,
+    roundBottom: Boolean,
+    halfTrack: Float,
+): List<SleepPill> {
+    val pills = mutableListOf<SleepPill>()
+    val startsAsleep = anchors.first().descriptor.asleepAbove
+    var openTop: Float? = if (startsAsleep) bgTop else null
+    var openRounded = if (startsAsleep) roundTop else false
+    for (anchor in anchors) {
+        val above = anchor.descriptor.asleepAbove
+        val below = anchor.descriptor.asleepBelow
+        // Same concentric-cap rule as the background — see drawSegment's comment on cap-edge placement.
+        if (above && !below) {
+            pills += SleepPill(openTop ?: (anchor.cy - halfTrack), anchor.cy + halfTrack, openRounded, roundBottom = true)
+            openTop = null
+        } else if (!above && below) {
+            openTop = anchor.cy - halfTrack
+            openRounded = true
+        }
+    }
+    val trailingOpen = openTop
+    if (anchors.last().descriptor.asleepBelow && trailingOpen != null) {
+        pills += SleepPill(trailingOpen, bgBottom, openRounded, roundBottom)
+    }
+    return pills
+}
+
+private fun cappedRect(
+    left: Float,
+    top: Float,
+    right: Float,
+    bottom: Float,
+    roundTop: Boolean,
+    roundBottom: Boolean,
+    corner: CornerRadius,
+): Path {
+    val zero = CornerRadius.Zero
+    return Path().apply {
+        addRoundRect(
+            RoundRect(
+                Rect(left, top, right, bottom),
+                topLeft = if (roundTop) corner else zero,
+                topRight = if (roundTop) corner else zero,
+                bottomLeft = if (roundBottom) corner else zero,
+                bottomRight = if (roundBottom) corner else zero,
+            ),
+        )
+    }
+}

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TriggerVisuals.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TriggerVisuals.kt
@@ -1,8 +1,10 @@
 package fr.bsodium.cron.ui.screens.home.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -10,11 +12,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import fr.bsodium.cron.session.model.TriggerType
 import fr.bsodium.cron.ui.screens.home.RunKind
 import fr.bsodium.cron.ui.screens.home.label
+import fr.bsodium.cron.ui.theme.CronColors
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.MaterialSymbol
 import fr.bsodium.cron.ui.theme.Spacing
@@ -65,21 +68,42 @@ internal fun TriggerType.timelineAccent(): TimelineAccent = when (this) {
     -> TimelineAccent.Schedule
 }
 
-@Composable
-internal fun TimelineAccent.containerColor(): Color = when (this) {
-    TimelineAccent.Body -> MaterialTheme.colorScheme.tertiaryContainer
-    TimelineAccent.AlarmAction -> MaterialTheme.colorScheme.secondaryContainer
-    TimelineAccent.Schedule -> MaterialTheme.colorScheme.surfaceContainerHigh
+/** Semantic silhouette dimension — orthogonal to [TimelineAccent] (hue). Positive events read as a
+ *  soft `Flower`, negative ones as a sharp `Triangle`, neutral ones stay a plain circle (no shape
+ *  change). Carries an at-a-glance "was this good or bad" read the color and icon alone don't. */
+internal enum class TimelineValence { Positive, Negative, Neutral }
+
+/** Exhaustive so a new [TriggerType] forces a deliberate valence choice rather than falling through. */
+internal fun TriggerType.timelineValence(): TimelineValence = when (this) {
+    TriggerType.OutOfBedConfirmed, TriggerType.WakeWindowOpportunity -> TimelineValence.Positive
+    TriggerType.HardLatestFired, TriggerType.AlarmSnoozed -> TimelineValence.Negative
+    TriggerType.SleepOnset, TriggerType.AlarmDismissed, TriggerType.CalendarChange,
+    TriggerType.HcStageUpdate, TriggerType.MidSleepActivity, TriggerType.EveningPlan -> TimelineValence.Neutral
 }
 
-@Composable
-internal fun TimelineAccent.onContainerColor(): Color = when (this) {
-    TimelineAccent.Body -> MaterialTheme.colorScheme.onTertiaryContainer
-    TimelineAccent.AlarmAction -> MaterialTheme.colorScheme.onSecondaryContainer
-    TimelineAccent.Schedule -> MaterialTheme.colorScheme.onSurfaceVariant
+/** A replan inherits its trigger's valence (a safety-alarm replan reads as negative, same as the event
+ *  would); a scheduled/manual base plan is neutral. Exhaustive over the sealed [RunKind]. */
+internal fun RunKind.timelineValence(): TimelineValence = when (this) {
+    RunKind.ScheduledBase, RunKind.ManualBase -> TimelineValence.Neutral
+    is RunKind.Replan -> trigger?.timelineValence() ?: TimelineValence.Neutral
 }
 
-@Preview(showBackground = true)
+/** Track-aware — every cap anchor's fill matches whichever track it's on:
+ *  [MaterialTheme.colorScheme.secondaryContainer] on the sleep track, [MaterialTheme.colorScheme.primary]
+ *  on the awake one, with no exception for a "muted" tier either — every anchor on a given track is
+ *  literally the same color, full stop, differentiated only by icon/shape. Both delegate to
+ *  `SessionTimeline.kt`'s `trackAccentColor`/`trackOnAccentColor`, so a same-track collision is
+ *  structurally impossible, unlike the per-accent/per-importance `*Container` pairing this replaced
+ *  (which needed its own escape hatch per accent/track combination to avoid one). */
+@Composable
+internal fun TimelineAccent.capContainerColor(isAsleep: Boolean): Color = trackAccentColor(isAsleep)
+
+/** [capContainerColor]'s paired foreground — always the matching `on*` role for whichever fill
+ *  [capContainerColor] resolved to, so the pair can never drift apart. */
+@Composable
+internal fun TimelineAccent.capOnContainerColor(isAsleep: Boolean): Color = trackOnAccentColor(isAsleep)
+
+@PreviewLightDark
 @Composable
 private fun TriggerIconsPreview() {
     // Real production kinds → the preview renders the exact icon/label pairs the app ships.
@@ -87,7 +111,10 @@ private fun TriggerIconsPreview() {
         TriggerType.entries.map { RunKind.Replan(it) }
     CronTheme {
         Column(
-            modifier = Modifier.padding(Spacing.lg),
+            modifier = Modifier
+                .fillMaxSize()
+                .background(CronColors.pageBackground)
+                .padding(Spacing.lg),
             verticalArrangement = Arrangement.spacedBy(Spacing.md),
         ) {
             kinds.forEach { kind ->

--- a/app/src/main/java/fr/bsodium/cron/ui/theme/Fonts.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/theme/Fonts.kt
@@ -66,6 +66,20 @@ val ExpressiveNarrowFontFamily: FontFamily = expressiveWidth(40f)
 val ExpressiveCondensedFontFamily: FontFamily = expressiveWidth(85f)
 val ExpressiveWideFontFamily: FontFamily = expressiveWidth(120f)
 
+/** Narrower than [ExpressiveNarrowFontFamily] — the timeline's day-boundary heading ("TODAY") needs
+ *  to read as more condensed than the home greeting's username, which already uses the narrowest
+ *  width otherwise defined. */
+val ExpressiveUltraCondensedFontFamily: FontFamily = expressiveWidth(30f)
+
+/** A genuinely thin face at the timeline hero's condensed width — [expressiveWidth] only registers
+ *  Normal/Medium/SemiBold/Bold, so a "super thin" contrast needs its own sub-400 `wght` face, the same
+ *  technique [CountdownFontFamily] already uses for its light face. */
+val ExpressiveCondensedThinFontFamily: FontFamily = FontFamily(
+    Font(R.font.roboto_flex, weight = FontWeight.Light, variationSettings = FontVariation.Settings(
+        FontVariation.weight(200), FontVariation.Setting("wdth", 85f),
+    )),
+)
+
 /**
  * Hero LCD face for the next-alarm time. Bundled .ttf files resolve first,
  * with the downloadable Google Fonts entry as a network fallback. The

--- a/app/src/main/java/fr/bsodium/cron/ui/theme/MaterialSymbols.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/theme/MaterialSymbols.kt
@@ -1,5 +1,6 @@
 package fr.bsodium.cron.ui.theme
 
+import android.content.Context
 import android.graphics.Paint
 import android.util.Log
 import android.graphics.Typeface
@@ -18,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFontFamilyResolver
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.Role
@@ -34,6 +36,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import fr.bsodium.cron.R
+import java.io.File
 
 /**
  * Material Symbols (Rounded), rendered from the bundled variable font with its FILL / wght / GRAD / opsz
@@ -116,18 +119,69 @@ private fun rememberSymbolTypeface(): Typeface? {
     }
 }
 
+private data class VariationKey(val weight: Int, val grade: Int, val opticalSize: Float)
+
+/** `Typeface.Builder` has no constructor that wraps an already-resolved [Typeface] or reads a `res/font`
+ *  id directly — only a raw [File]/`FileDescriptor`/asset path. [get] extracts the bundled subset once
+ *  per process into the app's cache dir so [rememberVariedTypeface] has a real file to rebuild from.
+ *  `openRawResource` accepts any compiled resource's raw byte blob regardless of its declared type — a
+ *  `res/font` ttf id works exactly like a `res/raw` one here, lint's `@RawRes` contract just doesn't
+ *  know that. */
+private object VariedFontFile {
+    @Volatile private var cached: File? = null
+
+    @Suppress("ResourceType")
+    fun get(context: Context): File = cached ?: synchronized(this) {
+        cached ?: File(context.cacheDir, "material_symbols_rounded.ttf").also { file ->
+            if (!file.exists()) {
+                context.resources.openRawResource(R.font.material_symbols_rounded).use { input ->
+                    file.outputStream().use { output -> input.copyTo(output) }
+                }
+            }
+        }.also { cached = it }
+    }
+}
+
+/** Bakes `wght`/`GRAD`/`opsz` into a real [Typeface] variant, cached per [VariationKey], instead of a
+ *  live per-Paint `fontVariationSettings` string. A per-Paint override isn't guaranteed to resolve
+ *  identically on [Paint.getTextBounds]'s measurement path and [android.graphics.Canvas.drawText]'s
+ *  render path on every OEM/API level — for a compound glyph (e.g. a bell-plus-slash icon like
+ *  [MaterialSymbol.AlarmOff]) where those axes reshape one part relative to another, that divergence
+ *  shows up as a visible centering offset; a simple convex glyph's silhouette barely changes shape
+ *  across the axes, so the same divergence stays invisible (see docs/color-roles.md Round 12). Baking
+ *  the axes into the [Typeface] itself makes both paths resolve the same physical glyph outline.
+ *  `fill` is deliberately excluded — it's animated per-frame elsewhere ([CronNavigationBar]'s
+ *  tab-selection morph) and mostly affects interior strokework, not the outer bbox centering depends
+ *  on, so it stays on the cheap per-Paint path instead of rebuilding a [Typeface] every frame. */
+@Composable
+private fun rememberVariedTypeface(fallback: Typeface?, weight: Int, grade: Int, opticalSize: Float): Typeface? {
+    val context = LocalContext.current
+    val key = VariationKey(weight, grade, opticalSize)
+    return remember(key) {
+        runCatching {
+            Typeface.Builder(VariedFontFile.get(context))
+                .setFontVariationSettings("'wght' $weight,'GRAD' $grade,'opsz' $opticalSize")
+                .build()
+        }
+            .onFailure { e -> Log.w("MaterialSymbols", "variation axis bake failed for $key — falling back to unvaried typeface", e) }
+            .getOrNull()
+    } ?: fallback
+}
+
 /**
  * Renders a Material Symbol as a font glyph. Drop-in for `Icon`: pass [tint] and [size] the same way.
  * [fill] 0→1 morphs outlined→filled (animate it for selection states); [weight]/[grade] tune stroke and
  * emphasis; `opsz` tracks [size] for optical correctness. [autoMirror] flips the glyph under RTL (the
  * replacement for the old `Icons.AutoMirrored.*`).
  *
- * Drawn straight onto the canvas rather than via `Text`: Material Symbol glyphs are centred on the em
- * (design centre = em/2 above the baseline), but the font's line metrics are top-heavy and the ink sits
- * entirely above the baseline, so a `Text` line box centres the glyph low. Placing the baseline at the
- * box bottom maps the em exactly onto the [size] box → glyph centred, independent of those metrics. The
- * px-derived `textSize` also keeps the icon fixed-size under the user's font-scale setting, and the axes
- * ride on the Paint (no per-frame `FontFamily` rebuild for an animated [fill]).
+ * Drawn straight onto the canvas rather than via `Text`: a `Text` line box centres the glyph using line
+ * metrics, which sit low for this font. Instead, [Paint.getTextBounds] measures the glyph's actual ink
+ * rectangle for the current size/variation settings, and the draw origin is placed so that rectangle's
+ * centre lands on the box's centre — this stays correct regardless of a specific font's side-bearings or
+ * baseline assumptions, unlike a fixed `(size/2, size)` origin (which measured ~3px off-centre for this
+ * bundled subset font; see docs/color-roles.md Round 10). The px-derived `textSize` also keeps the icon
+ * fixed-size under the user's font-scale setting, and the axes ride on the Paint (no per-frame
+ * `FontFamily` rebuild for an animated [fill]).
  */
 @Composable
 fun Symbol(
@@ -141,9 +195,10 @@ fun Symbol(
     grade: Int = 0,
     autoMirror: Boolean = false,
 ) {
-    val typeface = rememberSymbolTypeface()
+    val baseTypeface = rememberSymbolTypeface()
     val mirror = autoMirror && LocalLayoutDirection.current == LayoutDirection.Rtl
     val opticalSize = size.value.coerceIn(20f, 48f)
+    val typeface = rememberVariedTypeface(baseTypeface, weight, grade, opticalSize)
     Canvas(
         modifier = modifier
             .size(size)
@@ -159,20 +214,24 @@ fun Symbol(
             isAntiAlias = true
             this.typeface = typeface
             textSize = px
-            textAlign = Paint.Align.CENTER
+            textAlign = Paint.Align.LEFT
             color = tint.toArgb()
             // Float.toString is locale-independent ('.'), so this needs no Locale guard.
-            fontVariationSettings = "'FILL' $fill,'wght' $weight,'GRAD' $grade,'opsz' $opticalSize"
+            fontVariationSettings = "'FILL' $fill"
         }
+        val inkBounds = android.graphics.Rect()
+        paint.getTextBounds(symbol.code, 0, symbol.code.length, inkBounds)
+        val originX = px / 2f - inkBounds.exactCenterX()
+        val originY = px / 2f - inkBounds.exactCenterY()
         drawIntoCanvas { canvas ->
             val nc = canvas.nativeCanvas
             if (mirror) {
                 val count = nc.save()
                 nc.scale(-1f, 1f, px / 2f, px / 2f)
-                nc.drawText(symbol.code, px / 2f, px, paint)
+                nc.drawText(symbol.code, originX, originY, paint)
                 nc.restoreToCount(count)
             } else {
-                nc.drawText(symbol.code, px / 2f, px, paint)
+                nc.drawText(symbol.code, originX, originY, paint)
             }
         }
     }

--- a/app/src/main/java/fr/bsodium/cron/ui/theme/Tokens.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/theme/Tokens.kt
@@ -16,6 +16,7 @@ object Spacing {
     val xl = 20.dp
     val xxl = 24.dp
     val xxxl = 32.dp
+    val xxxxl = 40.dp
 
     /** Bottom clearance reserved for the floating nav pill (≈68dp) + breathing room. */
     val navBarClearance = 96.dp

--- a/app/src/main/java/fr/bsodium/cron/ui/theme/Type.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/theme/Type.kt
@@ -3,6 +3,7 @@ package fr.bsodium.cron.ui.theme
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.unit.em
@@ -182,6 +183,16 @@ object CronTypography {
     /** Smaller code label — tool-call name chips and result labels in the thinking timeline. */
     val labelMonoSmall: TextStyle = labelMono.copy(fontSize = 11.sp, lineHeight = 15.sp)
 
+    /** The trailing clock/relative-time figure on a minor (non-hero) timeline row — sized up from
+     *  [labelMonoSmall] specifically for this context rather than resizing that shared role, which
+     *  is also used well beyond the timeline (tool-call chips, etc.). Based on [tight] (Round 31),
+     *  not [labelMono] directly — passing an explicit `style` to a `Text` bypasses whatever
+     *  `LocalTextStyle` a `CompositionLocalProvider` might supply entirely, so a timeline row's own
+     *  extra font leading can only be stripped by baking [tight] into the style itself, not by
+     *  wrapping the composable in a provider (an earlier attempt at exactly that silently did
+     *  nothing, since every `Text` in this timeline passes its own `style`). */
+    val timelineRowTime: TextStyle = tight.copy(fontFamily = CodeFontFamily, fontSize = 13.sp, lineHeight = 17.sp)
+
     /** Bold code label — emphasis pills (e.g. the sleep-duration badge). */
     val labelMonoBold: TextStyle = labelMono.copy(fontWeight = FontWeight.Bold)
 
@@ -217,21 +228,54 @@ object CronTypography {
         lineHeight = 16.sp,
     )
 
-    /** Timeline day-boundary heading — a bold condensed word ("TODAY"). Pairs with [labelMonoSmall]
-     *  for the companion date figure, echoing the display/mono contrast from the Material Expressive
-     *  reference material. */
-    val timelineDayHeader: TextStyle = TextStyle(
-        fontFamily = ExpressiveCondensedFontFamily,
-        fontWeight = FontWeight.Bold,
-        fontSize = 28.sp,
-        lineHeight = 32.sp,
+    /** Timeline day-boundary heading's headline — the bare day-of-month figure ("7"), rendered
+     *  colossal and heavy, calendar-tear-off style, with [timelineDayMonth] as its caption
+     *  underneath rather than a same-size sibling beside it. `Black` (900) is the *inactive*-state
+     *  ceiling here; `DayHeaderLabel` itself drives a live variable-font `wght`/`wdth` animation on
+     *  top of this base style as the header becomes/stops being the active section, so this fixed
+     *  style is really just the animation's resting point. `lineHeight` is deliberately tighter than
+     *  `fontSize` — `DayHeaderLabel` also applies a bottom-anchored `graphicsLayer` vertical squash
+     *  to the glyph itself, and a matching tighter line height keeps the row's own layout height in
+     *  step instead of leaving dead space below the now-shorter-looking digit. */
+    val timelineDayNumber: TextStyle = TextStyle(
+        fontFamily = ExpressiveUltraCondensedFontFamily,
+        fontWeight = FontWeight.Black,
+        fontSize = 56.sp,
+        lineHeight = 40.sp,
         letterSpacing = (-0.02).em,
+    )
+
+    /** The month caption underneath [timelineDayNumber] — written in full ("JUNE", not "JUN"), sized
+     *  and weighted to read clearly next to the colossal number. Shares [timelineDayActiveLabel]'s
+     *  size exactly — the two sit on the same line, one right-aligned, one left — so only the weight
+     *  tells them apart. */
+    val timelineDayMonth: TextStyle = TextStyle(
+        fontFamily = ExpressiveCondensedFontFamily,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 18.sp,
+        lineHeight = 22.sp,
+        letterSpacing = 0.01.em,
+    )
+
+    /** The relative-day label ("TODAY"/"TOMORROW"/"TWO DAYS AGO"/weekday name) — sits on
+     *  [timelineDayMonth]'s own line, left-aligned opposite the month; italic, thinner, and rounder
+     *  than the month label. [ExpressiveCondensedThinFontFamily] (85 width, a genuine sub-400 `wght`
+     *  face) is *less* condensed than the number's own 30-width family, which is what "rounder" means
+     *  here: less condensing leaves round letterforms (O, D) closer to their natural shape instead of
+     *  squeezed into narrow ovals. Same `fontSize`/`lineHeight` as [timelineDayMonth] — same line,
+     *  same size, only weight/style/family differ. */
+    val timelineDayActiveLabel: TextStyle = timelineDayMonth.copy(
+        fontFamily = ExpressiveCondensedThinFontFamily,
+        fontWeight = FontWeight.Light,
+        fontStyle = FontStyle.Italic,
     )
 
     /** Latest timeline run's headline — the AI's resolved outcome sentence, set at headlineMedium
      *  scale so it reads as the one bold fact on the row (Material Expressive reference: a big
-     *  isolated headline paired with a small muted caption, not a gradient of medium sizes). */
-    val timelineHeroTitle: TextStyle = TextStyle(
+     *  isolated headline paired with a small muted caption, not a gradient of medium sizes). Based
+     *  on [tight] (Round 31) — see [timelineRowTime]'s KDoc for why; [timelineHeroTimeNew] and
+     *  [timelineHeroTimePrev] inherit it for free via `.copy()`. */
+    val timelineHeroTitle: TextStyle = tight.copy(
         fontFamily = ExpressiveCondensedFontFamily,
         fontWeight = FontWeight.Bold,
         fontSize = 26.sp,
@@ -239,13 +283,23 @@ object CronTypography {
         letterSpacing = (-0.01).em,
     )
 
-    /** The lighter "before" value in a [timelineHeroTitle]-scale PREV › NEW time pair — same face and
-     *  size as the (bold) new time, so the pair reads as a weight contrast, not a size mismatch. */
-    val timelineHeroTimePrev: TextStyle = timelineHeroTitle.copy(fontWeight = FontWeight.Normal)
+    /** The bold, emphasized NEW time in a hero PREV › NEW pair — same face/size/weight as
+     *  [timelineHeroTitle]; bold alone is enough contrast against [timelineHeroTimePrev]'s thin face,
+     *  no italic needed. */
+    val timelineHeroTimeNew: TextStyle = timelineHeroTitle
+
+    /** The super-thin "before" value in a [timelineHeroTitle]-scale PREV › NEW time pair — a real
+     *  sub-400 `wght` face ([ExpressiveCondensedThinFontFamily]), not just a Normal-vs-Bold contrast,
+     *  so the pair reads as thin-vs-bold-italic rather than two similarly-weighted numbers. */
+    val timelineHeroTimePrev: TextStyle = timelineHeroTitle.copy(
+        fontFamily = ExpressiveCondensedThinFontFamily,
+        fontWeight = FontWeight.Light,
+    )
 
     /** Small caption above [timelineHeroTitle] carrying the run's trigger category (e.g. "PLANNED",
-     *  "ALARM DISMISSED") now that the headline itself carries the outcome sentence. */
-    val timelineHeroKicker: TextStyle = TextStyle(
+     *  "ALARM DISMISSED") now that the headline itself carries the outcome sentence. Based on
+     *  [tight] (Round 31) — see [timelineRowTime]'s KDoc for why. */
+    val timelineHeroKicker: TextStyle = tight.copy(
         fontFamily = ExpressiveFontFamily,
         fontWeight = FontWeight.Medium,
         fontSize = 11.sp,
@@ -254,12 +308,13 @@ object CronTypography {
     )
 
     /** History timeline row title — condensed and muted so it reads as clearly subordinate to
-     *  [timelineHeroTitle] through weight/width, not just size. */
-    val timelineRowTitle: TextStyle = TextStyle(
+     *  [timelineHeroTitle] through weight/width, not just size. Sized up from 14sp for legibility.
+     *  Based on [tight] (Round 31) — see [timelineRowTime]'s KDoc for why. */
+    val timelineRowTitle: TextStyle = tight.copy(
         fontFamily = ExpressiveCondensedFontFamily,
         fontWeight = FontWeight.Medium,
-        fontSize = 14.sp,
-        lineHeight = 18.sp,
+        fontSize = 16.sp,
+        lineHeight = 20.sp,
     )
 }
 

--- a/app/src/main/java/fr/bsodium/cron/worker/CalendarChangeWorker.kt
+++ b/app/src/main/java/fr/bsodium/cron/worker/CalendarChangeWorker.kt
@@ -55,6 +55,7 @@ class CalendarChangeWorker(
                 changeType = "first_event_changed",
                 eventId = diff.newSig?.substringBefore("|") ?: "",
                 affectsFirstEvent = true,
+                firstEventTitle = diff.firstEventTitle,
             ),
         )
         repository.appendEventAndTriggerAi(session.id, event)

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/home/AiPlanMapperTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/home/AiPlanMapperTest.kt
@@ -62,7 +62,7 @@ class AiPlanMapperTest {
         val rows = listOf(assistant(0, createdAt = 0L), assistant(1, createdAt = 1000L))
         val events = listOf(event(TriggerType.CalendarChange, 500L, EventData.CalendarChange("modified", "e1", true)))
         val plan = requireNotNull(AiPlanMapper.buildPlan(rows, null, events))
-        assertEquals(listOf("Planned", "Your schedule changed"), plan.iterations.map { it.systemMessage })
+        assertEquals(listOf("Planned", "Replanned for your schedule"), plan.iterations.map { it.systemMessage })
         assertEquals(1, plan.iterations.last().turnIndex)
     }
 
@@ -82,7 +82,7 @@ class AiPlanMapperTest {
             event(TriggerType.AlarmSnoozed, 1500L), // after the turn started — must be ignored
         )
         val plan = requireNotNull(AiPlanMapper.buildPlan(rows, null, events))
-        assertEquals("Your schedule changed", plan.iterations.last().systemMessage)
+        assertEquals("Replanned for your schedule", plan.iterations.last().systemMessage)
     }
 
     @Test

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/home/HomeContentScreenshotTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/home/HomeContentScreenshotTest.kt
@@ -1,0 +1,67 @@
+package fr.bsodium.cron.ui.screens.home
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.bsodium.cron.ui.theme.CronTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+/** The timeline's left inset (`Spacing.md`) must line up with the alarm card's own left edge — this
+ *  renders both together so the alignment is directly checkable. */
+@Suppress("DEPRECATION")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@RunWith(RobolectricTestRunner::class)
+class HomeContentScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun timeline_gutter_aligns_with_the_alarm_card_left_edge() {
+        composeTestRule.mainClock.autoAdvance = false
+        val iterations = listOf(
+            AiIterationUi(
+                turnIndex = 0,
+                timeLabel = "21:30",
+                kind = RunKind.ScheduledBase,
+                thread = AiThreadUi(turnIndex = 0, summary = "Set alarm for 07:45.", process = emptyList(), response = "Alarm set for **07:45**."),
+                ranAtEpochMs = System.currentTimeMillis(),
+            ),
+        )
+        composeTestRule.setContent {
+            CronTheme {
+                HomePlanContent(
+                    uiState = HomeUiState(
+                        initialized = true,
+                        dateLabel = "Friday, 3 Jul",
+                        aiPlan = AiPlanUi(iterations = iterations),
+                        timeline = buildTimeline(
+                            listOf(
+                                TimelineSession(
+                                    sessionId = "s1",
+                                    iterations = iterations,
+                                    events = emptyList(),
+                                    streamingTurnIndex = null,
+                                ),
+                            ),
+                        ),
+                    ),
+                    statusInsetTop = 24.dp,
+                    navInsetBottom = 0.dp,
+                    hasNotificationPermission = true,
+                    onNotifEnable = {},
+                    onAutoAlarmsChange = {},
+                    onOpenAiRun = { _, _ -> },
+                    onNavigateToHistory = {},
+                )
+            }
+        }
+        composeTestRule.mainClock.advanceTimeBy(1_000L)
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/home/HomeViewModelTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/home/HomeViewModelTest.kt
@@ -7,7 +7,9 @@ import app.cash.turbine.test
 import fr.bsodium.cron.ai.StreamingTurn
 import fr.bsodium.cron.ai.StreamingTurnStore
 import fr.bsodium.cron.ai.wire.ContentBlock
+import fr.bsodium.cron.session.db.AiMessageEntity
 import fr.bsodium.cron.session.db.CronDatabase
+import fr.bsodium.cron.session.db.SessionJson
 import fr.bsodium.cron.session.db.toEntity
 import fr.bsodium.cron.session.model.ActionType
 import fr.bsodium.cron.testutil.Fixtures
@@ -20,6 +22,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
+import kotlinx.serialization.encodeToString
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -42,8 +45,7 @@ class HomeViewModelTest {
         Dispatchers.setMain(dispatcher)
         app = ApplicationProvider.getApplicationContext()
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
-        // The production CronDatabase singleton is file-backed and persists across tests in the JVM;
-        // wipe it (cascades to events + ai_messages) so each test starts from a clean slate.
+        // The production CronDatabase singleton is file-backed and persists across tests in the JVM; wipe it (cascades to events + ai_messages) so each test starts from a clean slate.
         runBlocking { CronDatabase.get(app).sessionDao().deleteOlderThan(Long.MAX_VALUE) }
         resetStreamingStore()
     }
@@ -58,6 +60,14 @@ class HomeViewModelTest {
     private fun resetStreamingStore() {
         StreamingTurnStore.active.value?.let { StreamingTurnStore.clear(it.sessionId, it.turnIndex) }
     }
+
+    private fun aiTurnRow(sessionId: String, turn: Int, createdAt: Long, text: String) = AiMessageEntity(
+        sessionId = sessionId,
+        turnIndex = turn,
+        role = "assistant",
+        contentJson = SessionJson.encodeToString<List<ContentBlock>>(listOf(ContentBlock.Text(text))),
+        createdAt = createdAt,
+    )
 
     @Test
     fun initializes_to_empty_state_without_a_session() = runTest(dispatcher) {
@@ -100,8 +110,7 @@ class HomeViewModelTest {
             var state = awaitItem()
             while (state.sessionDisplay == null) state = awaitItem()
 
-            // A turn for this session starts streaming. The answer is marked with SUMMARY (the model's
-            // convention) so the streamed text is revealed as the answer rather than held as narration.
+            // A turn for this session starts streaming; the answer is marked with SUMMARY (the model's convention) so the streamed text is revealed as the answer rather than held as narration.
             StreamingTurnStore.update(
                 StreamingTurn(
                     sessionId = "s1",
@@ -120,6 +129,25 @@ class HomeViewModelTest {
             StreamingTurnStore.clear("s1", 0)
             while (state.aiPlan != null) state = awaitItem()
             assertNull(state.aiPlan)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun newlyArrivedIds_is_empty_on_first_emission_then_marks_only_a_later_turn() = runTest(dispatcher) {
+        val db = CronDatabase.get(app)
+        db.sessionDao().insert(Fixtures.session(id = "s1", date = LocalDate.parse("2026-05-22")).toEntity())
+        db.aiMessageDao().insert(aiTurnRow(sessionId = "s1", turn = 0, createdAt = 1_000L, text = "SUMMARY: first\n\nFirst answer."))
+
+        HomeViewModel(app).uiState.test(timeout = 5.seconds) {
+            var state = awaitItem()
+            while (state.timeline.none { it.id == "ai-s1-0" }) state = awaitItem()
+            // The very first real emission of a cold-started ViewModel must never mark anything as newly-arrived, even though "ai-s1-0" is appearing on screen for the first time — there is no reference point yet.
+            assertTrue(state.newlyArrivedIds.isEmpty())
+
+            db.aiMessageDao().insert(aiTurnRow(sessionId = "s1", turn = 1, createdAt = 2_000L, text = "SUMMARY: second\n\nSecond answer."))
+            while (state.timeline.none { it.id == "ai-s1-1" }) state = awaitItem()
+            assertEquals(setOf("ai-s1-1"), state.newlyArrivedIds)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/home/TimelineMapperTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/home/TimelineMapperTest.kt
@@ -29,8 +29,26 @@ class TimelineMapperTest {
     private fun dayHeader(date: LocalDate) = TimelineItem.DayHeader(
         date = date,
         timestamp = Instant.fromEpochMilliseconds(0),
-        weekdayLabel = date.toString(),
-        dateLabel = date.toString(),
+    )
+
+    private fun event(ms: Long, trigger: TriggerType) = TimelineItem.Event(
+        timestamp = Instant.fromEpochMilliseconds(ms),
+        trigger = trigger,
+        label = trigger.name,
+        detail = null,
+    )
+
+    private fun aiRun(ms: Long) = TimelineItem.AiRun(
+        timestamp = Instant.fromEpochMilliseconds(ms),
+        iteration = AiIterationUi(
+            turnIndex = 0,
+            timeLabel = "00:00",
+            kind = RunKind.ScheduledBase,
+            thread = AiThreadUi(turnIndex = 0, summary = null, process = emptyList(), response = null),
+        ),
+        sessionId = "s",
+        isStreaming = false,
+        isLatest = false,
     )
 
     @Test
@@ -72,8 +90,13 @@ class TimelineMapperTest {
         assertTrue(result.items.none { it is TimelineItem.DayHeader })
     }
 
+    /** DayHeader is purely a sticky decoration — it's still inserted structurally into the list at
+     *  every local-day boundary so `stickyHeader` has something to pin, but it must stay invisible
+     *  to segment/cap/asleep-state derivation (see the timelineAsleepStates tests below and
+     *  SessionTimeline.kt's firstAnchorIndex/lastAnchorIndex). Today's own header is skipped
+     *  entirely — the user already knows it's today. */
     @Test
-    fun buildTimeline_inserts_a_header_at_every_local_day_boundary() {
+    fun buildTimeline_inserts_a_header_at_every_local_day_boundary_except_today() {
         val tz = TimeZone.currentSystemDefault()
         val today = Clock.System.now().toLocalDateTime(tz).date
         val todayEvent = SessionEvent(
@@ -93,11 +116,10 @@ class TimelineMapperTest {
             streamingTurnIndex = null,
         )
         val timeline = buildTimeline(listOf(session))
-        assertEquals(4, timeline.size)
-        assertTrue(timeline[0] is TimelineItem.DayHeader)
-        assertTrue(timeline[1] is TimelineItem.Event)
-        assertTrue(timeline[2] is TimelineItem.DayHeader)
-        assertTrue(timeline[3] is TimelineItem.Event)
+        assertEquals(3, timeline.size)
+        assertTrue(timeline[0] is TimelineItem.Event)
+        assertTrue(timeline[1] is TimelineItem.DayHeader)
+        assertTrue(timeline[2] is TimelineItem.Event)
     }
 
     /** Regression: a data-layer race can surface the identical (trigger, timestamp) event under two
@@ -124,5 +146,98 @@ class TimelineMapperTest {
         val timeline = buildTimeline(listOf(sessionA, sessionB))
         assertEquals(1, timeline.count { it is TimelineItem.Event })
         assertEquals(timeline.map { it.id }.toSet().size, timeline.size)
+    }
+
+    @Test
+    fun timelineAsleepStates_with_no_sleep_events_is_all_awake() {
+        val timeline = listOf(event(30, TriggerType.CalendarChange), event(20, TriggerType.AlarmDismissed), aiRun(10))
+        assertEquals(listOf(false, false, false), timelineAsleepStates(timeline))
+    }
+
+    @Test
+    fun timelineAsleepStates_marks_the_span_between_onset_and_wake_asleep() {
+        // Reverse-chronological: index 0 newest. Sandwiched item at 20 sits between wake (30) and onset (10).
+        val timeline = listOf(
+            event(40, TriggerType.CalendarChange), // after wake -> awake
+            event(30, TriggerType.OutOfBedConfirmed), // the wake row itself -> awake
+            aiRun(20), // sandwiched between onset and wake -> asleep
+            event(10, TriggerType.SleepOnset), // the onset row itself -> asleep
+            event(0, TriggerType.CalendarChange), // before onset -> awake
+        )
+        assertEquals(listOf(false, false, true, true, false), timelineAsleepStates(timeline))
+    }
+
+    @Test
+    fun timelineAsleepStates_alternates_across_multiple_onset_wake_pairs() {
+        val timeline = listOf(
+            event(70, TriggerType.CalendarChange), // after 2nd wake -> awake
+            event(60, TriggerType.OutOfBedConfirmed), // 2nd wake -> awake
+            event(50, TriggerType.SleepOnset), // 2nd nap -> asleep
+            event(40, TriggerType.OutOfBedConfirmed), // 1st wake -> awake
+            event(30, TriggerType.SleepOnset), // 1st nap -> asleep
+        )
+        assertEquals(listOf(false, false, true, false, true), timelineAsleepStates(timeline))
+    }
+
+    /** A day boundary must never reset the asleep flag — most sleep sessions span midnight, and
+     *  DayHeader is purely visual, a no-op for this derivation. */
+    @Test
+    fun timelineAsleepStates_stays_asleep_across_a_day_header_even_mid_sleep() {
+        val timeline = listOf(
+            event(20, TriggerType.CalendarChange), // new day, still asleep -> asleep
+            dayHeader(LocalDate(2026, 7, 2)),
+            event(10, TriggerType.SleepOnset), // asleep at the end of the prior day
+        )
+        assertEquals(listOf(true, true, true), timelineAsleepStates(timeline))
+    }
+
+    /** True cold start: no reference point yet, so the first load must render fully static, never
+     *  an animated reveal. */
+    @Test
+    fun diffNewlyArrivedIds_the_very_first_check_never_marks_anything_new() {
+        assertEquals(emptySet<String>(), diffNewlyArrivedIds(setOf("a", "b"), previousIds = null))
+    }
+
+    @Test
+    fun diffNewlyArrivedIds_a_later_check_marks_only_the_added_id() {
+        assertEquals(setOf("c"), diffNewlyArrivedIds(setOf("a", "b", "c"), previousIds = setOf("a", "b")))
+    }
+
+    @Test
+    fun diffNewlyArrivedIds_an_identical_re_check_marks_nothing_new() {
+        // The Home→Settings→back case: same ids as last time, nothing should animate.
+        assertEquals(emptySet<String>(), diffNewlyArrivedIds(setOf("a", "b"), previousIds = setOf("a", "b")))
+    }
+
+    @Test
+    fun diffNewlyArrivedIds_a_removed_id_does_not_appear_as_new() {
+        assertEquals(emptySet<String>(), diffNewlyArrivedIds(setOf("a"), previousIds = setOf("a", "b")))
+    }
+
+    /** Guards the entrance-animation pipeline: newlyArrivedIds is only meaningful if buildTimeline
+     *  itself doesn't spuriously reshuffle/rename ids across repeated calls with the same underlying
+     *  session data. */
+    @Test
+    fun buildTimeline_is_idempotent_given_identical_input() {
+        val session = TimelineSession(
+            sessionId = "s1",
+            iterations = listOf(
+                AiIterationUi(
+                    turnIndex = 0,
+                    timeLabel = "07:45",
+                    kind = RunKind.ScheduledBase,
+                    thread = AiThreadUi(turnIndex = 0, summary = null, process = emptyList(), response = null),
+                    ranAtEpochMs = 1_000L,
+                ),
+            ),
+            events = listOf(
+                SessionEvent(timestamp = Instant.fromEpochMilliseconds(500L), trigger = TriggerType.AlarmDismissed, data = EventData.Empty),
+            ),
+            streamingTurnIndex = null,
+        )
+        val first = buildTimeline(listOf(session))
+        val second = buildTimeline(listOf(session))
+        assertEquals(first, second)
+        assertEquals(first.map { it.id }, second.map { it.id })
     }
 }

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/PillPressMorphScreenshotTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/PillPressMorphScreenshotTest.kt
@@ -1,0 +1,89 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+
+package fr.bsodium.cron.ui.screens.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.bsodium.cron.ui.theme.CronColors
+import fr.bsodium.cron.ui.theme.CronTheme
+import fr.bsodium.cron.ui.theme.Spacing
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+/** A genuine touch-driven interaction test would need to fight fling/settle timing for a fairly
+ *  small visual payoff — this instead registers the exact same [AnchorShape.Pill] TimelineNode.kt
+ *  builds, at fixed `pressProgress` values, directly against [TimelineTrackRegistry] (the same
+ *  registry the real Composable writes into via `SideEffect`), so the rendered geometry is provably
+ *  the real production shape at each program point rather than a mid-gesture guess. */
+@Suppress("DEPRECATION")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@RunWith(RobolectricTestRunner::class)
+class PillPressMorphScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun pill_press_morph_unpressed_and_pressed_render_a_rounded_square() {
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            CronTheme {
+                val registry = rememberTimelineTrackRegistry()
+                Box(Modifier.fillMaxSize().background(CronColors.pageBackground)) {
+                    TimelineTrackOverlay(registry = registry)
+                    Column(modifier = Modifier.padding(Spacing.xl)) {
+                        PillPressExample(registry = registry, id = "unpressed", pressProgress = 0f)
+                        PillPressExample(registry = registry, id = "half-pressed", pressProgress = 0.5f)
+                        PillPressExample(registry = registry, id = "fully-pressed", pressProgress = 1f)
+                    }
+                }
+            }
+        }
+        composeTestRule.mainClock.advanceTimeBy(1_000L)
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}
+
+@Composable
+private fun PillPressExample(registry: TimelineTrackRegistry, id: String, pressProgress: Float) {
+    val density = LocalDensity.current
+    val accentColor = MaterialTheme.colorScheme.secondary
+    Box(
+        modifier = Modifier
+            .size(TRACK_WIDTH)
+            .onGloballyPositioned { coords -> registry.setPosition(id, coords) },
+    )
+    SideEffect {
+        registry.setDescriptor(
+            id,
+            AnchorDescriptor(
+                contentRadiusPx = with(density) { INTERIOR_ANCHOR_SIZE.toPx() / 2f },
+                shape = AnchorShape.Pill(pressProgress = { pressProgress }),
+                accentColor = accentColor,
+                isSegmentTop = false,
+                isSegmentBottom = false,
+                asleepAbove = false,
+                asleepBelow = false,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/SessionTimelineScreenshotTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/SessionTimelineScreenshotTest.kt
@@ -2,9 +2,14 @@
 
 package fr.bsodium.cron.ui.screens.home.components
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onRoot
@@ -15,6 +20,7 @@ import fr.bsodium.cron.ui.screens.home.AiThreadUi
 import fr.bsodium.cron.ui.screens.home.ProcessItem
 import fr.bsodium.cron.ui.screens.home.RunKind
 import fr.bsodium.cron.ui.screens.home.TimelineItem
+import fr.bsodium.cron.ui.screens.home.timelineAsleepStates
 import fr.bsodium.cron.ui.theme.CronTheme
 import fr.bsodium.cron.ui.theme.Spacing
 import kotlinx.datetime.Instant
@@ -41,15 +47,6 @@ private fun fixedIteration(
     previousAlarmTime = previousAlarmTime,
 )
 
-/** Deterministic day header — bypasses the real-clock [TimelineItem.DayHeader] mapper so the golden
- *  screenshot never depends on which weekday the test happens to run on. */
-private fun fixedDayHeader(isoDate: String, weekdayLabel: String, dateLabel: String) = TimelineItem.DayHeader(
-    date = LocalDate.parse(isoDate),
-    timestamp = Instant.fromEpochMilliseconds(0L),
-    weekdayLabel = weekdayLabel,
-    dateLabel = dateLabel,
-)
-
 @Suppress("DEPRECATION")
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @RunWith(RobolectricTestRunner::class)
@@ -62,7 +59,7 @@ class SessionTimelineScreenshotTest {
     fun timeline_spans_two_days_with_hero_run_and_accented_events() {
         composeTestRule.mainClock.autoAdvance = false
         val timeline = listOf(
-            fixedDayHeader("2026-07-03", "TODAY", "3 JUL"),
+            TimelineItem.DayHeader(date = LocalDate(2026, 7, 3), timestamp = Instant.fromEpochMilliseconds(0L)),
             TimelineItem.AiRun(
                 timestamp = Instant.fromEpochMilliseconds(0L),
                 iteration = fixedIteration(
@@ -85,7 +82,8 @@ class SessionTimelineScreenshotTest {
                 timestamp = Instant.fromEpochMilliseconds(0L),
                 trigger = TriggerType.AlarmSnoozed,
                 label = "Alarm snoozed",
-                detail = "9 min",
+                detail = "You get to sleep for 9 extra minutes",
+                detailEmphasis = "9 extra minutes",
             ),
             TimelineItem.Event(
                 timestamp = Instant.fromEpochMilliseconds(0L),
@@ -93,7 +91,7 @@ class SessionTimelineScreenshotTest {
                 label = "You fell asleep",
                 detail = null,
             ),
-            fixedDayHeader("2026-07-02", "YESTERDAY", "2 JUL"),
+            TimelineItem.DayHeader(date = LocalDate(2026, 7, 2), timestamp = Instant.fromEpochMilliseconds(0L)),
             TimelineItem.Event(
                 timestamp = Instant.fromEpochMilliseconds(0L),
                 trigger = TriggerType.OutOfBedConfirmed,
@@ -109,22 +107,196 @@ class SessionTimelineScreenshotTest {
             ),
         )
         composeTestRule.setContent {
-            CronTheme {
-                Column(modifier = Modifier.padding(horizontal = Spacing.md)) {
-                    timeline.forEachIndexed { index, item ->
-                        val isFirst = index == 0 || timeline[index - 1] is TimelineItem.DayHeader
-                        val isLast = index == timeline.lastIndex || timeline[index + 1] is TimelineItem.DayHeader
-                        when (item) {
-                            is TimelineItem.AiRun -> AiRunNode(item = item, isFirst = isFirst, isLast = isLast, onClick = {})
-                            is TimelineItem.Event -> EventNode(item = item, isFirst = isFirst, isLast = isLast)
-                            is TimelineItem.DayHeader -> DayHeaderRow(item = item)
-                        }
-                    }
-                }
-            }
+            CronTheme { TimelineTestContent(timeline) }
         }
         // Let the hero anchor's arrival morph settle before capturing.
         composeTestRule.mainClock.advanceTimeBy(1_000L)
         composeTestRule.onRoot().captureRoboImage()
+    }
+
+    /** A day boundary must never split a sleep session's pill/segment. The `DayHeader` sits right
+     *  where midnight would fall — between "Movement detected" (late "yesterday") and "You got up"
+     *  (early "today") — and must not affect segment/cap/asleep-state derivation; the whole stretch
+     *  should render as one uninterrupted dark pill with no cap/seam. */
+    @Test
+    fun sleep_session_spanning_midnight_renders_one_continuous_pill() {
+        composeTestRule.mainClock.autoAdvance = false
+        val timeline = listOf(
+            TimelineItem.Event(
+                timestamp = Instant.fromEpochMilliseconds(0L),
+                trigger = TriggerType.OutOfBedConfirmed,
+                label = "You got up",
+                detail = null,
+            ),
+            TimelineItem.DayHeader(date = LocalDate(2026, 7, 3), timestamp = Instant.fromEpochMilliseconds(0L)),
+            TimelineItem.Event(
+                timestamp = Instant.fromEpochMilliseconds(0L),
+                trigger = TriggerType.MidSleepActivity,
+                label = "Movement detected",
+                detail = null,
+            ),
+            TimelineItem.Event(
+                timestamp = Instant.fromEpochMilliseconds(0L),
+                trigger = TriggerType.SleepOnset,
+                label = "You fell asleep",
+                detail = null,
+            ),
+            TimelineItem.Event(
+                timestamp = Instant.fromEpochMilliseconds(0L),
+                trigger = TriggerType.CalendarChange,
+                label = "Your schedule changed",
+                detail = null,
+            ),
+        )
+        composeTestRule.setContent {
+            CronTheme { TimelineTestContent(timeline) }
+        }
+        composeTestRule.mainClock.advanceTimeBy(1_000L)
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    /** A static single-frame screenshot can't show scroll dynamics, so this drives a real
+     *  `LazyColumn` (via the production `sessionTimelineItems`, not the flattened
+     *  `TimelineTestContent` used elsewhere in this file) with a real `LazyListState`, scrolls
+     *  programmatically past a `DayHeader`'s natural position, and captures the result — every
+     *  header renders identically regardless of scroll position (see [DayHeaderRow]'s KDoc), so this
+     *  is a render-correctness regression check for the scrolled-past state, not a differential
+     *  active/inactive emphasis check. */
+    @Test
+    fun day_header_emphasizes_the_active_section_while_scrolled_past_it() {
+        composeTestRule.mainClock.autoAdvance = false
+        val timeline = buildList {
+            add(TimelineItem.DayHeader(date = LocalDate(2026, 7, 6), timestamp = Instant.fromEpochMilliseconds(0L)))
+            for (i in 0 until 20) {
+                add(
+                    TimelineItem.Event(
+                        timestamp = Instant.fromEpochMilliseconds((20 - i).toLong()),
+                        trigger = TriggerType.AlarmDismissed,
+                        label = "Event $i",
+                        detail = null,
+                    ),
+                )
+            }
+            add(TimelineItem.DayHeader(date = LocalDate(2026, 7, 5), timestamp = Instant.fromEpochMilliseconds(0L)))
+            add(TimelineItem.Event(timestamp = Instant.fromEpochMilliseconds(0L), trigger = TriggerType.AlarmDismissed, label = "Older event", detail = null))
+        }
+        composeTestRule.setContent {
+            CronTheme {
+                val listState = rememberLazyListState()
+                val registry = rememberTimelineTrackRegistry()
+                // Index 22 is DayHeader "Yesterday" (after the top spacer, "Today" header, and 20 events); scrolling there puts it at the viewport top with "Today" scrolled fully past.
+                LaunchedEffect(Unit) { listState.scrollToItem(index = 22) }
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    LazyColumn(state = listState, modifier = Modifier.padding(horizontal = Spacing.md)) {
+                        sessionTimelineItems(
+                            timeline = timeline,
+                            hasMore = false,
+                            registry = registry,
+                            onOpenAiRun = { _, _ -> },
+                            onNavigateToHistory = {},
+                        )
+                    }
+                }
+            }
+        }
+        composeTestRule.mainClock.advanceTimeBy(1_000L)
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    /** `suppressEntranceAnimation = true` mirrors the settled end-state a demoted row and its
+     *  successor reach once both have finished reflowing (also what a Home→Settings→back round trip
+     *  renders immediately) via the real `sessionTimelineItems` — capturing that resting frame
+     *  (rather than a static `TimelineTestContent` flattening) exercises `AiRunNode`/`TimelineNode`'s
+     *  actual `isNewlyArrived`-aware rendering path end to end, to guard against the two rows'
+     *  content ever being simultaneously fully opaque and visually superimposed. */
+    @Test
+    fun a_settled_demoted_run_and_its_successor_never_visually_overlap() {
+        composeTestRule.mainClock.autoAdvance = false
+        val timeline = listOf(
+            TimelineItem.AiRun(
+                timestamp = Instant.fromEpochMilliseconds(1L),
+                iteration = fixedIteration(
+                    turn = 1,
+                    kind = RunKind.Replan(TriggerType.CalendarChange),
+                    summary = "Moved alarm to 07:15 — your first meeting shifted to 09:00.",
+                    newAlarmTime = LocalTime(7, 15),
+                    previousAlarmTime = LocalTime(7, 45),
+                ),
+                sessionId = "s1",
+                isStreaming = false,
+                isLatest = true,
+            ),
+            TimelineItem.AiRun(
+                timestamp = Instant.fromEpochMilliseconds(0L),
+                iteration = fixedIteration(turn = 0, kind = RunKind.ScheduledBase, summary = null),
+                sessionId = "s1",
+                isStreaming = false,
+                isLatest = false,
+            ),
+        )
+        composeTestRule.setContent {
+            CronTheme {
+                val listState = rememberLazyListState()
+                val registry = rememberTimelineTrackRegistry()
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    LazyColumn(state = listState, modifier = Modifier.padding(horizontal = Spacing.md)) {
+                        sessionTimelineItems(
+                            timeline = timeline,
+                            hasMore = false,
+                            registry = registry,
+                            suppressEntranceAnimation = true,
+                            onOpenAiRun = { _, _ -> },
+                            onNavigateToHistory = {},
+                        )
+                    }
+                }
+            }
+        }
+        composeTestRule.mainClock.advanceTimeBy(1_000L)
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}
+
+/** Mirrors `sessionTimelineItems`' per-row flag derivation (single continuous segment, list-ends-only
+ *  caps) without the real LazyColumn — a golden-screenshot harness needs deterministic content, not
+ *  live scroll state. */
+@Composable
+private fun TimelineTestContent(timeline: List<TimelineItem>) {
+    val asleepStates = timelineAsleepStates(timeline)
+    val firstAnchorIndex = timeline.indexOfFirst { it !is TimelineItem.DayHeader }
+    val lastAnchorIndex = timeline.indexOfLast { it !is TimelineItem.DayHeader }
+    val registry = rememberTimelineTrackRegistry()
+    Box {
+        TimelineTrackOverlay(registry = registry)
+        Column(modifier = Modifier.padding(horizontal = Spacing.md)) {
+            timeline.forEachIndexed { index, item ->
+                val isSegmentTop = index == firstAnchorIndex
+                val isSegmentBottom = index == lastAnchorIndex
+                val isAsleepAbove = asleepStates[index]
+                val isAsleepBelow = asleepStates.getOrNull(index + 1) ?: asleepStates[index]
+                when (item) {
+                    is TimelineItem.AiRun -> AiRunNode(
+                        item = item,
+                        registry = registry,
+                        isSegmentTop = isSegmentTop,
+                        isSegmentBottom = isSegmentBottom,
+                        isAsleepAbove = isAsleepAbove,
+                        isAsleepBelow = isAsleepBelow,
+                        onClick = {},
+                    )
+                    is TimelineItem.Event -> EventNode(
+                        item = item,
+                        registry = registry,
+                        isSegmentTop = isSegmentTop,
+                        isSegmentBottom = isSegmentBottom,
+                        isAsleepAbove = isAsleepAbove,
+                        isAsleepBelow = isAsleepBelow,
+                    )
+                    is TimelineItem.DayHeader -> DayHeaderRow(item = item)
+                }
+            }
+        }
     }
 }

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/TimelineGalleryScreenshotTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/TimelineGalleryScreenshotTest.kt
@@ -1,0 +1,143 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
+package fr.bsodium.cron.ui.screens.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
+import fr.bsodium.cron.ui.screens.home.TimelineItem
+import fr.bsodium.cron.ui.theme.CronColors
+import fr.bsodium.cron.ui.theme.CronTheme
+import fr.bsodium.cron.ui.theme.Spacing
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/** One-off verification that the gallery previews (`TimelineEventGalleryPreviews.kt`,
+ *  `AiRunHeroGalleryPreviews.kt`) actually render as intended, in both themes — a `@Preview`
+ *  function only gets eyeballed in Android Studio's tooling otherwise, which this suite doesn't run
+ *  in. Robolectric's `+night`/`+notnight` qualifiers pick the theme, mirroring what
+ *  `@PreviewLightDark` does for the IDE. */
+@Suppress("DEPRECATION")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@RunWith(RobolectricTestRunner::class)
+class TimelineGalleryScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Config(qualifiers = "+notnight")
+    @Test
+    fun event_cap_gallery_light() {
+        composeTestRule.setContent { EventCapGalleryPreview() }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Config(qualifiers = "+night")
+    @Test
+    fun event_cap_gallery_dark() {
+        composeTestRule.setContent { EventCapGalleryPreview() }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Config(qualifiers = "+notnight")
+    @Test
+    fun event_interior_gallery_light() {
+        composeTestRule.setContent { EventInteriorGalleryPreview() }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Config(qualifiers = "+night")
+    @Test
+    fun event_interior_gallery_dark() {
+        composeTestRule.setContent { EventInteriorGalleryPreview() }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Config(qualifiers = "+notnight")
+    @Test
+    fun ai_run_hero_gallery_light() {
+        composeTestRule.setContent { AiRunHeroGalleryPreview() }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Config(qualifiers = "+night")
+    @Test
+    fun ai_run_hero_gallery_dark() {
+        composeTestRule.setContent { AiRunHeroGalleryPreview() }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    /** `EventCapGalleryPreview`'s sleep-track section renders below the fold in a fixed-height
+     *  Robolectric window (its `Column` has no scroll), so `event_cap_gallery_*` above never
+     *  exercises it — these two isolate that section alone to verify the `inverseSurface` escape
+     *  hatch ([TriggerVisuals] `capContainerColor`) against every accent. */
+    @Config(qualifiers = "+notnight")
+    @Test
+    fun cap_gallery_sleep_track_light() {
+        composeTestRule.setContent {
+            CronTheme {
+                Column(modifier = Modifier.fillMaxSize().background(CronColors.pageBackground)) {
+                    EventGalleryTrackBlock(sectionLabel = "Cap anchors — sleep track", isAsleep = true, atCap = true)
+                }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Config(qualifiers = "+night")
+    @Test
+    fun cap_gallery_sleep_track_dark() {
+        composeTestRule.setContent {
+            CronTheme {
+                Column(modifier = Modifier.fillMaxSize().background(CronColors.pageBackground)) {
+                    EventGalleryTrackBlock(sectionLabel = "Cap anchors — sleep track", isAsleep = true, atCap = true)
+                }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    /** Every header renders identically (see [DayHeaderRow]'s KDoc) — renders two consecutive
+     *  headers so spacing/divider/label rendering stays visually checked in both themes. */
+    @Config(qualifiers = "+notnight")
+    @Test
+    fun day_header_gallery_light() {
+        composeTestRule.setContent { DayHeaderGallery() }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Config(qualifiers = "+night")
+    @Test
+    fun day_header_gallery_dark() {
+        composeTestRule.setContent { DayHeaderGallery() }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}
+
+@Composable
+private fun DayHeaderGallery() {
+    CronTheme {
+        // Real usage always sits inside HomeContent.kt's LazyColumn contentPadding — matching it here so the big date number isn't rendered flush against the screen edge, which reads as clipped in a screenshot.
+        Column(modifier = Modifier.fillMaxSize().background(CronColors.pageBackground).padding(horizontal = Spacing.md)) {
+            DayHeaderRow(
+                item = TimelineItem.DayHeader(date = LocalDate(2026, 7, 3), timestamp = Instant.fromEpochMilliseconds(0)),
+            )
+            DayHeaderRow(
+                item = TimelineItem.DayHeader(date = LocalDate(2026, 7, 2), timestamp = Instant.fromEpochMilliseconds(0)),
+            )
+        }
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/TimelineNodeScreenshotTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/screens/home/components/TimelineNodeScreenshotTest.kt
@@ -3,12 +3,18 @@
 package fr.bsodium.cron.ui.screens.home.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onRoot
@@ -43,64 +49,157 @@ class TimelineNodeScreenshotTest {
         composeTestRule.setContent {
             CronTheme {
                 val dim = MaterialTheme.colorScheme.onSurfaceVariant
-                Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
-                    TimelineNode(
-                        anchor = TimelineAnchor.Loader,
-                        isFirst = true,
-                        isLast = false,
-                        title = { Text("Replanning", style = MaterialTheme.typography.bodyMedium) },
-                        status = { Text("Latest · 07:16", style = CronTypography.labelMonoSmall, color = dim) },
-                    )
-                    TimelineNode(
-                        anchor = TimelineAnchor.Icon(MaterialSymbol.Snooze),
-                        isFirst = false,
-                        isLast = false,
-                        title = { Text("Alarm snoozed", style = MaterialTheme.typography.bodyMedium, color = dim) },
-                        status = {
-                            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-                                MonoPill("9 min")
-                                Text("07:15", style = CronTypography.labelMonoSmall, color = dim)
-                            }
-                        },
-                    )
-                    TimelineNode(
-                        anchor = TimelineAnchor.Icon(
-                            symbol = MaterialSymbol.Schedule,
-                            tint = MaterialTheme.colorScheme.primary,
-                            containerColor = MaterialTheme.colorScheme.primaryContainer,
-                        ),
-                        isFirst = false,
-                        isLast = false,
-                        onClick = {},
-                        title = { Text("Planned", style = MaterialTheme.typography.bodyMedium) },
-                        status = { Text("Latest · 23:14", style = CronTypography.labelMonoSmall, color = dim) },
-                    )
-                    TimelineNode(
-                        anchor = TimelineAnchor.Latest(MaterialSymbol.Schedule),
-                        isFirst = false,
-                        isLast = false,
-                        onClick = {},
-                        title = { Text("Re-planned", style = CronTypography.timelineHeroTitle) },
-                        status = { Text("Latest · 23:27", style = CronTypography.labelMonoSmall, color = dim) },
-                    )
-                    TimelineNode(
-                        anchor = TimelineAnchor.Plain,
-                        isFirst = false,
-                        isLast = false,
-                        title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = dim) },
-                        status = { Text("23:40", style = CronTypography.labelMonoSmall, color = dim) },
-                    )
-                    TimelineNode(
-                        anchor = TimelineAnchor.Icon(MaterialSymbol.Bedtime),
-                        isFirst = false,
-                        isLast = true,
-                        title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = dim) },
-                        status = { Text("22:30", style = CronTypography.labelMonoSmall, color = dim) },
-                    )
+                val registry = rememberTimelineTrackRegistry()
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                        TimelineNode(
+                            id = "loader",
+                            registry = registry,
+                            anchor = TimelineAnchor.Loader,
+                            isSegmentTop = true,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("Replanning", style = MaterialTheme.typography.bodyMedium) },
+                            status = { Text("Latest · 07:16", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        // Interior + Negative valence → smaller Triangle silhouette (in an accent container so the carved shape reads against the track).
+                        TimelineNode(
+                            id = "snooze",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(
+                                symbol = MaterialSymbol.Snooze,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                valence = TimelineValence.Negative,
+                            ),
+                            isSegmentTop = false,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("Alarm snoozed", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = {
+                                Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                                    MonoPill("9 min")
+                                    Text("07:15", style = CronTypography.labelMonoSmall, color = dim)
+                                }
+                            },
+                        )
+                        // Interior + Positive valence → smaller Flower silhouette.
+                        TimelineNode(
+                            id = "gotup",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(
+                                symbol = MaterialSymbol.DirectionsWalk,
+                                tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                                valence = TimelineValence.Positive,
+                            ),
+                            isSegmentTop = false,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("You got up", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("07:50", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        TimelineNode(
+                            id = "planned",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(
+                                symbol = MaterialSymbol.Schedule,
+                                tint = MaterialTheme.colorScheme.primary,
+                                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            ),
+                            isSegmentTop = false,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            onClick = {},
+                            title = { Text("Planned", style = MaterialTheme.typography.bodyMedium) },
+                            status = { Text("Latest · 23:14", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        TimelineNode(
+                            id = "replanned",
+                            registry = registry,
+                            anchor = TimelineAnchor.Latest(MaterialSymbol.Schedule),
+                            isSegmentTop = false,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            onClick = {},
+                            title = { Text("Re-planned", style = CronTypography.timelineHeroTitle) },
+                            status = { Text("Latest · 23:27", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        TimelineNode(
+                            id = "asleep",
+                            registry = registry,
+                            anchor = TimelineAnchor.Plain,
+                            isSegmentTop = false,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("23:40", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        TimelineNode(
+                            id = "evening",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(MaterialSymbol.Bedtime),
+                            isSegmentTop = false,
+                            isSegmentBottom = true,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("22:30", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                    }
                 }
             }
         }
         // Let the latest-anchor's arrival morph (circle → Cookie9Sided) settle before capturing.
+        composeTestRule.mainClock.advanceTimeBy(1_000L)
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Test
+    fun latest_anchor_nests_flush_at_the_track_s_true_top_cap() {
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            CronTheme {
+                val dim = MaterialTheme.colorScheme.onSurfaceVariant
+                val registry = rememberTimelineTrackRegistry()
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                        // isSegmentTop = true with a track below (not a lone node) — the Latest anchor must not overflow past the top rounded cap here.
+                        TimelineNode(
+                            id = "replanned",
+                            registry = registry,
+                            anchor = TimelineAnchor.Latest(MaterialSymbol.Schedule),
+                            isSegmentTop = true,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            onClick = {},
+                            title = { Text("Re-planned", style = CronTypography.timelineHeroTitle) },
+                            status = { Text("Latest · 23:27", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        TimelineNode(
+                            id = "asleep",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(MaterialSymbol.Bedtime),
+                            isSegmentTop = false,
+                            isSegmentBottom = true,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("23:40", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                    }
+                }
+            }
+        }
         composeTestRule.mainClock.advanceTimeBy(1_000L)
         composeTestRule.onRoot().captureRoboImage()
     }
@@ -111,50 +210,212 @@ class TimelineNodeScreenshotTest {
         composeTestRule.setContent {
             CronTheme {
                 val dim = MaterialTheme.colorScheme.onSurfaceVariant
-                Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
-                    TimelineNode(
-                        anchor = TimelineAnchor.Icon(
-                            symbol = MaterialSymbol.Schedule,
-                            tint = MaterialTheme.colorScheme.primary,
-                            containerColor = MaterialTheme.colorScheme.primaryContainer,
-                        ),
-                        isFirst = true,
-                        isLast = false,
-                        onClick = {},
-                        title = { Text("Planned", style = MaterialTheme.typography.bodyMedium) },
-                        status = { Text("Latest · 23:14", style = CronTypography.labelMonoSmall, color = dim) },
-                        content = {
-                            Text(
-                                "Set alarm for 07:45. You have an 08:30 standup.",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = dim,
-                            )
-                        },
-                    )
-                    TimelineNode(
-                        anchor = TimelineAnchor.Icon(MaterialSymbol.DirectionsWalk),
-                        isFirst = false,
-                        isLast = false,
-                        title = { Text("You got up", style = MaterialTheme.typography.bodyMedium, color = dim) },
-                        status = { Text("07:50", style = CronTypography.labelMonoSmall, color = dim) },
-                    )
-                    TimelineNode(
-                        anchor = TimelineAnchor.Icon(MaterialSymbol.AlarmOff),
-                        isFirst = false,
-                        isLast = false,
-                        title = { Text("Alarm dismissed", style = MaterialTheme.typography.bodyMedium, color = dim) },
-                        status = { Text("07:45", style = CronTypography.labelMonoSmall, color = dim) },
-                    )
-                    TimelineNode(
-                        anchor = TimelineAnchor.Plain,
-                        isFirst = false,
-                        isLast = true,
-                        title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = dim) },
-                        status = { Text("23:10", style = CronTypography.labelMonoSmall, color = dim) },
-                    )
+                val registry = rememberTimelineTrackRegistry()
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                        TimelineNode(
+                            id = "planned",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(
+                                symbol = MaterialSymbol.Schedule,
+                                tint = MaterialTheme.colorScheme.primary,
+                                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            ),
+                            isSegmentTop = true,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            onClick = {},
+                            title = { Text("Planned", style = MaterialTheme.typography.bodyMedium) },
+                            status = { Text("Latest · 23:14", style = CronTypography.labelMonoSmall, color = dim) },
+                            content = {
+                                Text(
+                                    "Set alarm for 07:45. You have an 08:30 standup.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = dim,
+                                )
+                            },
+                        )
+                        TimelineNode(
+                            id = "got_up",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(MaterialSymbol.DirectionsWalk),
+                            isSegmentTop = false,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("You got up", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("07:50", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        TimelineNode(
+                            id = "dismissed",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(MaterialSymbol.AlarmOff),
+                            isSegmentTop = false,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("Alarm dismissed", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("07:45", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        TimelineNode(
+                            id = "asleep",
+                            registry = registry,
+                            anchor = TimelineAnchor.Plain,
+                            isSegmentTop = false,
+                            isSegmentBottom = true,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("23:10", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                    }
                 }
             }
         }
+        composeTestRule.mainClock.advanceTimeBy(1_000L)
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Test
+    fun asleep_awake_track_shows_the_transition_and_rounded_terminal_caps() {
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            CronTheme {
+                val dim = MaterialTheme.colorScheme.onSurfaceVariant
+                val registry = rememberTimelineTrackRegistry()
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                        // True top terminus — rounded cap, fully awake below.
+                        TimelineNode(
+                            id = "planned",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(MaterialSymbol.Schedule),
+                            isSegmentTop = true,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("Planned", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("21:00", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        // Fully awake — uniform, no split.
+                        TimelineNode(
+                            id = "schedule_changed",
+                            registry = registry,
+                            anchor = TimelineAnchor.Plain,
+                            isSegmentTop = false,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("Your schedule changed", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("22:15", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        // The onset row itself: awake above, asleep below — the sleep pill opens its own rounded cap here instead of a flat cut.
+                        TimelineNode(
+                            id = "onset",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(MaterialSymbol.Bedtime),
+                            isSegmentTop = false,
+                            isSegmentBottom = false,
+                            isAsleepAbove = false,
+                            isAsleepBelow = true,
+                            title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("23:00", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        // Fully asleep — uniform, no split.
+                        TimelineNode(
+                            id = "movement",
+                            registry = registry,
+                            anchor = TimelineAnchor.Plain,
+                            isSegmentTop = false,
+                            isSegmentBottom = false,
+                            isAsleepAbove = true,
+                            isAsleepBelow = true,
+                            title = { Text("Movement detected", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("03:20", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        // The wake row itself: asleep above, awake below — the sleep pill closes its own rounded cap here.
+                        TimelineNode(
+                            id = "wake",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(MaterialSymbol.DirectionsWalk),
+                            isSegmentTop = false,
+                            isSegmentBottom = false,
+                            isAsleepAbove = true,
+                            isAsleepBelow = false,
+                            title = { Text("You got up", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("07:15", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        // True bottom terminus — rounded cap, fully awake above.
+                        TimelineNode(
+                            id = "dismissed",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(MaterialSymbol.AlarmOff),
+                            isSegmentTop = false,
+                            isSegmentBottom = true,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            title = { Text("Alarm dismissed", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("07:20", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                    }
+                }
+            }
+        }
+        composeTestRule.mainClock.advanceTimeBy(1_000L)
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Test
+    fun icon_anchor_stays_separated_from_a_same_color_track_segment() {
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            CronTheme {
+                val dim = MaterialTheme.colorScheme.onSurfaceVariant
+                val asleep = MaterialTheme.colorScheme.tertiaryContainer
+                val onAsleep = MaterialTheme.colorScheme.onTertiaryContainer
+                val registry = rememberTimelineTrackRegistry()
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                        // A Body-accent icon (tertiaryContainer, matching TimelineAccent.Body) sitting on an asleep track segment — without proper nesting it has zero contrast and disappears into the track.
+                        TimelineNode(
+                            id = "onset",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(
+                                symbol = MaterialSymbol.Bedtime,
+                                tint = onAsleep,
+                                containerColor = asleep,
+                            ),
+                            isSegmentTop = true,
+                            isSegmentBottom = false,
+                            isAsleepAbove = true,
+                            isAsleepBelow = true,
+                            title = { Text("You fell asleep", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("23:14", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                        TimelineNode(
+                            id = "wake",
+                            registry = registry,
+                            anchor = TimelineAnchor.Icon(
+                                symbol = MaterialSymbol.DirectionsWalk,
+                                tint = onAsleep,
+                                containerColor = asleep,
+                            ),
+                            isSegmentTop = false,
+                            isSegmentBottom = true,
+                            isAsleepAbove = true,
+                            isAsleepBelow = true,
+                            title = { Text("You got up", style = MaterialTheme.typography.bodyMedium, color = dim) },
+                            status = { Text("07:15", style = CronTypography.labelMonoSmall, color = dim) },
+                        )
+                    }
+                }
+            }
+        }
+        composeTestRule.mainClock.advanceTimeBy(1_000L)
         composeTestRule.onRoot().captureRoboImage()
     }
 
@@ -187,17 +448,24 @@ class TimelineNodeScreenshotTest {
         composeTestRule.mainClock.autoAdvance = false
         composeTestRule.setContent {
             CronTheme {
-                Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
-                    AiRunNode(
-                        item = latestAiRun(
-                            summary = "Moved alarm to 07:15 — your first meeting shifted to 09:00.",
-                            newAlarmTime = LocalTime(7, 15),
-                            previousAlarmTime = LocalTime(7, 45),
-                        ),
-                        isFirst = true,
-                        isLast = true,
-                        onClick = {},
-                    )
+                val registry = rememberTimelineTrackRegistry()
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                        AiRunNode(
+                            item = latestAiRun(
+                                summary = "Moved alarm to 07:15 — your first meeting shifted to 09:00.",
+                                newAlarmTime = LocalTime(7, 15),
+                                previousAlarmTime = LocalTime(7, 45),
+                            ),
+                            registry = registry,
+                            isSegmentTop = true,
+                            isSegmentBottom = true,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            onClick = {},
+                        )
+                    }
                 }
             }
         }
@@ -211,17 +479,24 @@ class TimelineNodeScreenshotTest {
         composeTestRule.mainClock.autoAdvance = false
         composeTestRule.setContent {
             CronTheme {
-                Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
-                    AiRunNode(
-                        item = latestAiRun(
-                            summary = "Set your first alarm for the day.",
-                            newAlarmTime = LocalTime(7, 45),
-                            previousAlarmTime = null,
-                        ),
-                        isFirst = true,
-                        isLast = true,
-                        onClick = {},
-                    )
+                val registry = rememberTimelineTrackRegistry()
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                        AiRunNode(
+                            item = latestAiRun(
+                                summary = "Set your first alarm for the day.",
+                                newAlarmTime = LocalTime(7, 45),
+                                previousAlarmTime = null,
+                            ),
+                            registry = registry,
+                            isSegmentTop = true,
+                            isSegmentBottom = true,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            onClick = {},
+                        )
+                    }
                 }
             }
         }
@@ -230,21 +505,97 @@ class TimelineNodeScreenshotTest {
     }
 
     @Test
-    fun ai_run_node_latest_falls_back_to_prose_with_no_new_time() {
+    fun ai_run_node_latest_shows_the_standing_time_with_prose_demoted_below() {
         composeTestRule.mainClock.autoAdvance = false
         composeTestRule.setContent {
             CronTheme {
-                Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
-                    AiRunNode(
-                        item = latestAiRun(
-                            summary = "Cancelled today's alarm — no early meetings on your calendar.",
-                            newAlarmTime = null,
-                            previousAlarmTime = LocalTime(7, 45),
-                        ),
-                        isFirst = true,
-                        isLast = true,
-                        onClick = {},
-                    )
+                val registry = rememberTimelineTrackRegistry()
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                        AiRunNode(
+                            item = latestAiRun(
+                                summary = "Cancelled today's alarm — no early meetings on your calendar.",
+                                newAlarmTime = null,
+                                previousAlarmTime = LocalTime(7, 45),
+                            ),
+                            registry = registry,
+                            isSegmentTop = true,
+                            isSegmentBottom = true,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            onClick = {},
+                        )
+                    }
+                }
+            }
+        }
+        composeTestRule.mainClock.advanceTimeBy(1_000L)
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    /** A row that WAS latest and gets superseded (`isLatest` true → false within the same
+     *  composition) keeps `everLatest = true`, and its title `Crossfade` keeps reserving hero-sized
+     *  height even in the demoted single-line state. `Crossfade` has no `contentAlignment` param and
+     *  its own internal `Box` defaults to `TopStart`, so the demoted `Text` must be centered
+     *  explicitly or it floats at the top of that reserved height with visible dead space below —
+     *  only reproduces via an actual true→false transition, not a row demoted from its first
+     *  composition. */
+    @Test
+    fun ai_run_node_demoted_after_being_latest_centers_its_title_in_the_reserved_height() {
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            CronTheme {
+                val registry = rememberTimelineTrackRegistry()
+                var isLatest by remember { mutableStateOf(true) }
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                        AiRunNode(
+                            item = latestAiRun(
+                                summary = "Cancelled today's alarm — no early meetings on your calendar.",
+                                newAlarmTime = null,
+                                previousAlarmTime = LocalTime(7, 45),
+                            ).copy(isLatest = isLatest),
+                            registry = registry,
+                            isSegmentTop = true,
+                            isSegmentBottom = true,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            onClick = {},
+                        )
+                    }
+                }
+                LaunchedEffect(Unit) { isLatest = false }
+            }
+        }
+        composeTestRule.mainClock.advanceTimeBy(1_000L)
+        composeTestRule.onRoot().captureRoboImage()
+    }
+
+    @Test
+    fun ai_run_node_latest_shows_a_static_label_with_no_time_at_all() {
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            CronTheme {
+                val registry = rememberTimelineTrackRegistry()
+                Box {
+                    TimelineTrackOverlay(registry = registry)
+                    Column(modifier = Modifier.padding(horizontal = Spacing.lg)) {
+                        AiRunNode(
+                            item = latestAiRun(
+                                summary = "No prior alarms to compare against yet.",
+                                newAlarmTime = null,
+                                previousAlarmTime = null,
+                            ),
+                            registry = registry,
+                            isSegmentTop = true,
+                            isSegmentBottom = true,
+                            isAsleepAbove = false,
+                            isAsleepBelow = false,
+                            onClick = {},
+                        )
+                    }
                 }
             }
         }

--- a/app/src/test/java/fr/bsodium/cron/ui/theme/CronThemeColorTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/theme/CronThemeColorTest.kt
@@ -1,0 +1,39 @@
+package fr.bsodium.cron.ui.theme
+
+import android.app.Application
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Diagnostic for a user report that the timeline's asleep-track color (tertiaryContainer) looked
+ * identical after switching the device from dark to light theme. CronTheme.kt's own branching
+ * (isSystemInDarkTheme -> dynamicDarkColorScheme/dynamicLightColorScheme) reads correctly on
+ * inspection; this verifies the underlying M3 dynamic-color constructors themselves produce
+ * genuinely different tonal palettes for light vs dark, independent of any app-level logic — if
+ * this passes, CronTheme's branching is confirmed correct and an on-device report of no visible
+ * difference is more likely OEM/dynamic-color-cache related, not an in-app bug.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CronThemeColorTest {
+
+    private val app: Application = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun light_and_dark_dynamic_schemes_have_different_tertiary_container() {
+        val dark = dynamicDarkColorScheme(app)
+        val light = dynamicLightColorScheme(app)
+        assertNotEquals(dark.tertiaryContainer, light.tertiaryContainer)
+    }
+
+    @Test
+    fun light_and_dark_dynamic_schemes_have_different_surface_container_high() {
+        val dark = dynamicDarkColorScheme(app)
+        val light = dynamicLightColorScheme(app)
+        assertNotEquals(dark.surfaceContainerHigh, light.surfaceContainerHigh)
+    }
+}

--- a/app/src/test/java/fr/bsodium/cron/ui/theme/MaterialSymbolsScreenshotTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/ui/theme/MaterialSymbolsScreenshotTest.kt
@@ -1,0 +1,71 @@
+package fr.bsodium.cron.ui.theme
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.captureRoboImage
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+/** `Symbol()` bakes its variation axes into a cached `Typeface` variant rather than a live per-Paint
+ *  override (see docs/color-roles.md) — this covers the two glyphs reported off-center on-device
+ *  (`AlarmOff`, `NotificationImportant`, both compound bell-based icons) at the exact size the
+ *  timeline uses them, alongside the two that were already correct (`PlayArrow`, `Bedtime`) as a
+ *  no-regression control. */
+@Suppress("DEPRECATION")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@RunWith(RobolectricTestRunner::class)
+class MaterialSymbolsScreenshotTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun timeline_glyphs_sit_centered_in_their_dot_at_icon_size() {
+        composeTestRule.setContent {
+            CronTheme {
+                Row(
+                    modifier = Modifier.padding(Spacing.lg),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+                ) {
+                    listOf(
+                        MaterialSymbol.PlayArrow,
+                        MaterialSymbol.Bedtime,
+                        MaterialSymbol.AlarmOff,
+                        MaterialSymbol.NotificationImportant,
+                    ).forEach { symbol ->
+                        Box(
+                            modifier = Modifier
+                                .size(18.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Symbol(
+                                symbol = symbol,
+                                contentDescription = symbol.name,
+                                size = 14.dp,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        composeTestRule.onRoot().captureRoboImage()
+    }
+}

--- a/docs/color-roles.md
+++ b/docs/color-roles.md
@@ -49,3 +49,1022 @@ Applied example — none currently in this codebase. `AiRunNode`'s content slot 
 As of this pass, every accent usage in the timeline (`TriggerVisuals.kt`, `TimelineNode.kt`'s `TimelineAnchor.Icon`/`Latest`) only ever touches the neutral page background directly — no accent is nested inside a differently-hued container yet. No changes were needed; this doc exists so the next addition doesn't regress it.
 
 Round 3 added one more direct (non-nested) `primary` usage: the latest timeline run's kicker label (`SessionTimeline.kt`'s `AiRunNode`) is now tinted `colorScheme.primary`, deliberately matching the `LatestAnchor`'s `primary` fill and the countdown card's (`NextAlarmCard.kt`) `primary` fill, so the newest run visually rhymes with the alarm card above it. All three still only touch the neutral page background — none nests inside a differently-hued container — so this is a plain on-role pairing (`primary` on `surface`), not a case requiring one of the three nesting strategies above.
+
+Round 4 — timeline track. The two-tone vertical track (`TimelineNode.kt`) reuses `TimelineAccent.Body`'s `tertiaryContainer` for "asleep" stretches and `TimelineAccent.Schedule`'s `surfaceContainerHigh` for "awake" stretches — deliberately the *same* container roles already used for the `SleepOnset`/`OutOfBedConfirmed` event icons and the neutral "nothing happening" icons, rather than a new, undocumented pairing. The track is a plain fill touching only the neutral page background (no nesting), so none of the three nesting strategies above apply; the anchor icons sitting on/inside the tube carry their own correct `on*Container` pairing independently.
+
+Round 5 — anchor halo, the nesting case Round 4 missed. Round 4's "no nesting" conclusion assumed the track was a passive background, but the anchor icons paint *directly on top of it*, and a `Body`-accent icon (`tertiaryContainer`) can land on an asleep track segment (also `tertiaryContainer`) — the exact same role on both sides, so the icon's circular fill has no edge against the track behind it. This *is* a nesting case, and it calls for strategy 1: buffer via surface level. A first pass punched a `CronColors.pageBackground` disc behind each anchor's own circle as a separate layered halo ring — it fixed the color collision, but on-device testing showed it still read as a sticker lifted off the tube (a ring of ground color around a disc is the classic "lifted, not embedded" cue), not the nested transit-stop look intended.
+
+Round 6 — carved socket, replacing the layered halo. `TimelineNode.kt`'s `drawTrackSocket` now carves the anchor's silhouette directly out of the track's own path (`Path.op(trackPath, holePath, PathOperation.Difference)`) instead of layering a separate disc+ring on top — the anchor and the tube share one boundary, which is what actually reads as "set into" rather than "resting in front of." The carved rim is still `CronColors.pageBackground`, still `Spacing.xxs` wide, still strategy 1 in spirit (a neutral buffer below both track colors on the tone ladder) — only its geometric ownership changed, from a disc's backing to the tube's own interior edge. The hole is filled with the same accent each anchor variant always used (`Icon.containerColor`, `Loader`'s `primaryContainer`, `Plain`'s `outlineVariant`), now flush in the tube's plane, so the same-role collision stays structurally impossible as a property of the geometry, not a color patch. Anchors are also now inscribed to exactly fill `TRACK_WIDTH` rather than overflowing it, reinforcing the "bead threaded on the line" read. `TimelineAnchor.Latest`'s morphing `Cookie9Sided` shape (`LatestAnchor.kt`) is exempt from all of this — it's non-circular, so it can't share a carved socket with the tube, and it's meant to break out of the track as the "major interchange" rather than nest in it; it keeps the old two-segment track drawing with no hole and no halo.
+
+Round 7 — grow the track, decouple the track's role from the icon's, and give every anchor a real gap. Round 6's Latest exemption and Round 4's track-color reuse both turned out to be the wrong call once tested overnight on-device: the Latest anchor visibly overflowed a track sized for a plain circle, and reusing `TimelineAccent.Body`'s `tertiaryContainer` for the asleep track segment meant the track inherited that role's M3-spec-intentional light/dark asymmetry (pale in light scheme, bold in dark scheme) as its *only* color, which reads as a genuine contrast bug rather than the icon-pairing feature it originally was. A first pass at fixing the Latest overflow grew `TRACK_WIDTH` and made every anchor's hole exactly fill the tube's cross-section (content + 2×rim == `TRACK_WIDTH`, rim painted the same accent as the content) — but a second on-device screenshot showed this reads as "the tube becomes the icon," not "the icon nests in the tube": a circular hole inscribed to exactly match a straight-sided tube's width only touches the tube's walls at its exact vertical center, and filling the *entire* hole (content and rim alike) with one accent color meant the icon's own glyph sat in a disc as wide as the whole tube, with barely any visible margin around it.
+
+The fix: split the hole into two concentric layers instead of one. `ANCHOR_GAP` (`Spacing.xs`) is now a genuinely **neutral** buffer — the socket's outer hole (`content diameter + 2×ANCHOR_GAP`) is carved out of the track and filled with `CronColors.pageBackground`, and each anchor's own accent-colored content (the icon's container disc, the Loader's indicator, the Latest morph's fill, all already self-painting except `Icon`, which now gets an explicit `drawCircle` in the same `drawBehind` pass) is drawn centered *inside* that neutral hole at its own smaller diameter. The track's own color is now visible framing every anchor, which is what actually reads as "nested in the line" — a bead sitting inside the tube, not the tube's cross-section replaced outright. `TimelineAnchor.Latest`'s content diameter shrinks to match a regular icon's (`18dp`) rather than the full tube width, since its own morph silhouette, bold `primary` fill, and arrival spring are enough to distinguish it without also being oversized.
+
+Two further changes from the same round:
+
+- **`TRACK_WIDTH` grows from 20dp to 28dp** (`Spacing.xxl + Spacing.xs`) — comfortably larger than any anchor's outer footprint (content + gap), so nothing pokes past the tube's edges the way Latest used to.
+- **The asleep track segment moves from `tertiaryContainer` to bare `tertiary`** (`SessionTimeline.kt`'s `trackColorFor`) — a bold accent role that sits at a consistently visible tone in both light and dark schemes, unlike a `*Container` role. This is the same reasoning `LatestAnchor` and `AiRunNode`'s kicker already apply to `primary`. **This deliberately un-reuses Round 4's role-sharing with `TimelineAccent.Body`** — `TriggerVisuals.kt` is untouched, so a sleep-event icon (e.g. "You fell asleep") still carves a `tertiaryContainer`/`onTertiaryContainer` disc, now into a bolder `tertiary` tube, always separated from it by the same neutral `ANCHOR_GAP` ring every anchor gets — so this can't regress icon legibility, only fix the track's own cross-theme contrast.
+
+Round 8 — calmer track color, single-carve nesting with an end-cap-aware radius, importance-tiered icon contrast. Round 7's neutral-gap fix itself read as broken on a fresh on-device pass: bare `tertiary` was too vivid for the asleep track, and the two-layer socket (a neutral ring plus a separately-drawn accent disc) looked like two concentric circles rather than one nested shape.
+
+- **Asleep track color is now a blend, not a flat role**: `lerp(scheme.surfaceContainerHighest, scheme.tertiary, 0.22f)` (`ASLEEP_TRACK_TINT`), the same `lerp` technique `Theme.kt`'s `liftedSurfaces()` already uses. `surfaceContainerHighest` is the most-elevated neutral surface, generated symmetrically on the tone ladder in both themes — blending in a minority of `tertiary` keeps that symmetry (no light/dark asymmetry reintroduced) while calming the full-chroma vividness bare `tertiary` had, and it still reads as one rung more elevated than the awake `surfaceContainerHigh`.
+- **The two-layer gap is gone — back to one carved hole per anchor, filled directly with its own accent color.** `ANCHOR_GAP` (a neutral-filled ring) is replaced by `ANCHOR_PADDING` (`Spacing.xxs`), which is no longer painted at all — it's just margin left uncarved, so the track's own (now calmer) color shows through around the anchor instead of a separately-colored ring. `TimelineNode.kt`'s `socketAccentColor()` (replacing `socketFillColor`) is now exhaustive over all four anchor types and fills every hole directly — including `Loader`/`Latest`, which already self-paint the same color on top (no seam), and `Plain`, whose own self-painted dot is now redundant and removed for the socket-carved case (the carved fill *is* the dot).
+- **End-cap-aware radius**: at a track's true `isFirst`/`isLast` terminus, the anchor's center coincides exactly with the tube's own rounded-cap center, so the carved hole there uses `max(contentRadius, halfTrack − ANCHOR_PADDING)` instead of a plain content-sized circle — a smaller concentric version of the tube's own rounded end, nesting properly instead of reading as an arbitrary circle dropped onto a curved edge. `TRACK_WIDTH` grows from 28dp to `Spacing.xxxl` (32dp) so this end-cap disc has real room.
+- **Icon backgrounds now carry an *importance* tier, orthogonal to `TimelineAccent`'s hue family** (`TriggerVisuals.kt`'s new `TimelineImportance`): `Prominent` events (real alarm/state changes — dismissed, snoozed, the hard-latest safety alarm, a wake-window opportunity, confirmed out-of-bed) keep their hue's real container tone, which sits far enough from either track color to pop; `Muted` events (ambient sensing, routine schedule checks) always drop to a neutral `surfaceContainerLow`/`onSurfaceVariant` pair regardless of hue, so they recede into the track instead of competing for attention. Container and on-container are still chosen together as a pair per tier — the "not optional" rule above still holds, just with importance as an added key.
+
+Round 9 — the track is two shapes, not one; the Latest anchor's footprint finally matches its carve. A fresh on-device pass found the sleep/awake transition still read as a sharp cut (Round 8 only carved a single shared path, colored in two halves with no rounding at the transition), and the Latest anchor still overflowed the track's top cap in some rows.
+
+- **The Latest anchor's ~2dp offset was a real footprint bug, not a geometry-tuning issue.** `TimelineAnchor.diameter()` (which the carve's `anchorCenter` math is built on) assumes every anchor's outer footprint is `contentDiameter() + 2×ANCHOR_PADDING`, matching how `Icon`/`Plain`/`Loader` are wrapped in `AnchorFootprint`. `Latest` alone bypassed `AnchorFootprint`, rendering its own morph fill in a bare box sized to just `contentDiameter()` — so its actual visual center sat 2dp off from where the carve was centered, letting the morph shape poke past the track's rounded cap. Routing `Latest` through `AnchorFootprint` like every other anchor (`AnchorCircle`'s `Latest` branch) fixed it with no signature change.
+- **The track is now genuinely two overlapping shapes**: an always-present, round-capped **background** spanning the whole visible track (rounded only at the list's true first/last row), and a separate round-capped **sleep-pill overlay** drawn on top wherever a contiguous asleep stretch occurs — capped at its *own* onset/wake row, not just the list's global boundary. Both are carved independently via the same `Path.op(..., PathOperation.Difference)` technique (no antialiasing seam), so an icon marking a sleep block's own start or end nests concretely into *that pill's* rounded terminus (`atAnyCap` now also checks `sleepOpensHere`/`sleepClosesHere`, not just global `isFirst`/`isLast`) — the actual "background track + independently-capped sleep pills" mental model the user asked for, not a two-tone single shape. `TimelineNode`'s public signature changed from `trackColorAbove/Below: Color` to `isAsleepAbove/Below: Boolean`, since the track's two colors are now fixed constants (`trackColorFor`) resolved inside `TimelineNode`, not arbitrary per-half values a caller supplies.
+
+Round 10 — a rounded cap only nests if its rect is trimmed to the anchor, not just rounded; icon glyph ink wasn't centered in its own box. A fresh on-device pass found the sleep pill overflowing past the track's true edge in some rows and falling short in others, plus every icon still reading a few px off-center inside its circle — a report that had already surfaced once in Round 9 without a real fix (only `Latest`'s own footprint mismatch was addressed that round).
+
+- **A rounded cap's curvature is only concentric with the carved hole if the rect it's rounding is trimmed to stop exactly at the anchor's center — rounding an untrimmed rect just rounds the wrong point.** Before Round 9, the single shared track path trimmed its own rect to the anchor (`top = if (isFirst) center else 0f`) at a cap; Round 9's rewrite of `bgPath` kept the *rounding* flag but dropped the *trim*, always spanning `[0, size.height]` — so an `isFirst` cap's curvature centered at `(cx, 0 + halfTrack)`, generally a different point than the hole's own center (`anchorCenter`). The overlay pill already trimmed correctly for its *own* local cap (`sleepOpensHere`/`sleepClosesHere`), but reused the same untrimmed branch whenever a **global** cap coincided with a *continuing* sleep state (`isFirst && isAsleepAbove`, `isLast && isAsleepBelow`) — exactly the two reported directions (overflow at one end, falling short at the other). The fix keys both `bgPath`'s and the overlay's rect extents off the same `roundTop`/`roundBottom` booleans that decide rounding, so a trimmed edge and a rounded edge are always the same edge — `bgTop = if (isFirst) center else 0f` (background only cares about the list's true ends), `overlayTop = if (roundTop) center else 0f` (the overlay's cap folds in the local sleep boundary too).
+- **The icon glyph itself wasn't centered in its drawing canvas — a font-rendering issue, not a Compose layout bug.** `Symbol()` (`MaterialSymbols.kt`) drew every glyph at a fixed `(size/2, size)` origin (`Paint.Align.CENTER` for x, baseline pinned to the canvas's bottom edge for y), assuming that always maps the em-square onto the icon's own box. A Roborazzi render + pixel measurement across 5 different icons/positions/colors found a consistent rightward bias regardless of which icon or where it sat — ruling out per-glyph ink asymmetry (different glyphs would drift differently) and pointing at the shared drawing code instead. The fix measures the glyph's *actual* ink rectangle via `Paint.getTextBounds` for the current size/variation settings and centers the draw origin on that, the same "measure the real thing, don't assume a fixed origin" approach `AlignedFirstGlyph` (`NextAlarmCard.kt`) already uses — confirmed via direct pixel measurement afterward (hole-fill bbox center and glyph-ink bbox center now coincide exactly on both axes). This is a one-line-call-site change in the shared `Symbol()` composable, so every icon in the app is centered more accurately, not just the timeline's.
+- **A session's first turn can now carry over a real PREV time.** `AiIterationUi.previousAlarmTime` only ever looked within its own session's turn history, so a fresh session's turn 0 always showed NEW alone. `HomeViewModel.timelineFlow` now looks at the most-recent *older* session's own last resolved alarm time (history is guaranteed most-recent-first by `SessionDao.findPaginated`'s `ORDER BY createdAt DESC`) and patches turn 0's `previousAlarmTime` with it when null — a genuine intra-session PREV is never overwritten.
+
+Round 11 — fold the "Latest · HH:MM" status line into the kicker. The hero row showed a static kicker (`iter.systemMessage`, e.g. "PLANNED MANUALLY") above the PREV › NEW time, and a separate "Latest · HH:MM" line below in the content slot — two places carrying a time-ish fact where one would do. `SessionTimeline.kt`'s `AiRunNode` now computes a `kickerSuffix` off the sealed `RunKind` (exhaustive `when`, no `else`): a base plan (`ScheduledBase`/`ManualBase`) gets a relative "· Xm ago" (reusing `OldPlanFooter.kt`'s `rememberRelativeAgo`, promoted `private` → `internal`), since a base plan can be many hours old and the evening plan vs. a replan minutes ago read very differently; a `Replan` gets an absolute "· at HH:MM" instead, since replans usually cluster close together and an exact clock time is more useful for correlating against the other rows around them. The standalone status-line `Text` is gone; `content` collapses to `null` when there's no `heroHeadline` prose, rather than always building a now-empty `Column`.
+
+Round 12 — the flush-nest illusion only works for a circular hole; a live per-Paint variation override doesn't guarantee measurement and rendering see the same glyph.
+
+- **`TimelineAnchor.Latest`'s scalloped morph shape broke the cap-nesting illusion Round 8 built for circular anchors.** At any cap, the background rect is deliberately trimmed to a single point at the anchor's own center (`bgTop = center` when `isFirst`, with `topLeft`/`topRight` radius equal to the rect's own half-width) — the two rounded corners coincide into one point, so the background has *zero* area above it. The illusion that fills that gap: the anchor's own hole-fill is deliberately inflated to `endCapRadiusPx` at a cap, so its upper half *is* the visible rounded cap, just recolored in the anchor's accent — this only reads correctly when that hole-fill traces a perfect circle (true for `Icon`/`Plain`/`Loader`). `Latest`'s `Cookie9Sided` morph is scalloped, not circular, so inflating it the same way made its petals visibly overshoot the implied arc — exactly the "test plan shape overflowing the track" report. Separately, and only invisible by coincidence: `LatestAnchor.kt`'s own `Canvas` is hardcoded to `LATEST_ANCHOR_SIZE` (18dp) regardless of the inflated hole radius, so the carved hole and the actual painted fill were already two different sizes, papered over only because both use the same `primary` fill. The fix: `TimelineAnchor.Latest` opts out of the cap inflation entirely (`holeRadiusPx` stays at `contentRadiusPx` even `atAnyCap`) and always renders at its true size, accepting the same small `ANCHOR_PADDING` ring every anchor gets at an interior row — this also incidentally re-syncs the carved hole and `LatestAnchor`'s fixed-size fill, since neither depends on the other's independent inflation anymore.
+- **A live per-Paint `fontVariationSettings` string isn't guaranteed to resolve identically on `Paint.getTextBounds`'s measurement path and `Canvas.drawText`'s render path.** Two icons (`AlarmOff`, `NotificationImportant`) still read a few px off-center on-device after Round 10's ink-bounds fix, while others (`PlayArrow`, `Bedtime`) didn't — same `Symbol()` code path, different glyphs, different result. The two off-center icons are **compound** glyphs (a bell plus a diagonal slash, a bell plus an exclamation badge) whose parts reshape relative to each other across the `wght`/`GRAD`/`opsz` axes; a simple convex glyph's silhouette barely changes shape across those same axes, so the same measure/render divergence stays invisible there. `Symbol()` now bakes those three axes into a real cached `Typeface` variant (`Typeface.Builder(file).setFontVariationSettings(...)`, keyed per weight/grade/opticalSize) instead of a live per-Paint override, so measurement and rendering are guaranteed to resolve the same physical glyph outline — `fill` stays on the cheap per-Paint path since it's animated per-frame elsewhere (`CronNavigationBar`'s tab-selection morph) and mostly affects interior strokework, not the outer bbox centering depends on. `Typeface.Builder` has no constructor that accepts an already-resolved `Typeface` or a `res/font` id directly, only a raw file/asset path, so the bundled subset is extracted once per process into the app's cache dir to get a real `File` to build from.
+
+Round 13 — the track is a single continuous overlay, not per-row slices; every anchor is flush, not just the true caps. Two changes landed together because the second only became visible once the first shipped.
+
+- **The track used to be drawn per-row**, each `TimelineNode.drawBehind` painting its own `[0..height]` slice with caps decided by that row's own `isFirst`/`isLast`/sleep flags. Under the list's `animateItem` glide+fade this was structurally fragile: on insert/remove, cap ownership flipped instantaneously between rows instead of gliding: `animateItem`'s fade faded each row's track slice along with its content, and adjacent slices could gap or overlap mid-transition. The fix decouples the track from the rows entirely: `TimelineNode` now renders only its glyph/content (transparent background) and reports its own window-space anchor center plus an `AnchorDescriptor` (radius, shape, accent, segment id, cap/sleep flags) into a shared `TimelineTrackRegistry` (`TimelineAnchorRegistry.kt`) via `onGloballyPositioned`/`SideEffect`, cleaning up via `DisposableEffect`. A single new painter, `TimelineTrackOverlay.kt`, sits behind the whole `LazyColumn` and draws the entire track in one pass: anchors are grouped by segment id (incrementing at each `DayHeader`), one round-capped background stadium is drawn per segment from its topmost to bottommost *currently composed* anchor (rounding only where that anchor is a true segment end — otherwise the stadium runs uncapped to the viewport edge, since the segment continues off-screen), continuous sleep pills are drawn the same way, and each anchor's own socket is carved and filled on top. Because it's one continuous path rather than N independent per-row slices, it physically cannot gap or re-cap while rows glide or fade — the caps just track the live position of whichever anchor is currently topmost/bottommost.
+- **Once the track was a shared painter, Round 8's "only inflate a circular hole at a true cap" rule (`docs/color-roles.md` above) read as wrong, not just incomplete.** Every anchor not sitting at a true segment/sleep boundary stayed at its small nominal content radius (9dp) inside a 32dp-wide track, leaving a ~7dp ring of bare track color on every side — fine when the eye reads a row at a time, but glaringly disconnected once the whole track is visible as one continuous shape, confirmed against a reference showing every anchor (capped or not) nesting flush with only a thin rim. The fix folds every anchor size (`PLAIN_DOT_SIZE`/`ICON_DOT_SIZE`/`LOADER_DOT_SIZE`/`LATEST_ANCHOR_SIZE`) into one shared `FLUSH_ANCHOR_SIZE = TRACK_WIDTH − 2×ANCHOR_PADDING` (`TimelineNode.kt`), so `contentRadius + ANCHOR_PADDING == halfTrack` holds by construction for every anchor, at every position — the "never overflow the track" invariant is now structural rather than a per-site inflation check, and the cap-only `atCap`/`endCapRadius` branch in `TimelineTrackOverlay`'s socket carve is dead code, removed. `TimelineAnchor.Latest`'s `Cookie9Sided` morph gets the same flush diameter (a deliberate reversal of Round 12's "keep it smaller to avoid overshooting the cap arc," since `buildMorphPath` already scales the morph to fit exactly within whatever diameter it's given — the overshoot Round 12 fixed was specific to inflating *only at a cap*, which no longer happens).
+- **A track-center bug surfaced once flush sizing made every anchor's position matter far more:** `TimelineTrackOverlay`'s `trackCenterX` originally read `placed.first().cx` off a `SnapshotStateMap`'s `keys`, whose iteration order is arbitrary hash order, not insertion or visual order. Every anchor centers in the same fixed-width gutter so this happened to work, but it's fragile against a differently-ordered or momentarily-stale entry; it's now `placed.map { it.cx }.average()`, order-independent and self-correcting.
+
+Round 14 — variable anchor sizing, semantic valence shapes, a neutral Latest, and a completeness-gated overlay. Round 13's "every anchor flush" fixed a detachment problem but flattened the Google-Maps transit read the user wanted back; this round restores the interior/cap size distinction and layers several polish items on top.
+
+- **Variable anchor sizing.** A cap anchor (segment top/bottom, or a sleep sub-track's own onset/wake) keeps `FLUSH_ANCHOR_SIZE` (28dp, 2dp rim); every interior anchor shrinks to a new `INTERIOR_ANCHOR_SIZE` (20dp, 6dp rim) — clearly nested, not a rounding difference. The `atCap` predicate (`isSegmentTop || isSegmentBottom || sleepOpensHere || sleepClosesHere`) is computed in `TimelineNode` (it already receives all four flags) and picks between the two sizes for all four anchor types with no per-type exception. The glyph itself (`ICON_GLYPH_SIZE`) doesn't shrink — it just fills more of its smaller disc. The Latest run is always the segment top, so it evaluates `atCap = true` and reads big with no special rule. The reported `contentRadiusPx` is wrapped in `animateFloatAsState(defaultSpatialSpec())` so a row that stops being a cap (superseded by an insertion) visibly shrinks instead of snapping.
+- **Latest anchor drops its exclusive color, keeps its morph.** Its socket accent moves from `primary` to `primaryContainer` (and `LatestAnchor`'s glyph from `onPrimary` to `onPrimaryContainer`) — the same `primaryContainer`/`onPrimaryContainer` pair a *non-latest* AI run's icon already uses, so Latest no longer steps up to a bolder, exclusive fill. The `Circle → Cookie9Sided` morph is what distinguishes it now, not the color. The hero *text* styling (the `primary` kicker, the bold/italic PREV › NEW) is deliberately untouched — only the anchor icon's own color changed.
+- **Semantic silhouette by valence.** A new `TimelineValence` (`TriggerVisuals.kt`), orthogonal to `TimelineAccent` (hue) and `TimelineImportance` (contrast): positive triggers (`OutOfBedConfirmed`, `WakeWindowOpportunity`) carve a `MaterialShapes.Flower`, negative ones (`HardLatestFired`, `AlarmSnoozed`) a `MaterialShapes.Triangle`, everything else stays a plain circle. A `Replan` inherits its trigger's valence; base plans are neutral. Rendered as a *static* `AnchorShape.Polygon` via a new `buildPolygonPath` (sibling to `buildMorphPath`, same measure-and-scale, no per-frame progress). `Plain`/`Loader` anchors stay circles (no category to derive a shape from); `Latest` keeps its dedicated morph regardless of valence.
+- **Uniform track-to-text spacing, filled glyphs.** Every row's gutter-to-title gap is now `Spacing.md` (previously Latest-only got the wider gap), and every timeline anchor glyph renders `fill = 1f` (filled, not thin-outlined) — scoped to the two anchor call sites, not the app-wide `Symbol()`.
+- **Smoother supersession.** `AiRunNode`'s hero-vs-plain `title`/`status` swap is wrapped in a `Crossfade(defaultEffectsSpec())` (`ai-run-hero-demote`) so a demote fades instead of cutting; combined with the animated anchor-radius shrink above, the whole demotion is one coordinated soft transition (content fades, anchor shrinks, color already neutral).
+- **Never draw an incomplete registration set.** Two symptoms — an insertion briefly flashing the track to fill the whole screen, and the track visibly "catching up" frame-by-frame on nav-return — share one cause: `TimelineTrackOverlay` drew whatever partial set had registered *this frame*, even when the LazyColumn's own `visibleItemsInfo` said more anchor rows should be present. The fix computes the placed set (and whether it's *complete* — every anchor-eligible visible id, filtered by `contentType` so DayHeaders/spacers don't hold the gate, has both a descriptor and a position) in the *composition* phase via `derivedStateOf`, holds the last complete snapshot in a `remember`-ed state, and has `drawBehind` read only that stable snapshot. When a frame's set is incomplete, the overlay redraws the last complete one instead of a half-built track — so an insertion's one-frame gap (new top row not yet positioned) and a nav-return's empty-then-filling registry never render as a mismatched track.
+
+Round 15 — the track/anchors visibly lagged a frame behind the row content during ordinary scrolling; a much thicker track; a new center-line spine.
+
+- **The Round 14 completeness gate fixed the insertion/nav-return bugs but introduced a permanent one-frame lag on every ordinary scroll.** Gating the placed-set computation behind a composition-phase `derivedStateOf` + a `remember`-ed `lastComplete` write meant a position change (which happens every scroll frame, via `TimelineNode`'s `onGloballyPositioned`) had to wait for `TimelineTrackOverlay` to actually *recompose* before `lastComplete` updated — recomposition is scheduled for the next frame, not synchronous with the layout pass that triggered it. Row content has no such indirection (LazyColumn scrolling is pure layout, no recomposition needed), so it moved instantly while the track visibly trailed behind it. The fix moves the same completeness check and the "hold the last complete snapshot" cache directly into `drawBehind`, using a plain (non-`State`) `mutableListOf` mutated only from inside the draw lambda — the same pattern already used for the `scratch` `Path`. Reading `registry`/`listState`/`overlayOrigin` straight in the draw phase means a position change redraws the same frame it happens, no recomposition round-trip.
+- **Track thickness.** `TRACK_WIDTH` grows from `Spacing.xxxl` (32dp) to a new `Spacing.xxxxl` (40dp) token, with every dependent size scaled to match: `INTERIOR_ANCHOR_SIZE` 20→24dp, `NODE_GUTTER` 40→48dp, both anchor glyph sizes 14→18dp. Icon glyphs also reverted from filled back to outlined (Round 14 tried filled at the smaller size; once the track and glyphs are bigger, outlined reads cleanly again).
+- **A thin center-line "spine"** (`TimelineTrackOverlay.kt`) now runs down the track's vertical center, reinforcing the "this is a timeline" read the user asked for. It's drawn per-segment across the same `[bgTop, bgBottom]` extent as the background stadium, with a small gap carved around every anchor (`anchor.contentRadiusPx + SPINE_GAP`, so the gap scales with that anchor's own size) so the line never runs through a socket. Layered exactly like the background/sleep-pill fills: the awake-color spine spans the whole segment first, then an asleep-color spine overpaints each sleep pill's own sub-range on top — same whole-then-overlay technique, just for a line instead of a fill.
+
+Round 16 — the sleep track becomes deliberately dark, and the spine gets quieter/roomier now that it's proven out.
+
+- **The sleep track now reuses `colorScheme.primary` outright**, replacing Round 8's `lerp(surfaceContainerHighest, tertiary, …)` blend — the user wanted it "really dark, the same color as the next alarm card background," and `NextAlarmCard`'s own hero fill is exactly `colorScheme.primary`. This app's flat-design rule rules out a literal elevation for "the sleep track should feel raised"; borrowing the app's single boldest surface role is the color-only stand-in.
+- **Spine colors follow the sleep track's new fill.** The awake spine moves from `colorScheme.outline` to the quieter `colorScheme.outlineVariant` — a deliberately less assertive divider role, so the line reads as a subtle detail rather than competing with the sockets it threads between. The asleep spine moves from `colorScheme.onTertiaryContainer` to `colorScheme.onPrimary` — the exact M3 pairing for the new `primary` sleep-track fill, and the "inverted" (light-on-dark) counterpart the neutral awake spine doesn't need.
+- **`SPINE_GAP` doubles from 4dp to 8dp** for more visible breathing room between the line and each anchor's own shape, per direct feedback that 4dp read too tight once seen on-device.
+- **Open question carried forward, not resolved this round:** `TimelineImportance.Muted`'s `surfaceContainerLow` container (a light neutral, meant to "recede into the track") was tuned against the old blended-tertiary asleep track; against the new bold `primary` fill it may now read with much *more* contrast than intended. Not changed here since it wasn't part of what was asked — worth a dedicated look if a muted icon on the sleep track reads oddly on-device.
+
+Round 17 — outline tried and rejected; elevation-based interior anchors instead; a subtler spine.
+
+The bold `primary` sleep track from Round 16 resurfaced the original contrast bug from a different
+angle: a per-trigger/valence `*Container` accent (an MD3 role whose identity is in hue, not
+lightness) could render nearly indistinguishable from whichever track sat behind it. A same-round
+fix drew a thin `colorScheme.outline` stroke around every `Icon` anchor's socket — a real, working
+fix, but the user tried it on-device and rejected it as heavy-handed once seen on every single icon
+across a real timeline, asking for the *other* sanctioned nesting strategy this doc already lists
+instead: tone/elevation separation, not a drawn boundary.
+
+- **Outline removed entirely** — `AnchorDescriptor.hasOutline`, `TimelineTrackOverlay`'s
+  `SOCKET_OUTLINE_WIDTH`/`socketOutlineColor` and the `Stroke(...)` draw calls in `drawSocket` are
+  gone, back to a plain fill.
+- **Interior anchors drop their semantic shape and accent entirely, not just gain a boundary.**
+  Confirmed with the user: non-circular valence silhouettes (`Flower`/`Diamond`) and per-trigger
+  `*Container` accents are now reserved for **cap anchors only** (segment top/bottom, a sleep sub-
+  track's own onset/wake) — the "important, big" anchors. Every interior anchor is a plain circle
+  filled with a neutral pulled from the **opposite extreme of the surface-container tone ladder**
+  from whichever track it sits on: `colorScheme.surfaceContainerHighest` (lightest neutral) on the
+  awake track, `colorScheme.surfaceContainerLowest` on the bold dark `primary` sleep track — using
+  the ladder's two *named extremes*, not one step up/down, maximizes the guaranteed tone gap
+  without needing to hand-verify every accent/track combination across every dynamic palette. The
+  glyph tint also reverts to neutral (`onSurfaceVariant`) for interior anchors, since a colored
+  icon on a now-neutral disc would read as an arbitrary mismatch. Implemented by normalizing the
+  `Icon` anchor value once (`tint`/`containerColor` nulled, `valence` forced `Neutral`) at the top
+  of `TimelineNode` when `!atCap`, so the existing fallbacks in `AnchorContent` and
+  `socketAccentColor` do the rest without a separate `atCap` branch duplicated three times.
+- **Spine made deliberately subtler in both directions**, via `lerp` toward each track's own color
+  instead of a full-strength divider role: the awake spine is now `outlineVariant` blended 35% into
+  the track color (was a flat `outlineVariant`); the asleep spine is `onPrimary` blended 40% into
+  `primary` (was flat `onPrimary`, which read as a bold white stroke against the new dark track).
+  `SPINE_GAP` (already 8dp as of Round 16) is unchanged this round.
+- **Minor-row text grows and gains relative phrasing.** `timelineRowTitle` 14→16sp; a new
+  `timelineRowTime` role (13sp, derived from `labelMono` rather than resizing the widely-shared
+  `labelMonoSmall`) replaces it at both `EventNode`'s and non-latest `AiRunNode`'s trailing time.
+  A new `timelineTimeLabel(epochMs, absoluteLabel)` helper shows "12m ago" (via the existing
+  `rememberRelativeAgo`, already used for the hero kicker) for anything under a 60-minute cutoff,
+  falling back to the plain clock label beyond it — the day header already disambiguates the date
+  for anything older, so a multi-hour-old "3h 40m ago" wouldn't read better than "23:14" anyway.
+
+Round 18 — interior sockets go fully invisible, a cap anchor's `*Container` fill gets a track-aware
+escape hatch, and cap shapes get real breathing room. Also the round that finally removed the
+per-day header block that this doc's Round 13/14 entries assumed was a legitimate track-segment
+boundary — it wasn't; see the summary at the end of this entry.
+
+- **Interior sockets now match the track exactly, not a contrasting neutral.** Round 17's
+  opposite-tone-ladder-extreme fix (`surfaceContainerHighest`/`surfaceContainerLowest`) was itself a
+  visible dot, just a higher-contrast one — the user wanted no visible disc at all, only the glyph
+  floating on bare track. `TimelineNode.kt`'s `interiorNeutralColor(isAsleep)` now returns
+  `trackColorFor(isAsleep)` directly (the same `primary`/`surfaceContainerHigh` values the track
+  itself is painted with), so the carved socket disappears into its background. Because the disc no
+  longer carries any contrast on its own, the glyph tint can no longer fall back to a flat
+  `onSurfaceVariant` — that reads fine against the light awake track but disappears against the dark
+  `primary` sleep track. The `effectiveAnchor` normalization now sets `tint` explicitly per track
+  (`onPrimary` when asleep, `onSurfaceVariant` when awake) instead of nulling it.
+- **Cap anchors get a track-aware escape hatch from the `*Container`-on-track clash.** The original
+  Round 17 contrast bug (a `*Container` role is tonally close to a `surfaceContainer*` role by M3
+  construction — that's the entire point of the "container" tier) turned out not to be fully fixed:
+  it only ever applied to *interior* anchors. A cap anchor's raw `containerColor`
+  (`TriggerVisuals.kt`'s `containerColor(Prominent)`, or `AiRunNode`'s flat `primaryContainer`) still
+  painted straight onto the track, confirmed on-device with a `primaryContainer`-filled
+  "good moment to wake" cap barely separating from the awake `surfaceContainerHigh` track. New
+  `TimelineAccent.capContainerColor`/`capOnContainerColor` (`TriggerVisuals.kt`) resolve a Prominent
+  cap's fill to the accent's *solid* role (`primary`/`secondary`/`tertiary` + matching `on*`) on the
+  awake track — the opposite tonal extreme from any surface role by construction, a guarantee that
+  holds across dynamic color rather than one palette's specific hex values — while leaving the dark
+  `primary` sleep track on the plain `*Container` pairing, since a light Container tone already has
+  ample gap there and a solid `primary` fill for the Schedule accent would collide outright with the
+  sleep track's own `primary` fill. Applied uniformly across all three `TimelineAccent` values (not
+  just the one the user happened to screenshot) and mirrored in `AiRunNode`'s own flat
+  `primaryContainer` icon fill, which carries the identical structural risk. A detail chip
+  (`MonoPill`, e.g. the snooze-duration badge) is explicitly *not* routed through this — it sits on
+  the neutral page background, not the track, so the plain Container pairing is already correct
+  there and swapping it in would have been an unrelated regression.
+- **Cap shapes get more rim.** `ANCHOR_PADDING` (2dp) is renamed `CAP_ANCHOR_PADDING` and doubled to
+  4dp (`Spacing.xs`), so `FLUSH_ANCHOR_SIZE` drops from 36dp to 32dp inside the same 40dp track — a
+  non-circular cap silhouette (Flower/Diamond) reported as cramped/jagged at the old 2dp flush fit
+  now has real breathing room. The stadium's own cap radius is unchanged (still `halfTrack`); only
+  the anchor's content shrinks within it, so the concentric-cap math in `TimelineTrackOverlay.kt`
+  needed no changes beyond the renamed constant.
+- **The inline per-day header block is gone — a day boundary is no longer a track/segment break at
+  all.** This turned out to be a real, confirmed bug, not just a visual seam: `TimelineMapper.kt`'s
+  `timelineAsleepStates()` force-reset the asleep flag to `false` at every `DayHeader`, and
+  `SessionTimeline.kt` incremented `segmentId`/flanked `isSegmentTop`/`isSegmentBottom` at every day
+  boundary — meaning a sleep session spanning midnight (the overwhelming common case) got its asleep
+  state reset and its track literally cut into two independently-capped segments exactly at
+  midnight, and a genuinely mid-sleep event landing next to the boundary got wrongly forced into
+  big-cap-shape treatment. `TimelineItem.DayHeader` is removed entirely (not just skipped) — the
+  list is now one continuous segment end-to-end (`segmentId = 0`, cap only at the true list
+  ends), and `timelineAsleepStates` has nothing to reset on. A new floating pill
+  (`TimelineDayIndicator.kt`) replaces the removed header purely as a scroll-position reminder
+  ("Today"/"Yesterday"/a weekday name) — it's a genuine overlay, never a list item, so it can't
+  reintroduce the seam it replaces. This is why Round 13/14's "a DayHeader already marks a fresh
+  track segment" framing is now wrong, not just superseded — that framing was the bug.
+
+Round 19 — the floating day pill was badly positioned, a track-aware Container fallback still
+collided on one shipped palette, and "invisible" interior sockets read as boring. Three corrections
+after live-usage feedback on Round 18's build.
+
+- **The floating day-indicator pill is gone, replaced by a sticky *inline* row.** Round 18's overlay
+  pill landed pinned in the top-right corner regardless of scroll position — not the "floats above
+  the current section" the design intended, just a fixed badge. `TimelineItem.DayHeader` is
+  reinstated as a real (if purely decorative) list item — `TimelineMapper.kt`'s `insertDayHeaders`
+  and `capTimeline`'s header-skip logic are both back — but rendered via `LazyListScope.stickyHeader`
+  instead of a plain `item`, so it pins to the top of the viewport while its section scrolls beneath
+  it and yields to the next header, exactly the native "sticky section header" behavior. Restored the
+  original big/heavy typography (`timelineDayHeader`/`timelineDayDate`, `ExpressiveUltraCondensedFontFamily`)
+  Round 18 had deleted as part of the (now-reverted) compact-pill design, but right-aligned and with no
+  track anchor of its own (unlike an `Event`/`AiRun` row) — it's a reminder floating over the content,
+  not another node threaded onto the timeline. Round 18's core fix survives intact: `DayHeader` stays
+  fully transparent to `timelineAsleepStates`, segment id, and cap derivation (now via
+  `timeline.indexOfFirst/indexOfLast { it !is DayHeader }` rather than raw list-index math), so a
+  sleep session spanning midnight still renders as one continuous, uncapped pill with the header
+  merely floating over part of it — confirmed via a new screenshot regression test with a real
+  `DayHeader` sitting inside the sleep stretch.
+- **A Prominent cap's `*Container` fallback on the sleep track wasn't actually safe.** Round 18's
+  `capContainerColor` kept the plain `*Container` pairing on the sleep track on the theory that a
+  light Container tone has "ample gap" against the dark `primary` fill — an assumption that doesn't
+  hold universally: M3's dark-scheme tonal spec can place a Container role *darker* than its base
+  role (the inverse of light scheme), and this app's own non-dynamic dark fallback
+  (`Color.kt`'s `FallbackDarkColors`) sets `primaryContainer` to the exact same value as `primary` —
+  zero contrast, confirmed by reading the source, not just inferred. The fix now applies the solid
+  role (`primary`/`secondary`/`tertiary`) uniformly on **both** tracks for every accent — Container is
+  no safer a bet on the sleep track than the awake one — except the one collision no track-side branch
+  can dodge: [TimelineAccent.Schedule]'s solid role *is* `primary`, and the sleep track *is* a flat
+  `primary` fill. That single case now falls back to `colorScheme.inverseSurface`/`inverseOnSurface` —
+  an M3 role built specifically to read clearly against whatever surrounds it, independent of the
+  primary/secondary/tertiary palette entirely. `AiRunNode`'s own flat `primaryContainer` icon fill
+  (always Schedule-hued) gets the identical `inverseSurface` fallback on the sleep track.
+- **Interior anchors trade "invisible" for a high-contrast pill.** Round 18 made an interior anchor's
+  socket disc match its track exactly, so only the glyph read — the user found this "lame," not
+  boring-in-a-good-way, and asked for a visibly-present pill-shaped badge instead. Every interior
+  (non-cap) anchor now carves a new `AnchorShape.Pill` — a horizontal capsule the same width as a cap
+  anchor's own footprint (`FLUSH_ANCHOR_SIZE`) but only as tall as the interior content diameter
+  (`INTERIOR_ANCHOR_SIZE`), rounded left/right and flat top/bottom (a wide `RoundRect` with corner
+  radius equal to half its height — the standard capsule recipe). Its fill/glyph pair is the same
+  `inverseSurface`/`inverseOnSurface` role used for the one cap-collision case above, applied
+  *uniformly* regardless of track — deliberately sidestepping the per-track ladder-rung tuning that
+  Rounds 17 and 18 each got wrong in one direction or the other, since `inverseSurface` is guaranteed
+  by M3 spec to invert lightness against whatever's active, not tuned per-surface by hand.
+
+Round 20 — interior pills swap to track-crossed roles, the sticky header gets real geometry fixes,
+and a fade-in animation stopped replaying on every scroll.
+
+- **Interior pill fill swaps to a track-crossed pair, not a fixed `inverseSurface`.** Round 19's
+  uniform `inverseSurface`/`inverseOnSurface` fixed the contrast problem but read as flat/uninteresting
+  once seen live. `TimelineNode.kt`'s `interiorPillColor(isAsleep)` now deliberately *crosses* the two
+  tracks instead of using one color for both: on the sleep track the pill matches
+  `CronColors.pageBackground` (a low-elevation neutral — the pill reads as a hole punched through to
+  the page), and on the awake track it borrows the sleep track's own bold fill
+  (`trackColorFor(isAsleep = true)`, i.e. `primary`) — the boldest color in the app, popping clearly
+  off the lighter awake track. `interiorPillOnColor` pairs `onSurface` with the page-background case
+  and `onPrimary` (the M3-guaranteed pairing) with the borrowed-sleep-track case.
+- **The sticky day header was colliding with `HomeContent.kt`'s hand-rolled `StickyAlarm` overlay —
+  a real, confirmed-live bug a static Roborazzi screenshot can't catch on its own.** `stickyHeader`
+  pins at the LazyColumn's own content-padding top, which sits *behind* the separately-pinned
+  collapsed alarm bar (`StickyAlarm`, positioned via `graphicsLayer.translationY`, independent of the
+  LazyColumn's scroll state) — so a header trying to stick renders directly underneath the alarm and
+  is fully covered by it. Verified two ways this round: (1) a new scroll-driven Roborazzi test
+  (`day_header_pins_to_the_top_while_its_section_scrolls_beneath_it`) that drives a real `LazyColumn`
+  + `LazyListState.scrollToItem`, confirming `stickyHeader` itself *does* pin correctly — the bug was
+  purely the alarm-overlay collision, not broken pinning; (2) live on-device feedback, which caught
+  an over-correction this round's first pass made (see below). Fix: `sessionTimelineItems` now takes
+  the owning `LazyListState`, and each `DayHeader` derives `isPinned` (whether it's the first entry
+  in `listState.layoutInfo.visibleItemsInfo`) to conditionally add `ALARM_BAR_HEIGHT + Spacing.xxxl`
+  of extra top clearance — enough to clear the collapsed bar and its fade-out gradient tail — but
+  *only* while genuinely pinned. An unconditional version of this same clearance (applied to every
+  header regardless of position) shipped briefly within this round and was rejected on-device for
+  making every ordinary, non-pinned header needlessly oversized.
+- **The header's opaque backdrop was blocking the track underneath it entirely, in both pinned and
+  unpinned states** — a full-row-width `Modifier.background` covered the vertical track/spine on the
+  left, which should always stay visible since the header carries no anchor of its own. Fixed by
+  reserving `NODE_GUTTER` (the same gutter width every anchor row uses) as fully transparent space
+  before the opaque backdrop begins, so the track always shows through on the left, pinned or not.
+- **A newly-arrived latest row's delayed fade-in (Round 18) was replaying every time the row
+  scrolled off-screen and back into view**, not just on genuine insertion. The `Animatable`/delay
+  driving it lived in a per-row `remember(item.id)`, which resets whenever `TimelineNode`'s
+  `DisposableEffect` disposes the row (LazyColumn recycles rows scrolled far enough away) and it
+  later recomposes fresh. Fixed by tracking "has this id's entrance already played" in
+  `TimelineTrackRegistry.markEnteredOnce` — a plain `mutableSetOf` that, unlike a per-row `remember`,
+  survives the row's own dispose/recompose cycle for the registry's (i.e. the whole screen's)
+  lifetime, so the animation is gated to play at most once per row identity.
+
+Round 21 — a non-cap `Latest` anchor stopped borrowing the cap's morph shape, the sleep track moved
+off `primary` entirely, the awake track became an outline instead of a fill, and the sticky header
+was rebuilt as a `StickyAlarm`-style overlay.
+
+- **`TimelineAnchor.Latest` rendered its Cookie9Sided morph even when it wasn't a segment cap.**
+  `item.isLatest` (marks the chronologically-newest `AiRun`) doesn't imply `isSegmentTop`: an `Event`
+  timestamped more recently than the latest AI run (an alarm dismissed the next morning, after the
+  AI's plan ran the night before) legitimately sorts above it in the reverse-chronological list,
+  making the "latest" run a structurally interior row despite the name. `TimelineNode.kt`'s
+  `effectiveAnchor` normalization now converts a non-cap `Latest` into a plain interior `Icon`,
+  reusing the exact same Pill-shape/track-crossed-color path every other interior anchor already
+  takes — "only cap anchors get custom shapes" now holds for the morph too, not just the valence
+  polygons.
+- **The sleep track moved from `colorScheme.primary` to `colorScheme.secondary`**, freeing the
+  primary palette for the AI-run family (which already used `primary`/`primaryContainer` throughout)
+  to stop colliding with the track it sits on. `SessionTimeline.kt`'s `trackColorFor` and
+  `TimelineTrackOverlay.kt`'s spine blend both moved together; `AiRunNode`'s cap-color branch could
+  drop its `useInverseCapColor`/`useSolidCapColor` split entirely, since the solid `primary` role no
+  longer collides with anything on either track.
+- **The awake track switched from a filled `surfaceContainerHigh` stadium to a thin outline stroke**
+  — a flat fill at that tone read as barely visible against the page background, and the fix reaches
+  for the same treatment M3 Expressive's outlined buttons use (a 1dp `colorScheme.outline` stroke)
+  rather than raising the fill's own contrast, which would have fought the "quiet unless something
+  happened" read the awake track is meant to have.
+- **The sticky day header was rebuilt as a `StickyAlarm`-style overlay** to fix `LazyListScope.stickyHeader`'s
+  layout-shift/late-transition problems (superseded by Round 22 below — kept here for the record of
+  what was tried and why it still wasn't right).
+
+Round 22 — the outline/spine got quieter still, the sticky-header overlay was reverted for being
+its own source of glitches, a second Prominent accent was found colliding with the sleep track, and
+the timeline's left edge was aligned to the alarm card's.
+
+- **The awake track's outline and spine still read as too contrasty even after Round 21.**
+  `colorScheme.outline` is M3's role for a boundary that needs to read *clearly* — exactly the
+  opposite of what was wanted here, a track that sits quietly behind the content. `trackColorFor`
+  now uses `colorScheme.outlineVariant` instead, M3's own "quiet divider" role. The spine (the
+  center-line detail) needed to sit at an even lower visual weight than the outline it runs inside
+  of, so `TimelineTrackOverlay.kt`'s `awakeSpineColor` now blends the outline color *into*
+  `CronColors.pageBackground` (mostly background, a hint of the outline's own hue) rather than
+  blending the outline color toward a bolder neutral — the direction that increases rather than
+  decreases contrast.
+- **A second Prominent accent was confirmed colliding with the sleep track on-device**: an
+  `OutOfBedConfirmed` cap (`TimelineAccent.Body`, solid `tertiary`, rendered as a `Flower` for its
+  Positive valence) landed at a near-identical tone to the sleep track's own `secondary` fill —
+  the same "different palette, same elevation" failure Round 21 had only fixed for
+  `TimelineAccent.AlarmAction` (whose solid role is the literal same color, `secondary`, as the
+  sleep track). The root cause generalizes: once the sleep track itself became a *solid* role
+  instead of a neutral surface tone, no other solid role is guaranteed distinct from it by M3
+  construction — solid-vs-surface is a structural guarantee, solid-vs-solid isn't.
+
+  The first fix generalized every Prominent cap on the sleep track to
+  `colorScheme.inverseSurface`/`inverseOnSurface` — which turned out to be the wrong escape hatch,
+  caught by another live report showing the exact same collision one level deeper.
+  `inverseSurface` only guarantees it differs from *this theme's own* `surface` by mirroring the
+  opposite theme's `surface`; it has no guaranteed relationship to `secondary`. This app's `Color.kt`
+  fallback palette makes the collision concrete: `LightSecondary` (`0xFF3D6655`) is deliberately dark
+  (the sleep track is meant to read bold/dark in *both* themes, Round 16), and light theme's
+  `inverseSurface` mirrors dark theme's `surface` — also dark. Two independently-dark colors in
+  different hue families, the same bug, one abstraction layer removed. The real fix uses
+  `colorScheme.surfaceContainerHighest`/`onSurface` instead — a genuine surface-*family* role, the
+  one the solid-vs-surface guarantee actually covers, verified against this app's own fallback
+  palette to sit at the opposite tonal extreme from `secondary` in both themes
+  (`TriggerVisuals.kt`'s `capContainerColor`/`capOnContainerColor`, and the mirrored
+  `atCap`/`isAsleepAbove` branch in `SessionTimeline.kt`'s `AiRunNode`). Verified via two new
+  isolated Roborazzi captures (`cap_gallery_sleep_track_light`/`_dark`) — the combined
+  `EventCapGalleryPreview`'s sleep-track section renders below the fold in a fixed-height
+  Robolectric window, so the existing `event_cap_gallery_*` tests never actually exercised it.
+- **The Round 21 sticky-header overlay was reverted entirely.** It fixed `stickyHeader`'s layout-shift
+  problem but introduced its own: on-device testing showed the pin threshold triggering visibly late
+  and the handoff between the in-flow row and the overlay copy reading as glitchy rather than smooth
+  — more moving parts (a second `DayHeaderRow` copy, a live pin-target computation off `StickyAlarm`'s
+  collapse state, an alpha-hiding threshold on the in-flow row) than the payoff justified. `DayHeader.kt`
+  and `SessionTimeline.kt` are back to a single plain in-flow row with no pin behavior at all.
+  In its place: `DayHeaderLabel` gained an `isActive` flag that de-emphasizes every header except the
+  one governing whichever section is currently scrolled into view — computed inline off
+  `listState.layoutInfo` (the last day header whose live offset has crossed above the viewport top,
+  or the first one visible if none has yet). Since `CronTypography.timelineDayHeader` is already at
+  `FontWeight.Black` — the top of the weight scale — there's no heavier weight to step the *active*
+  header up to; instead the *inactive* state steps down to `FontWeight.SemiBold` plus
+  `onSurfaceVariant`, leaving the active header relatively bolder by contrast, with the color
+  transition (not the discrete weight swap) carrying the actual animation via
+  `animateColorAsState(label = "day-header-active-emphasis")`.
+- **The timeline's content padding moved from `Spacing.xl` to `Spacing.md`** so its left edge
+  (day headers, anchor gutter) lines up with `StickyAlarm`'s own horizontal inset — previously the
+  timeline sat visibly offset to the right of the alarm card above it.
+
+Round 23 — the alarm-card fade overlay no longer fully hides content, the awake-track outline was
+reverted back to a fill (again — see Round 21/22), a plan row's press feedback moved from a whole-row
+scale into a genuine shape morph, and the day header's active/inactive transition became a real
+continuous variable-font animation instead of a discrete weight swap.
+
+- **`StickyAlarm`'s fade overlay (`HomeContent.kt`) used a fully-opaque `pageBackground` before
+  fading to transparent**, completely hiding any timeline content scrolling up underneath the alarm
+  card until it cleared the fade band — including the exact moment Round 22's gutter-alignment fix
+  becomes visible. In light theme this read as content abruptly vanishing rather than fading. Fix:
+  cap the overlay's own max opacity at `MAX_LIGHT_FADE_OVERLAY_ALPHA = 0.5f` (light theme only —
+  dark theme's fade already read fine at full opacity), so content stays faintly visible through it
+  at every point in the scroll.
+- **The awake track's outline-stroke treatment (Round 21, retuned in Round 22) was reverted
+  entirely back to a fill** — not a further tuning pass, a full reversal: the user didn't want an
+  outline at all, regardless of how subtle. `trackColorFor`'s awake branch is back to
+  `colorScheme.surfaceContainerHigh` (a plain fill, same role Round 20 tried and found "barely
+  visible" — but this time the fill isn't expected to carry all the legibility alone). The spine
+  blend flipped direction to compensate: instead of blending the (now-gone) outline color toward the
+  page background, `TimelineTrackOverlay.kt`'s `awakeSpineColor` now blends the fill color toward
+  `colorScheme.onSurfaceVariant` — the M3 role calibrated to read on top of surface-family tones —
+  so the center line carries the visibility burden the fill isn't expected to.
+- **A plan row's press feedback moved from a whole-row `graphicsLayer { scaleX; scaleY }` shrink to
+  a shape morph on the anchor itself.** The scale transform only ever touched the foreground
+  `Surface` — never the anchor socket, which `TimelineTrackOverlay` paints independently at the
+  row's registered position — so a press visually read as the row content sliding sideways out from
+  under a static anchor. Fix: `AnchorShape.Pill` gained a `pressProgress: () -> Float` that
+  interpolates its corner radius from a full capsule (unpressed) down to `35%` of that radius
+  (pressed) — a `ToggleButton`-style rounder↔squarer morph (this repo's own Expressive guidance
+  already names `ToggleButton`'s shape morph as the pattern to reach for). A clickable cap anchor's
+  plain `Circle` gets the equivalent treatment via the existing `AnchorShape.MorphShape` mechanism —
+  a new `Morph(Circle, Cookie6Sided)` (a different point count from `Latest`'s own `Cookie9Sided`
+  arrival morph, so the two "selected" cues stay visually distinguishable) that renders
+  pixel-identical to a plain circle at `pressProgress == 0`, so it's used unconditionally for every
+  clickable Neutral cap rather than swapping shape types on press. `pressProgress`/`pressMorphProgress`
+  are hoisted above `TimelineNode`'s shape derivation and computed unconditionally (harmless when
+  `onClick` is null — `pressed` just never turns true without a `Surface.onClick` feeding events).
+- **`SessionTimeline.kt` crossed the 500-line file cap** once the press-morph plumbing landed —
+  `EventNode` (a fully self-contained "render one Event row" responsibility, ~80 lines) moved to its
+  own `EventNode.kt`, taking `SessionTimeline.kt` back to 427 lines. `timelineTimeLabel` (shared by
+  both `EventNode` and `AiRunNode`) stayed in `SessionTimeline.kt`, promoted from `private` to
+  `internal` so the split file can still call it.
+- **`DayHeaderLabel`'s active/inactive transition became a genuine continuous variable-font
+  animation.** Round 22's binary `FontWeight.Black`/`SemiBold` swap read as "brutal" — a discrete
+  jump, not a transition. Roboto Flex (the same variable font file
+  `fr.bsodium.cron.ui.theme.CountdownFontFamily` already draws on) exposes both `wght` and `wdth`
+  axes, so both can now animate in real time via `MaterialTheme.motionScheme.defaultSpatialSpec()`
+  driving two `animateFloatAsState` calls (weight 600→900, width 30→42), with a new
+  `rememberVariableWeekdayFont(weight, width)` building a fresh `FontFamily`/`FontVariation.Settings`
+  pinned to the (rounded, for cache-key stability) current axis values every frame the animation is
+  in flight — a real "resize," not a color/alpha fade, hence spatial specs rather than effects specs
+  per this repo's motion rules. This is the first live/per-frame `FontVariation` animation in the
+  codebase; existing uses (`CountdownFontFamily`, `expressiveWidth`) all pin fixed values at
+  composition time.
+- **`DayHeaderRow`'s top padding trimmed from `Spacing.xxl` to `Spacing.xl`** — a modest reduction,
+  not a redesign.
+
+Round 24 — the alarm-card fade and the app-wide status-bar scrim were fighting each other, and the
+Round 23 press-morph target changed from a squarer pill to a full circle.
+
+- **Two independent top-of-screen gradients were both active at once on Home, producing a visible
+  "fade, un-fade, fade again" as content scrolled through the gap between them.** `EdgeFades`
+  (`MainActivity.kt`) draws a generic status-bar scrim on every route without its own `PageAppBar`,
+  entirely independent of `StickyAlarm`'s own collapse-driven fade (`HomeContent.kt`) — the two were
+  never coordinated, each fading/un-fading content on its own schedule as it scrolled through their
+  respective (different-height) bands. Fix: `EdgeFades`' top scrim is now suppressed specifically for
+  `ROUTE_HOME` — `StickyAlarm`'s own gradient already covers the same y-range (it starts at `y=0`,
+  same as `EdgeFades`'), so Home owns 100% of its own top-of-screen occlusion with nothing else
+  layered on top.
+- **`StickyAlarm`'s Round 23 fade cap (50% max in light theme) now ramps to fully opaque as the card
+  settles into its collapsed state**, rather than staying capped at 50% indefinitely. The 50% cap
+  was specifically meant to keep the *collapse transition* watchable (seeing the timeline slide into
+  alignment with the card's edge); once the card is genuinely done collapsing there's no more
+  transition to see through, and a permanently-partial occlusion just reads as visual noise —
+  especially now that it's the *only* top-of-screen gradient (previous bullet). The overlay's alpha
+  cap is `lerp(MAX_LIGHT_FADE_OVERLAY_ALPHA, 1f, collapse.value.fraction)` — soft during the active
+  collapse, solid once settled.
+- **The Round 23 press-morph's `AnchorShape.Pill` target shape changed from a squarer corner radius
+  to a full circle**, per direct feedback that a circle "would make more sense" as the selected
+  state. Rather than reintroducing a separate corner-radius-fraction constant, the pill's *height*
+  now grows to meet its own fixed width as `pressProgress` goes 0→1, with the corner radius pinned
+  at `height / 2` throughout — at full press, width == height with a fully-round corner, which is
+  just a circle, and specifically one at the same flush diameter a cap anchor's own `Circle` uses.
+
+Round 25 — the press morph got bouncier and a real Cookie4Sided target, the two-gradient timing/
+opacity got tuned rather than just toggled, the sleep track's spine went wavy, and the day header
+was redesigned around a big date number.
+
+- **The press-morph animation switched from `fastSpatialSpec()` to `defaultSpatialSpec()`** — "fast"
+  read as an ease with no real spring, and a press cue is exactly the kind of moment M3 Expressive
+  wants to feel bouncy.
+- **An interior `Pill`'s press target changed from a plain circle to `MaterialShapes.Cookie4Sided`.**
+  Since `Pill` wasn't previously backed by a `RoundedPolygon` at all (it draws via a raw
+  `drawRoundRect`), this needed a real capsule endpoint shape —
+  `RoundedPolygon.pill(width = PILL_ASPECT, height = 1f)` at a normalized aspect ratio, morphed
+  toward `Cookie4Sided`. Scaling a non-square `Morph` output into a non-square target needed a new
+  sibling to `buildMorphPath`: `buildMorphPathFitRect` scales width/height independently instead of
+  uniformly into a single diameter, so the target shape only reads undistorted once `pressProgress`
+  has grown the pill's height to match its width (i.e. right at full press, exactly when it matters).
+  `AnchorShape.Pill` gained a `morph: Morph?` field (`null` — the default — keeps every
+  non-interactive `EventNode` pill on the original crisp `drawRoundRect`, since only a clickable
+  `AiRunNode` row needs the morph machinery at all).
+- **Two follow-ups to Round 24's single-gradient fix, both from live testing on a real device.**
+  First: `EdgeFades`' top scrim was suppressed on Home, but `StickyAlarm`'s own `gradientAlpha` was
+  still keyed to the *alarm card's* collapse distance — meaning the greeting had already scrolled
+  fully under the status bar, unoccluded, well before that distance turned positive. Fix:
+  `gradientAlpha` is now keyed to the *greeting row's own* scroll offset instead, so occlusion
+  engages as soon as scrolling starts, independent of how far the card itself is from collapsing.
+  Second: Round 24's fraction-based ramp to a fully-opaque (1f) settled state made the
+  `belowFadePx` tail's transition into visible timeline content too harsh — content that used to
+  visibly "transpire through" near the card's bottom edge now hit a hard cliff. Fix: the settled cap
+  is `MAX_LIGHT_FADE_OVERLAY_SETTLED_ALPHA = 0.85f`, not `1f` — solid enough to read as occluding,
+  short enough that the tail's transparent tail still stays gentle.
+- **The sleep track's center-line spine is now a hand-rolled sine wave; the awake track's stays
+  straight.** No off-the-shelf "wavy line" primitive was reused (M3 Expressive's wavy progress
+  indicators are full composables, not an exposed path utility) — `drawWavyVerticalLine` walks
+  short `lineTo` segments along a sine curve (`SPINE_WAVE_AMPLITUDE = 3dp`,
+  `SPINE_WAVE_LENGTH = 16dp`, phase anchored to each gap-free segment's own start so it reads as one
+  continuous wave across anchor gaps within the same pill, not a reset-per-anchor zigzag). `drawSpine`
+  gained a `wavy: Boolean` switch so the identical gap-skipping logic can emit either primitive.
+- **The day header was redesigned from a relative-day wordmark to a calendar-tear-off pairing** — a
+  colossal bold day-of-month digit (`timelineDayNumber`, 56sp, up from the wordmark's 28sp) with the
+  month abbreviation as a small thin caption underneath (`timelineDayMonth`, 14sp), both
+  right-aligned, closed off by a thin `HorizontalDivider` sized to the block's own width (not the
+  full row — "an underline under the month text," deliberately not touching the timeline gutter on
+  the left). Replaces `timelineDayHeader`/`timelineDayDate` entirely, which drops the "TODAY"/
+  "YESTERDAY"/weekday-name relative label along with them — `relativeDayLabel` (`TimelineMapper.kt`)
+  is now dead code and was removed. The existing bouncy variable-font `wght`/`wdth` animation
+  (Round 23) carries over unchanged, now driving the big number instead of the wordmark.
+- **`TimelineTrackOverlay.kt` crossed the 500-line file cap** once the wavy-spine and
+  `buildMorphPathFitRect` code landed — `buildMorphPath`/`buildMorphPathFitRect`/`buildPolygonPath`
+  (a fully self-contained "build a Compose Path from a graphics-shapes object, scaled to fit"
+  responsibility, not used outside this file) moved to a new `ShapePathBuilders.kt`.
+
+Round 26 — two Round 25 items got redone rather than tuned after live feedback ("the wavy line
+looks terrible" / "doesn't sell the animation"), plus four smaller day-header adjustments.
+
+- **The wavy sleep-track spine was rebuilt on the correct technique, and a real overlap bug got
+  fixed.** Two separate problems, confirmed together on-device: (1) the wave itself was built from
+  short straight `lineTo` segments, which reads as faceted/jagged rather than a smooth curve — M3
+  Expressive's own wavy progress indicators (`LinearProgressDrawingCache` in
+  `androidx.compose.material3.internal`, a `private class` and not directly reusable) build their
+  wave from one **quadratic Bézier curve per half-wavelength** with an alternating control-point
+  sign instead, which is what actually produces the smooth signature curve — `drawWavyVerticalLine`
+  now replicates that exact technique. (2) A genuine layering bug: the straight awake spine was
+  drawn across the *entire* segment extent first, on the assumption the wavy asleep spine would
+  fully overpaint its own sub-range the same way the solid background/pill *fills* do — but a wavy
+  line oscillates around `trackCenterX` while the straight line sits fixed on it, so the straight
+  line visibly peeked out from behind the wave at every peak and trough ("I see BOTH the wavy line
+  and a straight line"). Fixed with a new `awakeSpineRanges` helper that computes the actual
+  complement of the pill ranges and only draws the straight spine there — no more reliance on
+  overpaint for the spine specifically.
+- **The interior Pill's press-morph target changed again, from `Cookie4Sided` to a sideways arrow**
+  — Round 25's cookie shape looked fine as a static shape but "didn't sell the animation" as a
+  press/selection cue. `MaterialShapes.Arrow` points up by default (confirmed by rendering it, not
+  by assumption — an initial attempt to verify this with a bounding-box aspect-ratio check gave a
+  false reading, since the shape's wingspan is wider than its tip length even before rotation; a
+  dedicated `PillPressMorphScreenshotTest` renders the real production shape at fixed press values
+  instead and settles it visually). Rotated 90° via `RoundedPolygon.transformed { x, y ->
+  TransformResult(-y, x) }` — the same *public* mechanism M3's own `MaterialShapes` library uses
+  internally to build shapes like `Oval` by rotating a scaled circle, not the icon-direction-faking
+  CLAUDE.md's rule targets (that rule is specifically about `MaterialSymbol` glyphs, where flipping
+  can break an asymmetric icon's own design — this is a background shape morph). The press-morph
+  spec also stepped up from `defaultSpatialSpec` to `slowSpatialSpec`, the same tier the Latest
+  anchor's own arrival morph uses, to sell it as a real flourish rather than a quick snap.
+- **The day-header number gained a vertical squash** (`graphicsLayer { scaleY = 0.8f }`, the same
+  paint-time-only technique `CollapsibleAlarmCard`'s clock digits already use) paired with a
+  tightened `lineHeight` so the row's own layout height keeps pace instead of leaving dead space
+  under the now visually-shorter glyph.
+- **The month caption grew and thickened, and now writes the full name** ("JUNE", not "JUN") —
+  `timelineDayMonth` moved off the thin/italic pairing entirely (14sp Light → 18sp SemiBold, and off
+  `ExpressiveCondensedThinFontFamily` — which only ever registers one fixed Light face regardless of
+  requested weight — onto `ExpressiveCondensedFontFamily`, which actually has a SemiBold/Bold face
+  to request).
+- **The relative-day label ("TODAY"/"TOMORROW"/"TWO DAYS AGO"/weekday name), dropped in the Round 25
+  redesign, came back** — left-aligned on the same line as the month, opposite it, "a bit bolder"
+  (`timelineDayActiveLabel` = `timelineDayMonth.copy(fontWeight = Bold)`, sharing its exact size).
+- **`DayHeaderRow` now explicitly reserves `NODE_GUTTER`** the way every anchor row already does.
+  Without it, the header's own content — and specifically its divider, sized to the block's own
+  width — had nothing stopping it from extending far enough left to visually overlap the timeline
+  track itself for a wide (2-digit, colossal-font) day number ("the divider... currently does"
+  overlap, confirmed). The label now sits in a `Modifier.weight(1f)` slot after that gutter Spacer,
+  so it's confined to the same content column every other row already respects.
+
+Round 27 — the wavy spine is fully abandoned after live testing ("looked better on paper, but it
+turned out catastrophic"), every anchor's accent color converges on one track-matched rule, and
+three smaller day-header/press-morph items.
+
+- **The wavy sleep-track spine is gone, permanently.** Round 26's quadratic-Bézier rebuild fixed the
+  *technique* but the result still read badly on-device, and the user explicitly asked to stop
+  iterating on it rather than try a third approach — `drawWavyVerticalLine`, `awakeSpineRanges`,
+  `drawSpineSegment`, and the wave-amplitude/wavelength constants are deleted outright. Both tracks
+  draw a single straight `drawLine` per gap-free sub-range again — the full awake spine across the
+  segment's extent, then each sleep pill's own line overpainting its sub-range, the design from
+  before Round 25 ever touched this file. This also resolved a reported "hugging" artifact at
+  sleep-track boundaries as a side effect: `awakeSpineRanges` had hard-clipped the straight spine's
+  draw range exactly at each pill's edge (needed only for the wave), and clipping there rather than
+  overpainting is what was pulling the line in tight.
+- **Every anchor's fill color now matches whichever track it sits on — one rule, not six rounds of
+  patches.** New `trackAccentColor`/`trackOnAccentColor` functions (`SessionTimeline.kt`) return
+  `secondary`/`onSecondary` on the sleep track and `primary`/`onPrimary` on the awake track, and
+  every socket fill in the timeline — cap icons (`TriggerVisuals.kt`'s `capContainerColor`/
+  `capOnContainerColor`), interior pills (`TimelineNode.kt`, replacing the Round 19/20
+  `interiorPillColor`/`interiorPillOnColor` "track-crossed swap"), the Loader spinner, and the
+  Latest hero anchor (`LatestAnchor.kt`, previously a flat `primaryContainer` regardless of track)
+  — now derive from it instead of each carrying its own per-accent-hue or escape-hatch logic
+  (`inverseSurface`, `surfaceContainerHighest`, per-`TimelineAccent` branching). Confirmed with the
+  user this uses the *literal* solid track color, not a lighter Container shade — on the sleep
+  track specifically this means a Prominent cap's fill is now identical to the track's own fill, so
+  the shape itself blends away and only its glyph reads (the same "hole" tradeoff Round 20 already
+  accepted for interior pills, now consistent everywhere rather than swapped per anchor type). The
+  `MonoPill` detail chip (e.g. "9 min" snooze duration) is unaffected — it sits on the page
+  background, not the track, so it was never part of this collision class.
+- **Today's day header is skipped entirely** (`TimelineMapper.kt`'s `insertDayHeaders`) — the user
+  already knows it's today, so the header was pure redundancy at the top of the list.
+- **Day-header spacing tightened**: top padding down to `Spacing.md`, the big number's
+  `graphicsLayer` squash now anchors at `TransformOrigin(0.5f, 1f)` (bottom, not center) so tightening
+  `timelineDayNumber`'s `lineHeight` (46sp → 40sp) directly shortens the gap to the row below instead
+  of fighting a center-anchored transform, and the block's left inset grew from `NODE_GUTTER` alone
+  to `NODE_GUTTER + Spacing.md` so the relative-day label lines up with every other row's own text
+  indent (`titleSpacer` in `TimelineNode.kt`).
+- **The relative-day label reverses Round 26's "a bit bolder" call** — `timelineDayActiveLabel` now
+  reuses `ExpressiveCondensedThinFontFamily` with `FontWeight.Light` and `FontStyle.Italic` instead
+  of a bold `timelineDayMonth` copy, on the same request as the spacing/indent fixes.
+- **The interior Pill's press-morph target changed again, from a sideways arrow back to
+  `MaterialShapes.Square`** — Round 26's arrow "didn't sell the animation" any better than Round
+  25's `Cookie4Sided` did on live device testing. `Square` is a symmetric rounded-square silhouette
+  with no rotation to get wrong, sidestepping the whole class of "does this shape actually point
+  which way I think" verification problem Round 26 ran into. The press spec stays
+  `slowSpatialSpec` (unchanged) — its `dampingRatio = 0.8` is already genuinely underdamped, i.e.
+  it already overshoots before settling, which is the "bouncy" behavior asked for; no bespoke spring
+  was added per this repo's motion rule.
+
+Round 27.9 — a same-day live-device follow-up: the sleep-track color unification above used the
+*literal* `secondary` role for both the track's own fill and every anchor sitting on it, which
+[trackColorFor]'s own KDoc had already flagged as a deliberate choice — but on a real device every
+sleep-track anchor (`OutOfBedConfirmed`, `AlarmDismissed`, etc.) genuinely disappeared into the pill,
+leaving only a bare glyph with no shape around it ("same colour as the sleep track itself... needs
+tweaking"). `trackAccentColor`/`trackOnAccentColor`'s asleep branch moved to `secondaryContainer`/
+`onSecondaryContainer` — still the same secondary family (so the original ask, "same palette as the
+sleep track," still holds), but a genuinely different token, so it contrasts against the track's own
+`secondary` fill instead of matching it pixel-for-pixel. The awake branch is untouched: `primary`
+already contrasts fine against the awake track's neutral `surfaceContainerHigh` fill, since those two
+were never the same role to begin with — the collision was specific to the asleep side literally
+reusing the track's own fill token for its anchors.
+
+Round 27.11 — five smaller items from a live-device pass, none touching the color-unification logic
+above except one direct follow-up to 27.9:
+
+- **The interior Pill's press-morph "butterfly" glitch is fixed by dropping `Morph` entirely for
+  this case.** Rounds 24–27 each tried a different `Morph` press target (circle → `Cookie4Sided` →
+  sideways arrow → `MaterialShapes.Square`), scaling the *mid-interpolation* outline non-uniformly to
+  fit the growing rect (`buildMorphPathFitRect`) — morphing between two shapes with mismatched vertex
+  topology (a capsule vs. a 4-cornered square) produces a genuinely bowtie-shaped in-between outline,
+  and stretching that non-uniformly made it worse, reading as "some kind of butterfly shape." The
+  fix: `AnchorShape.Pill` no longer carries a `Morph` at all — `TimelineTrackOverlay.kt`'s
+  `drawSocket` just interpolates a plain `drawRoundRect`'s corner radius from a full capsule
+  (`pillHeight / 2`) down to `SQUARE_CORNER_FRACTION` (`0.3`, matching `MaterialShapes.Square`'s own
+  `CornerRounding(radius = 0.3f)` read from the M3 source) as press progress goes 0→1, the same
+  lerp already driving the height grow. `buildMorphPathFitRect` (now unused) and the
+  `pillPolygon`/`pressSquare` remembered values in `TimelineNode.kt` are deleted.
+- **A demoted `AiRunNode` title (a row that was latest and got superseded) was floating at the top of
+  its reserved height with dead space below.** `Crossfade` has no `contentAlignment` param in this
+  project's compose-animation version, and its own internal `Box` defaults to `TopStart` — once the
+  row demotes to its single-line state, that line rendered at the top of the still-`heightIn`-reserved
+  hero-sized box instead of centered in it. Fixed by moving the `heightIn(min = heroMinHeight)`
+  modifier onto a wrapping `Box(contentAlignment = Alignment.CenterStart)` around the `Crossfade`,
+  rather than trying to pass it to `Crossfade` directly. Covered by a new
+  `TimelineNodeScreenshotTest` that actually flips `isLatest` true→false within one composition (a
+  row that starts and stays demoted never reproduces this — `everLatest` only matters once a genuine
+  transition has happened).
+- **A cap anchor's fill is now identical across `TimelineImportance` tiers, not just across
+  accents.** Follow-up to 27.9: even after that fix, `TimelineImportance.Muted` cap anchors
+  (`SleepOnset`/"You fell asleep", etc.) still used a fixed, track-agnostic neutral
+  (`containerColor(Muted)` = `surfaceContainerLow`), which — since M3's own surface tones are
+  themselves derived from the primary seed — visibly read as an unrelated "primary" cast sitting
+  next to the obviously-secondary Prominent caps on the same sleep track. A first attempt blended a
+  minority of `trackAccentColor` into that neutral as a compromise (keeping Muted's own recede
+  quality); live testing showed that still wasn't enough — the ask was for every anchor on a track to
+  be *literally* the same color, full stop. `capContainerColor`/`capOnContainerColor` dropped their
+  `TimelineImportance` parameter entirely and now just return `trackAccentColor`/`trackOnAccentColor`
+  unconditionally; the Muted/Prominent distinction on a cap now lives entirely in icon and shape
+  (still separately valence-driven), not color. `containerColor`/`onContainerColor` (the detail chip,
+  off-track) keep their full per-accent/per-importance branching — unaffected.
+- **The day-header divider is now a real Material 3 Expressive component, not a hand-rolled wave.**
+  `LinearWavyProgressIndicator(progress = { 1f }, ...)` — a genuine public composable — replaces the
+  plain `HorizontalDivider`. `amplitude` is forced to a constant `{ 1f }` (the default fades it to 0
+  past ~95% progress, meant for an actually-completing bar, which would flatten this to a straight
+  line at our permanent `progress = 1f`), and `waveSpeed = 0.dp` keeps the wave static — a second
+  perpetually-running animation here would undercut the very next fix. Top padding also dropped
+  `Spacing.md` → `Spacing.xs` (still read as too far from the row above on-device), and
+  `relativeDayLabel` (`DayHeader.kt`) dropped its trailing `.uppercase(...)` — every branch was
+  already naturally capitalized, just not shouty.
+- **The day header's "you are here" active-day emphasis is removed entirely, not optimized.** Round
+  22 added a `derivedStateOf` over `listState.layoutInfo`, re-evaluated on every scroll frame for
+  every visible `DayHeader`, driving three separate `animate*AsState` calls (color, variable-font
+  weight, variable-font width) per header. Reported as a genuine on-device performance cost with no
+  cheaper way to preserve the same live "which section am I scrolled into" tracking, so it's gone:
+  every header now renders at one fixed style, no per-frame scroll-position computation at all.
+  `sessionTimelineItems` dropped its now-unused `listState` parameter as a result.
+
+Round 28 — a live-device pass covering press-motion tuning, a layout-inset bug, a chip → subtext
+redesign (with a cascading dead-code cleanup), and the Latest hero's own spacing/typography.
+
+- **The interior pill's press-morph moved from `slowSpatialSpec` to `fastSpatialSpec`** ("faster and
+  bouncier"). Checked against the actual token values
+  (`androidx.compose.material3.tokens.ExpressiveMotionTokens`) rather than guessing: fast is
+  `dampingRatio=0.6`/`stiffness=800` against slow's `0.8`/`200` — genuinely *more* underdamped (more
+  overshoot) as well as quicker to settle, i.e. legitimately both faster and bouncier, not a tradeoff
+  between the two. A stale comment claiming fast "read as an ease, not a spring" (the reason Round 25
+  moved off it) didn't match these numbers and was removed rather than carried forward unverified.
+- **`DayHeaderRow` was missing the `end = Spacing.md` inset every anchor row's own trailing content
+  applies** before the screen edge — the day number/month sat closer to the edge than every row's own
+  time label. Added to match.
+- **The `AlarmSnoozed`/`CalendarChange` detail chip (the *only* two triggers `TimelineMapper.kt`'s
+  `eventDetail` ever populated) is gone, replaced by a subtext line.** "Those chips are actually not
+  very useful... we could just add them below as extra content" — a `MonoPill` reading "9 min" or
+  "Added" had no room to say what happened; a subtext line can ("9 minutes added" / "Added event"),
+  with the one fact that matters bolded via a plain `AnnotatedString` (`EventNode.kt`'s `emphasized`)
+  rather than a markup language — `TimelineItem.Event` gained a `detailEmphasis: String?` naming the
+  substring of `detail` to bold, computed once alongside `detail` itself in `TimelineMapper.kt`'s new
+  `EventDetail(text, emphasis)` return type. This left `TriggerVisuals.kt`'s per-accent/per-importance
+  `containerColor`/`onContainerColor` — the detail chip's *only* remaining caller — fully dead, which
+  cascaded to `TimelineImportance`/`timelineImportance()` (no callers left once those two functions
+  were gone either); all four are deleted rather than left as an orphaned, uncalled color system.
+  `TimelineAccent`/`timelineAccent()` themselves are untouched — still called from `EventNode.kt` to
+  reach `capContainerColor`/`capOnContainerColor`, even though (per Round 27) those two now ignore
+  their `TimelineAccent` receiver entirely; that's pre-existing Round 27 residue, not something this
+  round's edit newly orphaned, so it's left for a future pass rather than scope-creeping this one.
+- **The Latest hero's kicker-to-headline and headline-to-subtext gaps are swapped.** "The big text...
+  was closer to the subtext than to the text above" — previously the reverse (`Spacing.xxs` kicker
+  gap vs. `Spacing.sm` subtext gap). A new shared `HERO_KICKER_GAP` (`Spacing.sm`) constant now drives
+  the kicker gap, `heroMinHeight`'s reservation term, *and* the new `heroAnchorOffset` below, so the
+  three can't drift out of sync; `TimelineNode.kt`'s generic subtext gap (used by every row's
+  `content` slot, not just the hero's) tightened from `Spacing.sm` to `Spacing.xxs`.
+- **The anchor glyph and trailing arrow now align with the headline, not the whole row.** `TimelineNode`
+  gained a `heroAnchorOffset: Dp` param — zero for every ordinary row, and (while `anchor is
+  TimelineAnchor.Latest`) the kicker's line height plus `HERO_KICKER_GAP` for the hero row, applied as
+  a top-alignment `padding` on both the anchor gutter `Box` and the trailing `status` `Box`. It
+  automatically turns back off the moment a row demotes, since `anchor` stops being
+  `TimelineAnchor.Latest` at that exact point (see `AiRunNode`'s own `when` deriving `anchor`) — no
+  separate flag needed to track "are we still in the hero state."
+- **"Crank the rounding axis to the max" on the hero headline's numerals.** In this app's own
+  vocabulary a *wider* Roboto Flex `wdth` setting is the "rounder" one (less condensing leaves round
+  letterforms like O/D closer to their natural shape — see `ExpressiveCondensedThinFontFamily`'s
+  KDoc) — `timelineHeroTimeNew`/`timelineHeroTimePrev` move off the hero title's own condensed
+  85-width face onto a new `ExpressiveMaxWidthFontFamily`/`ExpressiveMaxWidthThinFontFamily` pinned at
+  151, Roboto Flex's registered `wdth` ceiling per its own public `fvar` spec.
+- **The trailing arrow is thicker/bolder** via `Symbol`'s own Material Symbols `weight` axis (bumped
+  to 700) rather than just sizing the glyph up, which wouldn't itself thicken the stroke.
+
+Round 29 — a same-day live-device follow-up on three Round 28 items that didn't hold up once actually
+seen on a phone, plus one real bug the "too spaced out" report led to.
+
+- **The hero headline's max-width font is reverted.** Live testing read the whole block as more
+  spaced out with it than without, and the width axis was the one thing that had visibly changed —
+  `timelineHeroTimeNew`/`timelineHeroTimePrev` go back to `timelineHeroTitle`'s own condensed 85-width
+  face; `ExpressiveMaxWidthFontFamily`/`ExpressiveMaxWidthThinFontFamily` are deleted rather than left
+  defined-but-unused.
+- **The real bug behind "I need the title closer to the subtext": the subtext was never inside the
+  `TightTextStyle` `CompositionLocalProvider`.** `TimelineNode`'s title/status Row strips Android's
+  default `includeFontPadding` leading; the `content` (subtext) Box rendered as a **sibling** below
+  that provider's closing brace, not inside it — so the subtext's own invisible font padding stacked
+  on top of the real `Spacing.xxs` gap, and no amount of shrinking that literal padding value would
+  have closed the visual gap. Moving `content`'s `Box` inside the same `CompositionLocalProvider`
+  fixed it directly, rather than continuing to tune a padding constant that was never the actual cause.
+- **The anchor-glyph/arrow alignment hack is replaced with real Compose alignment lines.** Round 28's
+  `heroAnchorOffset` — a padding value hand-computed from the kicker's own `lineHeight` — "didn't work
+  at all" live. Replaced with a proper `HorizontalAlignmentLine` (`HeroHeadlineCenter`,
+  `TimelineNode.kt`): the headline itself declares its own vertical center via a small
+  `Modifier.declareCenterAs(line)` helper (a `Modifier.layout {}` reporting `placeable.height / 2` as
+  the named line's value), and the anchor gutter `Box`/trailing arrow `Box` read it back via
+  `RowScope.alignBy`, either the named-line overload (reads the headline's declared value, bubbled up
+  through the title's Column automatically) or the lambda overload (`{ measured -> measured.measuredHeight
+  / 2 }`, each box's own center) — Compose measures the real position instead of a hand-computed guess.
+  A custom line (not the built-in `FirstBaseline`/`LastBaseline`) avoids ambiguity from the kicker
+  caption *also* being a `Text` a couple of layers up in the same Column — only the headline ever
+  declares `HeroHeadlineCenter`, so there's never a second candidate value to merge.
+- **`EventNode`'s subtext (the Round 28 chip replacement) moves off `contentColor`
+  (`onSurfaceVariant`, the same color as the row's own title/time) onto `colorScheme.outline`** — "the
+  subtext should probably be less preeminent," and sharing a color with the title/time competed with
+  them for the same attention rather than reading as secondary detail underneath.
+- **The `CalendarChange` subtext no longer interpolates the raw backend `changeType` string.**
+  `changeType` is an internal identifier (`CalendarChangeWorker.kt` only ever emits
+  `"first_event_changed"`), not human-readable text — Round 28's `"$changeType event"` template
+  produced garbled snake_case ("First_event_changed event," reported as "event moved event" not
+  making sense). `EventData.CalendarChange` already carries a proper typed `affectsFirstEvent:
+  Boolean` alongside the free-form string; the subtext is built from that instead — "Your first event
+  changed" (or "Your calendar changed" as a fallback for a future `changeType` this flag doesn't
+  cover), with the affected subject bolded.
+
+Round 30 — theme-consistent occlusion, an eased (not linear) fade shared across every scrim in the
+app, the timeline track finally participating in that fade instead of relying on incidental z-order
+coverage, and a follow-up pass on hero/subtext spacing and content.
+
+- **The collapsed alarm card's occlusion scrim now behaves the same in both themes.** Round 23
+  found light theme's fully-opaque "solid" zone read as content abruptly vanishing rather than
+  fading, and capped light theme's own alpha to stay dimmed-but-visible instead — but left dark
+  theme hardcoded to a fully-opaque `1f`, on the (at-the-time reasonable, now-outdated) assumption
+  dark theme's fade "read fine" fully opaque. Reported as an inconsistency ("only in light theme"):
+  fully opaque genuinely hides content rather than dimming it, so light theme's ramp
+  (`MAX_FADE_OVERLAY_ALPHA`/`MAX_FADE_OVERLAY_SETTLED_ALPHA`, renamed off their `_LIGHT_` prefixes)
+  now applies unconditionally in `HomeContent.kt`'s `StickyAlarm`.
+- **Every fade-to-transparent scrim in the app now eases rather than linearly ramps.** A straight
+  `Brush.verticalGradient` alpha lerp crosses a high-contrast element (the timeline's solid-filled
+  sleep track, in particular) at a constant rate, which reads as an artificial hard edge rather than
+  a soft dissolve. New shared `ui/components/EasedFade.kt`: `easedFadeInAlpha`/`easedFadeOutAlpha`
+  (scalar, `FastOutSlowInEasing` by default) and `easedVerticalGradient` (samples that same curve at
+  16 stops, since `Brush.verticalGradient` only linearly interpolates *between* the stops it's given
+  — a genuinely eased curve means supplying many stops sampled from an `Easing`, not two or three
+  flat ones). Applied to `StickyAlarm`'s own tail gradient and both of `EdgeFades.kt`'s top/bottom
+  scrims, for one consistent fade language across the app.
+- **The timeline track now fades in lockstep with the scrim, instead of relying on incidental
+  z-order coverage.** Root cause of the reported "track cuts off, looks like a mistake": every draw
+  call in `TimelineTrackOverlay.kt` used a flat, constant-alpha `Color` with zero scroll-position
+  awareness — the track's only "occlusion" was happening to sit z-order-under `StickyAlarm`'s scrim
+  Box. Combine that with `TimelineNode`'s `DisposableEffect` yanking a scrolled-off row's anchor out
+  of the registry the instant its composable is disposed (no interpolation), and the track's cap
+  could visibly snap to a new position in one frame. Fix: a new `FadeZone` class (same file) shares
+  the exact fade bounds `StickyAlarm` uses (`cardBottomPx`/`totalPx`, hoisted up to `HomePlanContent`
+  so both composables derive them from the same measured card height rather than each guessing
+  independently) and fades the track's own colors in as they move away from the card — by the time
+  an anchor's row actually gets disposed, it's already faded to near-nothing, so the snap becomes
+  imperceptible. Applied three ways depending on how much Y-span each draw call has: background/pill
+  fills (can span a large range) get a real `easedVerticalGradient` brush; the spine (already broken
+  into short pieces at anchor gaps) gets a flat per-piece alpha from that piece's own start-Y; sockets
+  (a single point, no span) get an exact flat alpha from their own center. Fills skip building a brush
+  entirely when they're nowhere near the zone (`FadeZone.mayOverlap`) — the common case away from the
+  top of the screen — so the extra cost is paid only by whatever's actually near the card.
+- **The hero kicker now hugs its headline as tightly as the headline hugs its own subtext.** Round 28
+  deliberately widened `HERO_KICKER_GAP` past the headline→subtext gap so the headline read as
+  belonging with the subtext, not the caption above it; live feedback asked for the opposite —
+  `HERO_KICKER_GAP` now matches `Spacing.xxs` exactly, the same value the subtext gap already used.
+- **`AlarmSnoozed`'s subtext rephrased as the upside, not the bare mechanic**: "9 minutes added" →
+  "You get to sleep for 9 extra minutes" — still built from the one fact this event actually carries
+  (`snoozeDurationMinutes`), just friendlier and longer, per explicit direction to skip correlating it
+  with a later AI replan's resolved time (fragile: no replan exists past 3 snoozes, other events can
+  interleave and get matched instead, throttling can skip it outright).
+- **`CalendarChange`'s subtext surfaces the actual calendar event title.** The title was already
+  being read, just discarded one call too early: `CalendarChangeAnalyzer.computeFirstEventSig` read a
+  full `CalendarReader.Event` (with a real `.title`) but only folded `id`/`start`/`location`/
+  `selfAttendeeStatus` into its signature string. `CalendarChangeAnalyzer.Result` gained a
+  `firstEventTitle: String?`, threaded through `CalendarChangeWorker.kt` into a new
+  `EventData.CalendarChange.firstEventTitle` field (defaulted, so already-persisted events missing it
+  still deserialize fine) and into `TimelineMapper.kt`'s subtext: "{title} on your calendar changed,"
+  falling back to the prior generic "Your first event changed" whenever a title isn't available.
+
+Round 31 — a same-day live-device pass on Round 30 corrects a real bug the subtext-hugging fix never
+actually applied, a real color bug in the eased-gradient work, and reverts the whole track-fade
+approach and half the gradient scope after live testing rejected them.
+
+- **The subtext still wasn't hugging its title, because Round 29's fix never actually did anything.**
+  `CompositionLocalProvider(LocalTextStyle provides ...TightTextStyle)` only affects a `Text` that
+  relies on its *default* `style = LocalTextStyle.current` — every `Text` in this timeline (title,
+  status, content, the hero's kicker/headline) passes its own explicit `style`, which bypasses
+  `LocalTextStyle` entirely regardless of what a provider higher up supplies. The wrapper was dead
+  code from the moment it was written. Real fix: bake `tight`'s platform/line-height properties
+  directly into the `CronTypography` roles that only ever apply within this timeline context
+  (`timelineRowTitle`, `timelineRowTime`, `timelineHeroKicker`, `timelineHeroTitle` — `Type.kt`, via
+  `tight.copy(...)` instead of a bare `TextStyle(...)`, the same pattern `lcdHero`/`lcdStack`/
+  `timeMono` already use), and `.merge(TightTextStyle)` locally at the two ad hoc
+  `MaterialTheme.typography.bodyMedium` subtext call sites (`EventNode.kt`, `SessionTimeline.kt`) —
+  `bodyMedium` itself stays untouched since it's a shared, app-wide role. The now-fully-inert
+  `CompositionLocalProvider` wrapper in `TimelineNode.kt` is removed.
+- **The eased-gradient work from Round 30 had a real color-blend bug, was applied somewhere it
+  shouldn't have been, and is reverted.** `easedVerticalGradient(from, to, ...)` used
+  `androidx.compose.ui.graphics.lerp(from, to, t)` to interpolate between an opaque color and
+  `Color.Transparent` — but `Color.Transparent` is *black* at alpha 0, and a plain per-channel lerp
+  blends the RGB channels toward black as alpha drops, producing a muddy gray "shadow" band instead
+  of a clean alpha-only fade (reported as "a really ugly [effect] reminiscent of 2010's designs," the
+  colors "completely wrong" in light theme). Also in scope was `EdgeFades.kt`'s top *and* bottom
+  scrim, when only the collapsed alarm card's own scrim should have been touched ("I really expected
+  you to only change the one under the next alarm card"). Given the bug, the narrower-than-intended
+  scope, and a live report that the eased curve read as "way too short" and "even less natural than
+  before" regardless, both `EdgeFades.kt` and `StickyAlarm`'s own gradient (`HomeContent.kt`) are
+  reverted to their exact pre-Round-30 plain linear `Brush.verticalGradient` — the Round 30.1 theme-
+  consistency fix (dropping the dark-theme-only fully-opaque cap) is the one Round 30 change to this
+  area that stands, since it was never part of this complaint. `EasedFade.kt` is deleted — reverting
+  both its only two call sites leaves it with zero callers.
+- **The track-fade-through approach is fully reverted — every track element draws at flat, constant
+  opacity again, with no exceptions.** Explicit, unambiguous instruction: elements must stay fully
+  visible as long as even one pixel of them is still on screen; a scroll-position-derived dissolve is
+  rejected outright, not just tuned. `FadeZone`, `fillFaded`, and the per-anchor/per-spine-piece alpha
+  multiplies are removed from `TimelineTrackOverlay.kt`; `HomeContent.kt`'s hoisted
+  `cardVisiblePx`/`fadeZone` plumbing between `HomePlanContent`/`StickyAlarm`/`TimelineTrackOverlay`
+  is removed along with it.
+- **The actual track-cutoff bug — still open after Round 30's non-fix — is a geometric discontinuity,
+  not a disposal/fade timing issue.** `drawSegment`'s non-cap boundary
+  (`if (roundTop || top.cy >= 0f) top.cy - halfTrack else 0f`) was written to guard a *rare*
+  mid-insertion stale-frame case (a new true-first row whose `isSegmentTop` hasn't propagated yet),
+  but its `top.cy >= 0f` branch fires on *every* ordinary scroll: `computePlacedIfComplete` filters to
+  `LazyListState.layoutInfo.visibleItemsInfo`, and the instant the previous topmost tracked anchor
+  drops out of that set, the new topmost tracked anchor is very much on-screen (`cy >= 0`) — so
+  `bgTop` snaps downward from the flush screen edge (`0f`) to that anchor's own position every single
+  time a row scrolls fully past, which is exactly "the track brutally cuts off/despawns." Fixed by
+  always extending to the screen edge for a non-cap boundary (`if (roundTop) top.cy - halfTrack else
+  0f`, and the mirrored change for the bottom edge) — the rare stale-frame glitch this reintroduces is
+  one frame long during a new-item insertion at the very top of the whole timeline, far less
+  disruptive than a cutoff on every scroll.
+
+Round 32 — fixes a broken entrance animation (a genuine new-item arrival visibly overlapped the row it
+demoted) and a spurious slide-in on plain navigation (Home→Settings→back, or cold start, animated the
+whole timeline even though nothing in the data had changed).
+
+- **Root cause of the overlap: a hand-rolled 220ms reveal delay raced the demoted row's own placement
+  spring on two independent, unsynchronized clocks.** `AiRunNode`'s old `heroFadeAlpha`/
+  `NEW_ENTRY_FADE_DELAY_MS`/`registry.markEnteredOnce` mechanism waited a fixed 220ms before fading the
+  new latest row in, meant to give the previous latest row's own reflow (`MaterialTheme.motionScheme
+  .defaultSpatialSpec()`, a spring with no fixed settle duration, more so with Expressive's bouncy
+  overshoot) time to finish first — but a spring's real settle time isn't bounded to 220ms, so
+  whichever animation finished second painted fully opaque over the other for as long as the race
+  lasted. Fix: delete the hand-rolled delay entirely and trust `LazyListScope`'s own `animateItem
+  (fadeInSpec, placementSpec, fadeOutSpec)` uniformly for every row — verified against the actual
+  Compose Foundation source (`LazyLayoutItemAnimator.kt`) that a genuinely new key's appearance
+  (`previousIndex == -1 && previousKeyToIndexMap != null`) and an existing key's reposition are both
+  driven by the *same* synchronized per-frame system, not two independently-clocked ones. A
+  `Modifier.zIndex(if (item.isLatest) 1f else 0f)` on the `AiRun` branch (`SessionTimeline.kt`)
+  additionally guarantees the incoming hero paints on top of the demoting row for whatever momentary
+  crossing still happens during a normal reorder reflow — a residual overlap source regardless of how
+  well the timing itself is fixed.
+- **`DayHeaderRow` never had an `animateItem` modifier at all**, so a header snapped to its new
+  position instantly while sibling rows were still mid-flight through their own animated reflow.
+  Fixed by giving it the same gated `animateItem` shape as the `AiRun`/`Event` branches
+  (`sessionTimelineItems`'s new private `gatedAnimateItem` helper).
+- **The spurious slide-in on plain navigation had two contributing causes, both rooted in confusing
+  "freshly mounted" with "genuinely new data."** `HomePlanContent`'s `cardFullHeightPx` starts at 0 and
+  only receives its real measured value a frame or two after `CollapsibleAlarmCard`'s own first layout
+  pass — since this lands on a *later* frame than the LazyColumn's very first measure pass, `
+  animateItem` sees it as a legitimate offset delta and slides the entire visible timeline, even though
+  `uiState.timeline` itself never changed. Separately, the old `registry.markEnteredOnce`-based
+  "have I seen this id" bookkeeping lived in `remember`-scoped Compose state, which resets every time
+  `HomePlanContent`'s composition is torn down and rebuilt — which happens on every Home↔Settings round
+  trip (`HomeViewModel` itself survives via `MainActivity.kt`'s `popUpTo(ROUTE_HOME){ inclusive = false
+  }`, but the composition holding `LazyListState`/`TimelineTrackRegistry` does not) — so a row already
+  seen before Home was backgrounded could still misreport itself as new on return.
+  - Fix part one: `TimelineMapper.kt`'s `diffNewlyArrivedIds(currentIds, previousIds)` is a pure
+    function — `previousIds == null` only on the true first check of the caller's lifetime, always
+    returning `emptySet()`. `HomeViewModel`'s new `NewlyArrivedIdTracker` holds the one piece of
+    mutable bookkeeping this needs *at the ViewModel layer*, which survives the Home↔Settings round
+    trip that resets Compose's own `remember` state — diffed on the *uncapped* timeline id set (before
+    `capTimeline` truncates), so a genuinely new item (always sorted near the front) is never
+    misreported as truncated-away, and an old item scrolling back into the cap window purely because
+    the cap boundary shifted isn't misreported as new. Threaded through as `HomeUiState
+    .newlyArrivedIds`, into `sessionTimelineItems(newlyArrivedIds = ...)`, into `AiRunNode
+    (isNewlyArrived = ...)`, into `TimelineNode` — which now gates its own bespoke Circle→Cookie9Sided
+    arrival morph (`latestMorph`/`latestProgress`) on `isNewlyArrived && registry.markEnteredOnce(id)`
+    together, rather than on `markEnteredOnce` alone — the one thing that mechanism still needs to
+    guard, since that morph isn't driven by `animateItem` at all.
+  - Fix part two: `HomeContent.kt`'s new `rememberTimelineSettled(framesToWait = 2)` counts actual
+    rendered frames (`withFrameNanos`) since the composable was first composed, independent of device
+    speed. `HomePlanContent` threads `!timelineSettled` into `sessionTimelineItems
+    (suppressEntranceAnimation = ...)`, which forces every row's `animateItem` specs to `null` — this
+    unconditionally wins over `newlyArrivedIds` during the settle window, so a genuine arrival that
+    happened while the user was away (e.g. behind Settings) still renders statically on return, per
+    the explicit requirement that plain navigation must never animate.
+- **Tests**: `TimelineMapperTest` covers `diffNewlyArrivedIds`'s four cases (cold start, one added id,
+  an identical re-check, a removed id) and a `buildTimeline` idempotency check (same input twice →
+  structurally-equal output, since nothing upstream of the diff is memoized). `HomeViewModelTest`
+  drives a real session + a second AI turn insert through `CronDatabase` and Room's own invalidation,
+  asserting `newlyArrivedIds` is empty on the first real emission and contains only the new turn's id
+  on the next. `SessionTimelineScreenshotTest` gained a settled two-`AiRun` (demoted + latest) capture
+  via `suppressEntranceAnimation = true` — the resting frame the old racing-clocks bug never reliably
+  reached — confirming no residual double-content. A from-scratch attempt at a dynamic, mid-transition
+  `LazyColumn` test (mutating `timeline` state after `setContent` and sampling `animateItem`'s live
+  offsets) was abandoned: under this project's `createComposeRule()` + Robolectric harness, pausing
+  `mainClock.autoAdvance` before a state-driven `LazyColumn` content change prevents even the very
+  first non-animated remeasure from ever running, regardless of `runOnIdle`/`advanceTimeByFrame`
+  sequencing — a test-infrastructure gap, not a production bug, and not worth working around given the
+  data-layer tests already pin down the actual root cause precisely.
+
+Round 32.1 — a live-device pass on Round 32 found both reported bugs still present; this corrects the
+actual mechanisms rather than the ones Round 32 assumed.
+
+- **The settle gate's own signal was wrong, not just its timing.** Round 32's `rememberTimelineSettled`
+  gated purely on `cardFullHeightPx > 0` — but `HomeViewModel.uiState` is `stateIn(..., SharingStarted
+  .WhileSubscribed(5_000), HomeUiState())`: any time Home is backgrounded (behind Settings) for more
+  than 5 seconds — the common case — the whole flow cold-restarts to that all-empty default
+  (`initialized = false`, `sessionDisplay = null`) the moment Home is mounted again. `
+  CollapsibleAlarmCard` renders that default's "no alarm" empty state, which has its own nonzero
+  height and fires `onFullHeight` almost immediately — satisfying `cardFullHeightPx > 0` and flipping
+  `settled` true *before* the real `uiState` (and the real card height under it) had even arrived,
+  leaving the actual data-arrival jump completely unsuppressed. Fixed by also requiring `uiState
+  .initialized`, which only flips true on the first REAL combine emission — so the card height the
+  gate settles on is the one driven by genuine data, not the cold-start placeholder.
+- **This is not specific to a committed back-navigation pop.** Navigation Compose 2.8.5's `composable
+  (popEnterTransition = tabEnter, ...)` is live-seeked by the system predictive-back gesture itself
+  (confirmed against the actual library version and `AndroidManifest.xml`'s `android
+  :enableOnBackInvokedCallback="true"`) — Home's composition restarts progressively *during the drag*,
+  before the user's finger lifts, not just at a discrete "pop committed" moment. `docs/navigation.md`'s
+  own summary table calls the tab-level back gesture "instant, no card" — true only in the sense that
+  it has no *spatial* motion of its own to half-finish; the settle-gate bug above still fully applies
+  frame-by-frame throughout the live-seeked drag, which is what produced the reported "track and
+  content slide in from the top, misaligned" during a predictive-back preview specifically.
+- **The "whole timeline scales upward" report on a new arrival is a reflow-fanout problem, not an
+  overlap regression.** Inserting one row at the top of a long timeline shifts every row below it down
+  by that row's height, and since every row has `animateItem`'s `placementSpec` active, all of them
+  reposition at once — a `defaultSpatialSpec` spring's longer settle, played across a dozen-plus
+  simultaneously-reflowing rows with Expressive's bounce, reads as the whole timeline rubber-banding
+  into place rather than a crisp single insertion. `gatedAnimateItem` (`SessionTimeline.kt`) now uses
+  `fastSpatialSpec`/`fastEffectsSpec` instead of `default*` — same spring family, shorter window for
+  the mass-reflow to be visible. Not independently re-verified live as of this writing (device
+  disconnected mid-session); flagged here rather than silently assumed fixed.
+
+Round 33 — a code-reading pass (no live device available) found a second, independent cause of the
+Round 32.1 "track and content slide in misaligned" report that neither prior round's fix touched.
+
+- **`TimelineTrackOverlay` and the `LazyColumn` are separate sibling composables that only agree on
+  position via `TimelineTrackRegistry`, and that registry starts empty on the exact same fresh-mount
+  window Round 32.1 already found.** `rememberTimelineTrackRegistry()` is `remember`-scoped to
+  `HomePlanContent`, so a cold start or a Home remount after a Settings round trip gives it a brand
+  new, empty registry. Each row re-reports its own position (`TimelineNode`'s `Modifier
+  .onGloballyPositioned`) and descriptor (a `SideEffect`) independently as it recomposes, and
+  `TimelineTrackOverlay`'s `computePlacedIfComplete` only accepts a fresh snapshot once *every*
+  currently-visible anchor has done so — until then it keeps painting `lastComplete`, which on a fresh
+  registry starts as an empty list. Meanwhile the `LazyColumn`'s own row content has no dependency on
+  the registry at all and renders fully opaque on the very first frame. The two subtrees have no shared
+  layout/draw pass, so nothing keeps them in step during this window — the track is blank or stale for
+  however many frames it takes every visible row to catch up, while the content beside it is already
+  final. This is the literal mechanism behind "track and content... misaligned," and it's untouched by
+  Round 32/32.1's fix, which only threads into `sessionTimelineItems`' `animateItem` specs and never
+  reaches `TimelineTrackOverlay` at all.
+- **Fix: gate the overlay's paint on the same settle signal, not a second one.** `TimelineTrackOverlay`
+  gained a `visible: Boolean = true` param; its `drawBehind` block still updates `lastComplete`/
+  `computePlacedIfComplete` unconditionally (so the first frame after settling paints immediately, with
+  no extra catch-up delay), but only calls `drawTrack(...)` when `visible` is true. `HomeContent.kt`
+  passes `visible = timelineSettled` — the identical boolean already driving `suppressEntranceAnimation`
+  — rather than deriving a second settle signal, since both consumers are answering the same question
+  ("has this fresh mount's first real layout with real data landed yet?"). Steady-state scrolling is
+  unaffected: `timelineSettled` is a one-time latch that never reverts, so every frame after the
+  initial settle calls `drawTrack` exactly as before, and the overlay's intentionally zero-lag
+  draw-phase registry read (see `TimelineTrackOverlay`'s own KDoc on why it avoids `derivedStateOf`) is
+  untouched.
+- **Not independently re-verified live as of this writing** (device disconnected for the whole
+  session) — build, lint, and the existing `SessionTimelineScreenshotTest` suite (which exercises the
+  default `visible = true` path and shows no regression in the settled resting frame) all pass, but per
+  this file's own standing note, none of that substitutes for a real predictive-back gesture and a real
+  new-arrival check on-device. Do that before trusting this fix; if the symptom still reproduces, the
+  next step is the more invasive structural alternative noted in earlier rounds (moving the alarm
+  card's reserved space from an in-list `item("alarm-spacer")` into the `LazyColumn`'s own
+  `contentPadding.top`), not another patch on the registry/overlay split.
+
+Round 35 — a live-device pass (both navbar tabs, both nav directions, real predictive-back drags)
+found two independent correctness bugs behind symptoms earlier rounds had only chased with timing
+tweaks, plus two follow-up refinements once the fixes were tested more broadly.
+
+- **Track/content misalignment during any Home nav transition.** `registry.positions` used to cache
+  a plain `Offset` computed once inside `TimelineNode`'s `onGloballyPositioned`. But `MainActivity.kt`'s
+  navbar tab transitions are a `graphicsLayer` scale/alpha transform on the whole entering/exiting
+  subtree — a draw-phase-only transform that doesn't retrigger layout — so each row's cached position
+  ended up baked in at different, mutually-inconsistent points of the animation. Fixed by not caching a
+  value at all: `registry.positions` now holds the live `LayoutCoordinates` handle, queried fresh via
+  `LayoutCoordinates.localPositionOf` at draw time in `TimelineTrackOverlay.computePlacedAnchors` —
+  mapping the anchor's own untransformed local center directly into the overlay's local space in one
+  step, so Compose applies the real transform matrix (translation and scale) between the two exactly
+  once. An initial attempt used a window-space delta instead, which double-counted the transition's
+  scale since the overlay's own draw content sits inside the same scaled subtree; `localPositionOf`
+  avoids that round trip entirely.
+- **Track flush-to-screen-edge flash on a new arrival.** `drawSegment`'s `isSegmentTop`/`isSegmentBottom`
+  reasoning could read stale right after a new anchor is prepended and hasn't registered yet, flushing
+  the track's background to the literal screen edge under the alarm card for a frame. A same-round
+  attempt cross-checked against `listState.layoutInfo.visibleItemsInfo` membership to catch this, but
+  further live testing found `visibleItemsInfo` recomputes on essentially every scroll frame while the
+  registry's own flags update on composition/effect timing — two independently-clocked systems that
+  briefly disagree constantly during ordinary scrolling, producing a worse, more frequent flicker than
+  the narrow bug it targeted. Reverted back to pure `descriptor.isSegmentTop`/`isSegmentBottom`, computed
+  fresh from `uiState.timeline` every recomposition, which can't race with scrolling since scrolling
+  never changes `uiState.timeline`. The narrow new-arrival case is real but rare and not re-addressed
+  here; a future fix should be scoped to "did the timeline's head genuinely change" as a data event, not
+  anything derived from `layoutInfo` or scroll position.
+- **A disposed row's stale-position ghost, tried and reverted.** A same-round attempt cached a disposed
+  row's last-known placement and kept drawing it until its position proved genuinely off-screen, to
+  paper over a row's registry entry disappearing the instant `LazyColumn` disposes it (which doesn't
+  necessarily wait until a row is fully past the edge). Reverted after live testing found it traded one
+  bug for a worse one: a disposed row's cached position never updates again, so "still on screen" could
+  evaluate true forever — a permanently stuck, non-scrolling ghost element. Back to drawing only what's
+  currently registered; a row disposing while still visually on-screen can still flicker, and this
+  remains an open issue — the right fix controls `LazyColumn`'s own beyond-viewport composition margin
+  directly, rather than caching or second-guessing its disposal decisions from outside.
+- Also fixed the screenshot tests silently rendering with no track at all, since they never advanced
+  the test clock past the settle gate an earlier round introduced — all of `TimelineNodeScreenshotTest`'s
+  cases plus `PillPressMorphScreenshotTest`, confirmed by tracing every `captureRoboImage()` call site
+  in the touched test files, not just the handful first noticed.


### PR DESCRIPTION
## Summary
- Redesigns the vertical home-timeline's connecting track from a thin (1.5dp), meaningless line into a two-shape, round-capped, Google-Maps-transit-style track: an always-present neutral **background** spans the whole timeline, and a separate **sleep-pill overlay** (calm blended tint) is drawn on top over each contiguous asleep stretch, capped at its own onset/wake row — not just the list's true top/bottom.
- Every anchor — icons, the plain dot, the loading spinner, and the `Latest` morph shape alike — is carved as a single shape directly into whichever track shape it sits on, with a real margin (the track's own color, left uncarved) separating it from the tube's edge. An anchor marking a sleep block's own start/end nests into *that pill's* own rounded cap; an anchor at the list's true edge nests into the background's cap. A rounded cap's rect is trimmed to stop exactly at the anchor's center (not just rounded), so the cap's curvature and the carved hole stay concentric in every case, including where a sleep pill's local cap coincides with the list's own global edge.
- Every icon glyph is now centered on its actual measured ink (`Paint.getTextBounds`), not a fixed draw origin — fixes a small but consistent off-center rendering across all icons app-wide, most visible at the timeline's small anchor sizes.
- Event icons carry an **importance tier**, orthogonal to their category color: a real alarm/state change (dismissed, snoozed, the safety alarm, a wake-window opportunity, confirmed out-of-bed) keeps a bold hue container that pops off the track; a routine/ambient event (sleep sensing, schedule checks) drops to a neutral, low-contrast pair that recedes into the track.
- The TODAY/YESTERDAY day heading is more condensed than the home greeting's username; the date label beside it matches the heading's size but reads thinner and less condensed.
- The AI hero headline is exclusively a time fact — PREV › NEW (NEW bold italic, PREV a genuinely thin variable-font weight) when the alarm changed, the standing time alone when it didn't, or a static "No alarm set" label — never the AI's own prose, which is always demoted to a smaller line below. A session's first turn can now show a real PREV time too: it looks at the most recent older session's own last resolved alarm time and carries it over when this session has none of its own to compare against.
- Sleep/awake state is derived purely from the `SleepOnset`/`OutOfBedConfirmed` rows already shown in the timeline (`timelineAsleepStates` in `TimelineMapper.kt`) — no new data plumbing, no Health Connect stage blending (scoped out).
- The `Latest` anchor no longer inflates to the track's end-cap radius: its scalloped `Cookie9Sided` morph shape isn't circular, so the flush-nest illusion (correct for circular anchors) made its petals visibly overshoot the cap. It now always renders at its own true size.
- Icon glyph centering now survives real on-device rendering, not just Robolectric: `Symbol()` bakes its `wght`/`GRAD`/`opsz` axes into a real cached `Typeface` variant instead of a live per-Paint override, since the two aren't guaranteed to resolve the same glyph outline on measurement vs. render on every OEM/API level (only visible on compound glyphs like `AlarmOff`/`NotificationImportant`, not simple ones like `PlayArrow`/`Bedtime`).
- The Latest row's "Latest · HH:MM" status line is folded into the kicker above it instead of a separate line: a base plan reads "PLANNED · 14M AGO", a replan reads "REPLANNED · AT 07:15".
- The trickiest part remains the track geometry in `TimelineNode.kt`: each row now carves its anchor's hole out of *two* independently-shaped, independently-rounded paths (the background and, where applicable, the sleep-pill overlay) instead of one shared path colored in two halves — needed so the asleep/awake transition gets a real rounded cap instead of a flat cut, and so an anchor's end-cap radius can key off either the list's global boundary or a sleep pill's own local boundary.

**Stacked on [#feat/hc-sleep-write](https://github.com/BSoDium/Cron/compare/feat/hc-sleep-write...feat/timeline-track)** (itself stacked on [#149](https://github.com/BSoDium/Cron/pull/149)) — base branch is `feat/hc-sleep-write`, so the diff only shows this feature's changes. Merge in order: #149 → hc-sleep-write → this one, or rebase onto `main` as earlier branches land.

A related but unrelated-subsystem fix (sleep/wake false-detection debounce) landed separately as [#172](https://github.com/BSoDium/Cron/pull/172), branched off `main` since it's sensors/state-machine, not timeline UI.

## Test plan
- [x] `./gradlew :app:assembleDebug :app:lintDebug :app:checkFileLength :app:checkAnimationPreviews :app:testDebugUnitTest` — all green.
- [x] New `timelineAsleepStates` unit tests (`TimelineMapperTest`): no sleep events, an onset→wake pair with an AI run sandwiched inside, alternating multi-nap pairs, day-header reset mid-sleep.
- [x] Roborazzi screenshots re-recorded and visually inspected across all ten rounds, including this one: the sleep pill's rounded cap is concentric with its nested anchor in every case (global edge, local sleep boundary, and the two coinciding); every icon glyph sits centered in its circle (confirmed via direct pixel measurement, not just visual review); the `Latest` anchor sits flush inside the track's rounded cap with no overflow; prominent vs. muted event icons visibly differ in contrast; the day header/date label typography reads as intended; the hero headline is always a time or "No alarm set," with a manual-base (turn 0) run whose session has an older sibling with a resolved alarm time now showing a real PREV › NEW pair.
- [x] New `CronThemeColorTest` confirming `dynamicDarkColorScheme`/`dynamicLightColorScheme` produce genuinely different `tertiaryContainer`/`surfaceContainerHigh` values (theme-wiring itself was never the bug).
- [x] Round 12: `assembleDebug`/`lintDebug`/`checkFileLength`/`checkAnimationPreviews`/`testDebugUnitTest` all green; new `MaterialSymbolsScreenshotTest` covers `AlarmOff`/`NotificationImportant` alongside the previously-correct `PlayArrow`/`Bedtime` as a no-regression control; `TimelineNodeScreenshotTest`/`SessionTimelineScreenshotTest` re-recorded and inspected — Latest anchor no longer overflows its cap, kicker shows the folded time fact, no more standalone status line.
- [ ] Manual on-device (pending user confirmation): scroll the real home timeline across a night with a sleep session, confirm the track's sleep pill has real rounded caps at its own boundaries with no overflow/underflow at any transition, every anchor (including `Latest`) reads as nested with no overflow, every icon glyph — including `AlarmOff`/`NotificationImportant` — is centered in its circle, prominent events pop while routine ones recede, the day header/date label read correctly, and the hero headline shows a real PREV time on a fresh session when an earlier one resolved an alarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
