### PR TITLE
fix(sensors): debounce false sleep-wake detection

### DIFF
--- a/app/src/debug/java/fr/bsodium/cron/sensors/SleepTuning.kt
+++ b/app/src/debug/java/fr/bsodium/cron/sensors/SleepTuning.kt
@@ -16,4 +16,7 @@ object SleepTuning {
 
     fun rearmThreshold(context: Context): Duration =
         if (SleepTestPrefs(context).fastOnset) 5.seconds else 15.minutes
+
+    fun outOfBedConfirmThreshold(context: Context): Duration =
+        if (SleepTestPrefs(context).fastOnset) 5.seconds else 90.seconds
 }

--- a/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
@@ -107,8 +107,7 @@ class ScreenStateMonitor(
 
     private fun onScreenOff() {
         screenOffSince = Clock.System.now()
-        // A re-lock before out-of-bed confirms aborts it — that's the fix for a momentary glance
-        // in bed (pick up phone, put it back down) being mistaken for getting up.
+        // A re-lock before out-of-bed confirms aborts it, so a momentary glance in bed isn't mistaken for getting up.
         pendingOutOfBed?.cancel()
         Log.d(TAG, "Screen off — onset check scheduled (threshold=$currentOnsetThreshold)")
         scheduleOnsetCheck(currentOnsetThreshold)
@@ -158,7 +157,12 @@ class ScreenStateMonitor(
         pendingOutOfBed?.cancel()
         pendingOutOfBed = scope.launch {
             kotlinx.coroutines.delay(outOfBedThreshold)
-            if (!shouldConfirmOutOfBed(outOfBedThreshold, outOfBedThreshold, powerManager.isInteractive)) {
+            if (!shouldConfirmOutOfBed(
+                    interactiveFor = outOfBedThreshold,
+                    threshold = outOfBedThreshold,
+                    stillInteractive = powerManager.isInteractive,
+                )
+            ) {
                 Log.i(TAG, "Unlock not sustained — treating as an in-bed glance, not out-of-bed")
                 return@launch
             }

--- a/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
+++ b/app/src/main/java/fr/bsodium/cron/sensors/ScreenStateMonitor.kt
@@ -20,6 +20,7 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Listens to ACTION_SCREEN_OFF / SCREEN_ON / USER_PRESENT broadcasts and synthesizes:
@@ -40,6 +41,7 @@ class ScreenStateMonitor(
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob()),
     private val sleepOnsetThreshold: Duration = 20.minutes,
     private val rearmThreshold: Duration = REARM_ONSET_THRESHOLD,
+    private val outOfBedThreshold: Duration = OUT_OF_BED_CONFIRM_THRESHOLD,
     private val lightReader: AmbientLightReader = AmbientLightReader(context),
     private val isAlarmRinging: () -> Boolean = { AlarmRingingState.isRinging },
 ) {
@@ -47,6 +49,7 @@ class ScreenStateMonitor(
     private var screenOffSince: Instant? = null
     private var sleepOnsetEmitted: Boolean = false
     private var pendingOnset: Job? = null
+    private var pendingOutOfBed: Job? = null
     /** True after [rearm] has been called; consumed by the next SleepOnset emission. */
     private var isRearm: Boolean = false
     /** The threshold the pending onset check is using; survives a screen-on/off blip during rearm. */
@@ -85,6 +88,7 @@ class ScreenStateMonitor(
             .onFailure { Log.w(TAG, "unregisterReceiver failed", it) }
         lightReader.stop()
         pendingOnset?.cancel()
+        pendingOutOfBed?.cancel()
         Log.i(TAG, "ScreenStateMonitor stopped")
     }
 
@@ -103,6 +107,9 @@ class ScreenStateMonitor(
 
     private fun onScreenOff() {
         screenOffSince = Clock.System.now()
+        // A re-lock before out-of-bed confirms aborts it — that's the fix for a momentary glance
+        // in bed (pick up phone, put it back down) being mistaken for getting up.
+        pendingOutOfBed?.cancel()
         Log.d(TAG, "Screen off — onset check scheduled (threshold=$currentOnsetThreshold)")
         scheduleOnsetCheck(currentOnsetThreshold)
     }
@@ -116,9 +123,11 @@ class ScreenStateMonitor(
     }
 
     /**
-     * A genuine unlock is our strongest "awake" signal — the user is handling the phone, not stirring
-     * in their sleep. If we'd latched sleep, treat it as getting out of bed (one event → FSM Awake →
-     * [rearm]) rather than firing a plan on every pickup.
+     * A genuine unlock is a candidate "awake" signal, but on its own it doesn't distinguish a
+     * momentary glance in bed (checking the time, a notification) from actually getting up — so it
+     * only starts a [scheduleOutOfBedConfirm] debounce rather than emitting immediately. If we'd
+     * latched sleep and the unlock is sustained, treat it as getting out of bed (one event → FSM
+     * Awake → [rearm]) rather than firing a plan on every pickup.
      *
      * Suppressed while an alarm is actively ringing: [AlarmActivity][fr.bsodium.cron.ui.screens.alarm.AlarmActivity]
      * dismisses the keyguard as soon as it launches, so USER_PRESENT fires a beat before the user's
@@ -136,17 +145,33 @@ class ScreenStateMonitor(
             Log.i(TAG, "User present while an alarm is ringing — treating as the dismiss unlock, not out-of-bed")
             return
         }
-        sleepOnsetEmitted = false
-        scope.launch {
+        scheduleOutOfBedConfirm()
+    }
+
+    /** Debounce-then-confirm, mirroring [scheduleOnsetCheck]'s shape: a genuine wake-up keeps the
+     *  screen interactive past [outOfBedThreshold]; a glance re-locks or times out before then and
+     *  [onScreenOff]/[stop] cancel this job, so [sleepOnsetEmitted] stays true and the session
+     *  remains correctly latched as asleep. Reaching the end of the delay uncancelled already proves
+     *  the interactive duration was met; [powerManager.isInteractive] is rechecked only as a safety
+     *  net against the rare race where the screen times out just before its off-broadcast is delivered. */
+    private fun scheduleOutOfBedConfirm() {
+        pendingOutOfBed?.cancel()
+        pendingOutOfBed = scope.launch {
+            kotlinx.coroutines.delay(outOfBedThreshold)
+            if (!shouldConfirmOutOfBed(outOfBedThreshold, outOfBedThreshold, powerManager.isInteractive)) {
+                Log.i(TAG, "Unlock not sustained — treating as an in-bed glance, not out-of-bed")
+                return@launch
+            }
+            sleepOnsetEmitted = false
             sink.emit(
                 SessionEvent(
                     trigger = TriggerType.OutOfBedConfirmed,
                     timestamp = Clock.System.now(),
-                    data = EventData.OutOfBedConfirmed(evidence = listOf("device_unlocked")),
+                    data = EventData.OutOfBedConfirmed(evidence = listOf("device_unlocked", "sustained_${outOfBedThreshold.inWholeSeconds}s")),
                 )
             )
+            Log.i(TAG, "Sustained unlock while asleep — out of bed")
         }
-        Log.i(TAG, "User present while asleep — out of bed")
     }
 
     private fun scheduleOnsetCheck(threshold: Duration = sleepOnsetThreshold) {
@@ -186,6 +211,10 @@ class ScreenStateMonitor(
         private val REARM_ONSET_THRESHOLD = 15.minutes
         /** How often to re-test the dark/charging gate while the screen stays off. */
         private val ONSET_RECHECK_INTERVAL = 5.minutes
+        /** A momentary in-bed glance (checking the time, a notification) rarely keeps the screen
+         *  interactive this long; a genuine wake-up comfortably does, and 90s is trivial next to the
+         *  15-20 min onset windows, so a real wake-driven replan isn't noticeably delayed. */
+        private val OUT_OF_BED_CONFIRM_THRESHOLD = 90.seconds
 
         /**
          * Pure onset decision — unit-testable. Sleep onset requires a dark room; an uncharged device
@@ -202,5 +231,17 @@ class ScreenStateMonitor(
             val required = if (isCharging) baseThreshold else baseThreshold * 2
             return screenOff >= required
         }
+
+        /**
+         * Pure out-of-bed decision — unit-testable. A genuine unlock ends sleep only if the screen
+         * stayed interactive for [threshold]; a momentary pickup (re-locked/screen-off before then) is
+         * a glance in bed, not getting up. Conservative like onset: a missed confirmation only delays
+         * a replan, a false one wrongly ends tracking.
+         */
+        internal fun shouldConfirmOutOfBed(
+            interactiveFor: Duration,
+            threshold: Duration,
+            stillInteractive: Boolean,
+        ): Boolean = stillInteractive && interactiveFor >= threshold
     }
 }

--- a/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
+++ b/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
@@ -85,9 +85,7 @@ class SleepSessionService : Service() {
         // Location-typed FGS keeps the fetch "in use" on foreground permission alone; a sticky restart (null intent) only resumes monitoring, never re-fires the plan.
         startForegroundService(includeLocation = eveningPlan)
 
-        // A REARM after the service was killed and restarted fresh finds screenStateMonitor null —
-        // treat that the same as a normal start (build the monitors) before rearming, so REARM never
-        // silently no-ops and leaves the session with no sensors and no foreground notification.
+        // A REARM after the service was killed and restarted fresh finds screenStateMonitor null — treat that the same as a normal start (build the monitors) before rearming, so REARM never silently no-ops.
         val freshlyConstructed = screenStateMonitor == null
         if (freshlyConstructed) {
             screenStateMonitor = ScreenStateMonitor(
@@ -103,8 +101,7 @@ class SleepSessionService : Service() {
             activityRecognitionMonitor = ActivityRecognitionMonitor(applicationContext, fsmSink, serviceScope).also { it.start() }
         }
 
-        // Only rearm explicitly on a fresh construction — start() already seeds onset detection
-        // from the current screen state, and rearm() would just redundantly reset the same latch.
+        // Only rearm explicitly on a fresh construction — start() already seeds onset detection from the current screen state, and rearm() would just redundantly reset the same latch.
         if (isRearm && !freshlyConstructed) {
             screenStateMonitor?.rearm()
         }

--- a/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
+++ b/app/src/main/java/fr/bsodium/cron/service/SleepSessionService.kt
@@ -96,6 +96,7 @@ class SleepSessionService : Service() {
                 serviceScope,
                 sleepOnsetThreshold = SleepTuning.onsetThreshold(applicationContext),
                 rearmThreshold = SleepTuning.rearmThreshold(applicationContext),
+                outOfBedThreshold = SleepTuning.outOfBedConfirmThreshold(applicationContext),
             ).also { it.start() }
         }
         if (activityRecognitionMonitor == null) {

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -257,10 +257,7 @@ class SessionFsm(
             when (event.trigger) {
                 TriggerType.AlarmDismissed -> when (session.status) {
                     SessionStatus.Monitoring -> SessionStatus.Awake
-                    // Reaching ReMonitoring means the session already had a full sleep→wake→resleep
-                    // cycle. A dismiss from here is the morning wake unless it's a rapid genuine
-                    // re-ring (dismiss → fall back asleep → re-ring, all within dismissGrace of the
-                    // prior dismiss) — that legitimate chain still re-arms; anything later completes.
+                    // A dismiss here completes the session unless it's a rapid genuine re-ring within dismissGrace of the prior dismiss, which still re-arms.
                     SessionStatus.ReMonitoring -> {
                         val lastDismiss = session.events.lastOrNull { it.trigger == TriggerType.AlarmDismissed }?.timestamp
                         val withinGrace = lastDismiss != null && event.timestamp - lastDismiss < dismissGrace

--- a/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
+++ b/app/src/main/java/fr/bsodium/cron/session/SessionFsm.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 /**
@@ -238,16 +239,33 @@ class SessionFsm(
 
         private val AI_COOLDOWN = 15.minutes
 
+        /** A dismiss from ReMonitoring more than this long after the prior dismiss is the morning
+         *  wake, not a rapid re-ring chain — see [transition]'s AlarmDismissed/ReMonitoring case. */
+        private val DISMISS_GRACE = 30.minutes
+
         /**
          * Pure status transition, unit-testable: given the session's current status and an incoming
          * event, what status should it become? A dismiss while still asleep re-arms (→ Awake) rather
          * than completing outright, so a second sleep onset can re-ring the alarm; a second dismiss
          * (already Awake) ends the session.
          */
-        internal fun transition(session: SleepSession, event: SessionEvent): SessionStatus =
+        internal fun transition(
+            session: SleepSession,
+            event: SessionEvent,
+            dismissGrace: Duration = DISMISS_GRACE,
+        ): SessionStatus =
             when (event.trigger) {
                 TriggerType.AlarmDismissed -> when (session.status) {
-                    SessionStatus.Monitoring, SessionStatus.ReMonitoring -> SessionStatus.Awake
+                    SessionStatus.Monitoring -> SessionStatus.Awake
+                    // Reaching ReMonitoring means the session already had a full sleep→wake→resleep
+                    // cycle. A dismiss from here is the morning wake unless it's a rapid genuine
+                    // re-ring (dismiss → fall back asleep → re-ring, all within dismissGrace of the
+                    // prior dismiss) — that legitimate chain still re-arms; anything later completes.
+                    SessionStatus.ReMonitoring -> {
+                        val lastDismiss = session.events.lastOrNull { it.trigger == TriggerType.AlarmDismissed }?.timestamp
+                        val withinGrace = lastDismiss != null && event.timestamp - lastDismiss < dismissGrace
+                        if (withinGrace) SessionStatus.Awake else SessionStatus.Complete
+                    }
                     SessionStatus.Planning, SessionStatus.Awake, SessionStatus.Complete -> SessionStatus.Complete
                 }
                 TriggerType.SleepOnset -> when (session.status) {

--- a/app/src/release/java/fr/bsodium/cron/sensors/SleepTuning.kt
+++ b/app/src/release/java/fr/bsodium/cron/sensors/SleepTuning.kt
@@ -3,6 +3,7 @@ package fr.bsodium.cron.sensors
 import android.content.Context
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 /** RELEASE variant — production sleep-detection timings; no debug overrides. */
 object SleepTuning {
@@ -11,4 +12,7 @@ object SleepTuning {
 
     @Suppress("UNUSED_PARAMETER")
     fun rearmThreshold(context: Context): Duration = 15.minutes
+
+    @Suppress("UNUSED_PARAMETER")
+    fun outOfBedConfirmThreshold(context: Context): Duration = 90.seconds
 }

--- a/app/src/test/java/fr/bsodium/cron/sensors/ScreenStateMonitorOutOfBedDebounceTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/sensors/ScreenStateMonitorOutOfBedDebounceTest.kt
@@ -9,28 +9,28 @@ import androidx.test.core.app.ApplicationProvider
 import fr.bsodium.cron.session.model.SessionEvent
 import fr.bsodium.cron.session.model.TriggerType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.seconds
 
 /**
- * Regresses Bug 3: [AlarmActivity][fr.bsodium.cron.ui.screens.alarm.AlarmActivity] dismisses the
- * keyguard on launch, so a real device fires USER_PRESENT a beat before the user's actual
- * slide-to-dismiss gesture. Left unguarded, that unlock alone drives the session to Awake and the
- * dismiss gesture right behind it then completes the session immediately — collapsing the
- * dismiss-while-asleep re-ring guarantee on the very first real dismissal.
+ * Regresses the false-wake bug: a momentary phone pickup while still asleep must not end sleep
+ * tracking. [ScreenStateMonitor.onUserPresent] only confirms out-of-bed after the unlock has stayed
+ * sustained for [outOfBedThreshold] — a re-lock before then must abort it.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
-class ScreenStateMonitorUserPresentTest {
+class ScreenStateMonitorOutOfBedDebounceTest {
 
     private val app: Application = ApplicationProvider.getApplicationContext()
+    private val threshold = 90.seconds
 
     private class RecordingSink : SensorEventSink {
         val received = mutableListOf<SessionEvent>()
@@ -39,10 +39,7 @@ class ScreenStateMonitorUserPresentTest {
         }
     }
 
-    private fun seedScreenOff() {
-        val powerManager = app.getSystemService(Context.POWER_SERVICE) as PowerManager
-        shadowOf(powerManager).setIsInteractive(false)
-    }
+    private fun powerManager() = app.getSystemService(Context.POWER_SERVICE) as PowerManager
 
     private fun sendBroadcastAndIdle(action: String) {
         app.sendBroadcast(Intent(action))
@@ -50,48 +47,15 @@ class ScreenStateMonitorUserPresentTest {
     }
 
     @Test
-    fun user_present_while_alarm_ringing_does_not_emit_out_of_bed() = runTest {
-        seedScreenOff()
+    fun a_momentary_glance_that_relocks_before_threshold_does_not_end_sleep_tracking() = runTest {
+        shadowOf(powerManager()).setIsInteractive(false)
         val sink = RecordingSink()
         val monitor = ScreenStateMonitor(
             context = app,
             sink = sink,
             scope = this,
             sleepOnsetThreshold = ZERO,
-            lightReader = AmbientLightReader(app),
-            isAlarmRinging = { true },
-        )
-        try {
-            monitor.start()
-            advanceUntilIdle()
-            assertTrue(
-                "precondition: onset should have latched before USER_PRESENT",
-                sink.received.any { it.trigger == TriggerType.SleepOnset },
-            )
-            sink.received.clear()
-
-            sendBroadcastAndIdle(Intent.ACTION_USER_PRESENT)
-            advanceUntilIdle()
-
-            assertTrue(
-                "OutOfBedConfirmed must be suppressed while an alarm is ringing",
-                sink.received.none { it.trigger == TriggerType.OutOfBedConfirmed },
-            )
-        } finally {
-            monitor.stop()
-        }
-    }
-
-    @Test
-    fun user_present_while_no_alarm_ringing_emits_out_of_bed() = runTest {
-        seedScreenOff()
-        val sink = RecordingSink()
-        val monitor = ScreenStateMonitor(
-            context = app,
-            sink = sink,
-            scope = this,
-            sleepOnsetThreshold = ZERO,
-            outOfBedThreshold = ZERO,
+            outOfBedThreshold = threshold,
             lightReader = AmbientLightReader(app),
             isAlarmRinging = { false },
         )
@@ -100,9 +64,45 @@ class ScreenStateMonitorUserPresentTest {
             advanceUntilIdle()
             sink.received.clear()
 
-            // A real unlock leaves the device interactive — the sustained-unlock debounce checks
-            // this at confirm time (see ScreenStateMonitorOutOfBedDebounceTest for the debounce itself).
-            (app.getSystemService(Context.POWER_SERVICE) as PowerManager).let { shadowOf(it).setIsInteractive(true) }
+            // User picks up the phone briefly, still in bed.
+            shadowOf(powerManager()).setIsInteractive(true)
+            sendBroadcastAndIdle(Intent.ACTION_USER_PRESENT)
+            advanceTimeBy(30.seconds)
+
+            // ...then puts it back down and falls back asleep, well before the threshold.
+            shadowOf(powerManager()).setIsInteractive(false)
+            sendBroadcastAndIdle(Intent.ACTION_SCREEN_OFF)
+            advanceUntilIdle()
+
+            assertEquals(
+                "a glance that re-locks before the threshold must not confirm out-of-bed",
+                0,
+                sink.received.count { it.trigger == TriggerType.OutOfBedConfirmed },
+            )
+        } finally {
+            monitor.stop()
+        }
+    }
+
+    @Test
+    fun a_sustained_unlock_past_threshold_confirms_out_of_bed() = runTest {
+        shadowOf(powerManager()).setIsInteractive(false)
+        val sink = RecordingSink()
+        val monitor = ScreenStateMonitor(
+            context = app,
+            sink = sink,
+            scope = this,
+            sleepOnsetThreshold = ZERO,
+            outOfBedThreshold = threshold,
+            lightReader = AmbientLightReader(app),
+            isAlarmRinging = { false },
+        )
+        try {
+            monitor.start()
+            advanceUntilIdle()
+            sink.received.clear()
+
+            shadowOf(powerManager()).setIsInteractive(true)
             sendBroadcastAndIdle(Intent.ACTION_USER_PRESENT)
             advanceUntilIdle()
 

--- a/app/src/test/java/fr/bsodium/cron/sensors/ScreenStateMonitorTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/sensors/ScreenStateMonitorTest.kt
@@ -4,10 +4,12 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class ScreenStateMonitorTest {
 
     private val base = 20.minutes
+    private val outOfBedThreshold = 90.seconds
 
     @Test
     fun never_fires_in_a_lit_room() {
@@ -38,6 +40,27 @@ class ScreenStateMonitorTest {
         )
         assertTrue(
             ScreenStateMonitor.shouldEmitOnset(base * 2, base, isDark = true, isCharging = false),
+        )
+    }
+
+    @Test
+    fun sustained_interactive_unlock_confirms_out_of_bed() {
+        assertTrue(
+            ScreenStateMonitor.shouldConfirmOutOfBed(outOfBedThreshold, outOfBedThreshold, stillInteractive = true),
+        )
+    }
+
+    @Test
+    fun a_glance_below_threshold_does_not_confirm() {
+        assertFalse(
+            ScreenStateMonitor.shouldConfirmOutOfBed(outOfBedThreshold - 1.seconds, outOfBedThreshold, stillInteractive = true),
+        )
+    }
+
+    @Test
+    fun relocked_before_confirming_does_not_confirm_even_past_threshold() {
+        assertFalse(
+            ScreenStateMonitor.shouldConfirmOutOfBed(outOfBedThreshold * 2, outOfBedThreshold, stillInteractive = false),
         )
     }
 }

--- a/app/src/test/java/fr/bsodium/cron/sensors/ScreenStateMonitorUserPresentTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/sensors/ScreenStateMonitorUserPresentTest.kt
@@ -100,8 +100,7 @@ class ScreenStateMonitorUserPresentTest {
             advanceUntilIdle()
             sink.received.clear()
 
-            // A real unlock leaves the device interactive — the sustained-unlock debounce checks
-            // this at confirm time (see ScreenStateMonitorOutOfBedDebounceTest for the debounce itself).
+            // A real unlock leaves the device interactive — the sustained-unlock debounce itself is covered by ScreenStateMonitorOutOfBedDebounceTest.
             (app.getSystemService(Context.POWER_SERVICE) as PowerManager).let { shadowOf(it).setIsInteractive(true) }
             sendBroadcastAndIdle(Intent.ACTION_USER_PRESENT)
             advanceUntilIdle()

--- a/app/src/test/java/fr/bsodium/cron/session/SessionFsmTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/session/SessionFsmTest.kt
@@ -53,11 +53,11 @@ class SessionFsmTest {
         assertEquals(SessionStatus.Awake, SessionFsm.transition(session, alarmDismissed))
     }
 
+    /** No prior dismiss in the event history means this dismiss is the morning wake — completing
+     *  outright is the fix for the false-wake bug (a spurious OutOfBedConfirmed re-armed onset
+     *  detection hours before the real dismissal). */
     @Test
     fun alarm_dismissed_from_remonitoring_with_no_prior_dismiss_completes_session() {
-        // Reaching ReMonitoring with no prior dismiss in the event history means this dismiss is the
-        // morning wake — completing outright is the fix for the false-wake bug (a spurious
-        // OutOfBedConfirmed re-armed onset detection hours before the real dismissal).
         val session = Fixtures.session(status = SessionStatus.ReMonitoring)
         assertEquals(SessionStatus.Complete, SessionFsm.transition(session, alarmDismissed))
     }
@@ -69,10 +69,9 @@ class SessionFsmTest {
         assertEquals(SessionStatus.Complete, SessionFsm.transition(session, alarmDismissed))
     }
 
+    /** A rapid dismiss -> fall back asleep -> re-ring -> dismiss chain, all within the grace window — the legitimate re-ring flow, still re-arms rather than completing. */
     @Test
     fun alarm_dismissed_from_remonitoring_shortly_after_a_prior_dismiss_rearms_to_awake() {
-        // A rapid dismiss -> fall back asleep -> re-ring -> dismiss chain, all within the grace
-        // window — the legitimate re-ring flow, still re-arms rather than completing.
         val priorDismiss = alarmDismissed.copy(timestamp = now - 10.minutes)
         val session = Fixtures.session(status = SessionStatus.ReMonitoring, events = listOf(priorDismiss))
         assertEquals(SessionStatus.Awake, SessionFsm.transition(session, alarmDismissed))

--- a/app/src/test/java/fr/bsodium/cron/session/SessionFsmTest.kt
+++ b/app/src/test/java/fr/bsodium/cron/session/SessionFsmTest.kt
@@ -10,6 +10,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
 class SessionFsmTest {
@@ -53,8 +54,27 @@ class SessionFsmTest {
     }
 
     @Test
-    fun alarm_dismissed_from_remonitoring_rearms_to_awake() {
+    fun alarm_dismissed_from_remonitoring_with_no_prior_dismiss_completes_session() {
+        // Reaching ReMonitoring with no prior dismiss in the event history means this dismiss is the
+        // morning wake — completing outright is the fix for the false-wake bug (a spurious
+        // OutOfBedConfirmed re-armed onset detection hours before the real dismissal).
         val session = Fixtures.session(status = SessionStatus.ReMonitoring)
+        assertEquals(SessionStatus.Complete, SessionFsm.transition(session, alarmDismissed))
+    }
+
+    @Test
+    fun alarm_dismissed_from_remonitoring_long_after_a_prior_dismiss_completes_session() {
+        val priorDismiss = alarmDismissed.copy(timestamp = now - 6.hours)
+        val session = Fixtures.session(status = SessionStatus.ReMonitoring, events = listOf(priorDismiss))
+        assertEquals(SessionStatus.Complete, SessionFsm.transition(session, alarmDismissed))
+    }
+
+    @Test
+    fun alarm_dismissed_from_remonitoring_shortly_after_a_prior_dismiss_rearms_to_awake() {
+        // A rapid dismiss -> fall back asleep -> re-ring -> dismiss chain, all within the grace
+        // window — the legitimate re-ring flow, still re-arms rather than completing.
+        val priorDismiss = alarmDismissed.copy(timestamp = now - 10.minutes)
+        val session = Fixtures.session(status = SessionStatus.ReMonitoring, events = listOf(priorDismiss))
         assertEquals(SessionStatus.Awake, SessionFsm.transition(session, alarmDismissed))
     }
 


### PR DESCRIPTION
## Summary
- A momentary phone pickup while still asleep instantly fired `OutOfBedConfirmed`, ending sleep tracking on the very first screen unlock. `ScreenStateMonitor` now requires the screen to stay interactive for 90s before confirming out-of-bed — a re-lock before then aborts the confirmation.
- That false wake could re-arm onset detection and re-latch into `ReMonitoring`, causing the real morning alarm dismissal to only re-arm (not complete) the session. `SessionFsm.transition()` now completes a dismiss from `ReMonitoring` outright unless the prior dismiss was within a 30-minute grace window (the legitimate rapid dismiss → fall back asleep → re-ring chain).
- Traced against a real overnight report: fell asleep ~01:14, a phone pickup at 01:25 wrongly ended tracking, and the real 08:00 alarm dismissal didn't close the session until an incidental unlock ~09:00. Both fixes target this exact sequence.

## Test plan
- [x] New unit tests for `ScreenStateMonitor.shouldConfirmOutOfBed` (sustained+interactive, below threshold, re-locked) and an end-to-end Robolectric debounce test (glance aborts, sustained unlock confirms).
- [x] New/updated `SessionFsm.transition()` tests for the `ReMonitoring` dismiss cases (no prior dismiss → Complete, old prior dismiss → Complete, recent prior dismiss within grace → Awake).
- [x] `./gradlew :app:testDebugUnitTest` all green.
- [x] `./gradlew :app:assembleDebug :app:lintDebug :app:checkFileLength` all green, zero lint errors.
- [ ] On-device overnight validation (pending — this branches independently so it can be reviewed/reverted without affecting the timeline-visual PR stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)