### PR TITLE
fix(home): three stuck/overflow/instant-snap animation bugs

### DIFF
--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/HomeContent.kt
@@ -120,9 +120,7 @@ internal fun HomePlanContent(
             } else {
                 ((collapseSafeTopPx - greetingTop).coerceAtLeast(0).toFloat() / collapseFadePx).coerceIn(0f, 1f)
             }
-            if (screenTop == null) {
-                AlarmCollapse(top = collapseSafeTopPx, gradientAlpha = gradientAlpha, fraction = 1f, distancePx = collapseRangePx)
-            } else {
+            if (screenTop != null) {
                 val distance = (collapseSafeTopPx - screenTop).coerceAtLeast(0).toFloat()
                 AlarmCollapse(
                     top = maxOf(collapseSafeTopPx, screenTop),
@@ -130,6 +128,14 @@ internal fun HomePlanContent(
                     fraction = (distance / collapseRangePx).coerceIn(0f, 1f),
                     distancePx = distance,
                 )
+            } else if (listState.firstVisibleItemIndex <= 1) {
+                // "alarm-spacer" is always index 1 (right after "greeting" at 0) — if we haven't
+                // scrolled past it yet, a missing visibleItemsInfo entry is a stale/transient read,
+                // not a genuine scroll-past. Forcing collapsed here was the discontinuity that got
+                // this state stuck (it also corrupts AlarmCollapseEffects' scrollingDown tracker).
+                AlarmCollapse(top = collapseSafeTopPx, gradientAlpha = gradientAlpha, fraction = 0f, distancePx = 0f)
+            } else {
+                AlarmCollapse(top = collapseSafeTopPx, gradientAlpha = gradientAlpha, fraction = 1f, distancePx = collapseRangePx)
             }
         }
     }

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/PlanDetailScreen.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/PlanDetailScreen.kt
@@ -92,14 +92,20 @@ fun PlanDetailScreen(
                     thread = iteration.thread,
                     expanded = pullState.expanded,
                     onExpandedChange = { next ->
-                        pullState.expanded = next
-                        scope.launch {
-                            if (next) {
+                        // Expand must animate reveal to full BEFORE flipping `expanded`, mirroring
+                        // onPreFling below — ExpandReveal's targetPx clips straight to the full
+                        // measured height once `expanded` is true, bypassing this Animatable entirely,
+                        // so flipping it synchronously here made expand-by-tap snap instantly instead
+                        // of animating. Collapse has no such bypass, so it can flip first as before.
+                        if (next) {
+                            scope.launch {
                                 val full = pullState.fullPx.intValue
                                 if (full > 0) pullState.reveal.animateTo(full.toFloat())
-                            } else {
-                                pullState.reveal.animateTo(0f)
+                                pullState.expanded = true
                             }
+                        } else {
+                            pullState.expanded = false
+                            scope.launch { pullState.reveal.animateTo(0f) }
                         }
                     },
                     expandPx = { pullState.reveal.value },

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineTrackOverlay.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineTrackOverlay.kt
@@ -98,7 +98,7 @@ internal fun TimelineTrackOverlay(
                 // Read directly in the draw phase (not via derivedStateOf) so a position change redraws the same frame with no recomposition round-trip; see computePlacedAnchors.
                 if (visible) {
                     val placed = computePlacedAnchors(registry, overlayCoordinates)
-                    drawTrack(placed, awakeColor, asleepColor, awakeSpineColor, asleepSpineColor, scratch)
+                    drawTrack(placed, registry, awakeColor, asleepColor, awakeSpineColor, asleepSpineColor, scratch)
                 }
             },
     )
@@ -136,6 +136,7 @@ private fun computePlacedAnchors(
 
 private fun DrawScope.drawTrack(
     placed: List<PlacedAnchor>,
+    registry: TimelineTrackRegistry,
     awakeColor: Color,
     asleepColor: Color,
     awakeSpineColor: Color,
@@ -148,6 +149,13 @@ private fun DrawScope.drawTrack(
     // Every anchor centers in the same fixed-width gutter; averaging their x's is order-independent and self-corrects if one row's position lands a frame stale.
     val trackCenterX = placed.map { it.cx }.average().toFloat()
     val corner = CornerRadius(halfTrack)
+    // A descriptor claiming the segment top/bottom exists in the registry (SideEffect-written,
+    // pre-layout) but hasn't produced a placed anchor yet (position registers post-layout, one
+    // frame later for a brand-new row) — see drawSegment's KDoc for why this, and not the placed
+    // list alone, is what distinguishes "new top row not yet positioned" from "true top row
+    // disposed by ordinary scrolling" (registry.remove clears both maps together on disposal).
+    val topUnplaced = registry.descriptors.values.any { it.isSegmentTop } && placed.none { it.descriptor.isSegmentTop }
+    val bottomUnplaced = registry.descriptors.values.any { it.isSegmentBottom } && placed.none { it.descriptor.isSegmentBottom }
 
     drawSegment(
         anchors = placed.sortedBy { it.cy },
@@ -159,6 +167,8 @@ private fun DrawScope.drawTrack(
         awakeSpineColor = awakeSpineColor,
         asleepSpineColor = asleepSpineColor,
         scratch = scratch,
+        topUnplaced = topUnplaced,
+        bottomUnplaced = bottomUnplaced,
     )
 }
 
@@ -167,10 +177,14 @@ private fun DrawScope.drawTrack(
  *
  *  Driven by `descriptor.isSegmentTop`/`isSegmentBottom`, computed fresh from `uiState.timeline` on
  *  every recomposition (`SessionTimeline.kt`'s `firstAnchorIndex`/`lastAnchorIndex`), so it never
- *  races with scrolling — scrolling doesn't change `uiState.timeline` at all. A narrow case (a stale
- *  reading right after a new anchor is prepended and hasn't registered yet, flushing the track to the
- *  screen edge under the alarm card) is real but rare and not yet addressed; see docs/color-roles.md
- *  for prior attempts and why they made things worse. */
+ *  races with scrolling — scrolling doesn't change `uiState.timeline` at all. [topUnplaced]/
+ *  [bottomUnplaced] (from `drawTrack`) additionally catch the case where a new anchor is prepended
+ *  and its descriptor has registered `isSegmentTop`/`isSegmentBottom` but its position hasn't yet —
+ *  without that, the track would flush to the screen edge under the alarm card for one frame. See
+ *  docs/color-roles.md Round 35/36 for why a plain `anchors`-only fallback (`anchors.none {
+ *  isSegmentTop }`) was rejected: it can't distinguish that transient case from the true top/bottom
+ *  anchor being disposed by ordinary scrolling, which reintroduces the flicker a prior
+ *  `visibleItemsInfo`-based attempt was reverted for. */
 private fun DrawScope.drawSegment(
     anchors: List<PlacedAnchor>,
     trackCenterX: Float,
@@ -181,11 +195,13 @@ private fun DrawScope.drawSegment(
     awakeSpineColor: Color,
     asleepSpineColor: Color,
     scratch: android.graphics.Path,
+    topUnplaced: Boolean,
+    bottomUnplaced: Boolean,
 ) {
     val top = anchors.first()
     val bottom = anchors.last()
-    val roundTop = top.descriptor.isSegmentTop
-    val roundBottom = bottom.descriptor.isSegmentBottom
+    val roundTop = top.descriptor.isSegmentTop || topUnplaced
+    val roundBottom = bottom.descriptor.isSegmentBottom || bottomUnplaced
     // Cap edge sits a full halfTrack beyond the terminal anchor's center (not at it) so the anchor nests concentrically inside the cap's rounded corner.
     val bgTop = if (roundTop) top.cy - halfTrack else 0f
     val bgBottom = if (roundBottom) bottom.cy + halfTrack else size.height

--- a/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineTrackOverlay.kt
+++ b/app/src/main/java/fr/bsodium/cron/ui/screens/home/components/TimelineTrackOverlay.kt
@@ -89,6 +89,7 @@ internal fun TimelineTrackOverlay(
     val asleepSpineColor = lerp(asleepColor, MaterialTheme.colorScheme.onSecondary, ASLEEP_SPINE_BLEND)
     val scratch = remember { android.graphics.Path() }
     var overlayCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    val endState = remember { TrackEndState() }
 
     Box(
         modifier = modifier
@@ -98,13 +99,22 @@ internal fun TimelineTrackOverlay(
                 // Read directly in the draw phase (not via derivedStateOf) so a position change redraws the same frame with no recomposition round-trip; see computePlacedAnchors.
                 if (visible) {
                     val placed = computePlacedAnchors(registry, overlayCoordinates)
-                    drawTrack(placed, registry, awakeColor, asleepColor, awakeSpineColor, asleepSpineColor, scratch)
+                    drawTrack(placed, endState, awakeColor, asleepColor, awakeSpineColor, asleepSpineColor, scratch)
                 }
             },
     )
 }
 
 private class PlacedAnchor(val id: String, val descriptor: AnchorDescriptor, val cx: Float, val cy: Float)
+
+/** Remembers which anchor id last legitimately confirmed the segment's top/bottom cap — a plain
+ *  draw-phase-mutated field, not snapshot state, since it only needs to survive across this
+ *  composable's own draw calls, never trigger recomposition. See [drawTrack]'s KDoc for why this
+ *  replaces a same-frame registry lookup. */
+private class TrackEndState {
+    var lastTopId: String? = null
+    var lastBottomId: String? = null
+}
 
 private class SleepPill(val top: Float, val bottom: Float, val roundTop: Boolean, val roundBottom: Boolean)
 
@@ -136,7 +146,7 @@ private fun computePlacedAnchors(
 
 private fun DrawScope.drawTrack(
     placed: List<PlacedAnchor>,
-    registry: TimelineTrackRegistry,
+    endState: TrackEndState,
     awakeColor: Color,
     asleepColor: Color,
     awakeSpineColor: Color,
@@ -149,13 +159,11 @@ private fun DrawScope.drawTrack(
     // Every anchor centers in the same fixed-width gutter; averaging their x's is order-independent and self-corrects if one row's position lands a frame stale.
     val trackCenterX = placed.map { it.cx }.average().toFloat()
     val corner = CornerRadius(halfTrack)
-    // A descriptor claiming the segment top/bottom exists in the registry (SideEffect-written,
-    // pre-layout) but hasn't produced a placed anchor yet (position registers post-layout, one
-    // frame later for a brand-new row) — see drawSegment's KDoc for why this, and not the placed
-    // list alone, is what distinguishes "new top row not yet positioned" from "true top row
-    // disposed by ordinary scrolling" (registry.remove clears both maps together on disposal).
-    val topUnplaced = registry.descriptors.values.any { it.isSegmentTop } && placed.none { it.descriptor.isSegmentTop }
-    val bottomUnplaced = registry.descriptors.values.any { it.isSegmentBottom } && placed.none { it.descriptor.isSegmentBottom }
+    // A fresh claim this frame (an anchor that's both placed AND whose descriptor says
+    // isSegmentTop/isSegmentBottom) updates the remembered id; see drawSegment's KDoc for why an
+    // absent claim falls back to the last confirmed id instead of ever flushing to the edge.
+    placed.firstOrNull { it.descriptor.isSegmentTop }?.let { endState.lastTopId = it.id }
+    placed.firstOrNull { it.descriptor.isSegmentBottom }?.let { endState.lastBottomId = it.id }
 
     drawSegment(
         anchors = placed.sortedBy { it.cy },
@@ -167,24 +175,30 @@ private fun DrawScope.drawTrack(
         awakeSpineColor = awakeSpineColor,
         asleepSpineColor = asleepSpineColor,
         scratch = scratch,
-        topUnplaced = topUnplaced,
-        bottomUnplaced = bottomUnplaced,
+        topId = endState.lastTopId,
+        bottomId = endState.lastBottomId,
     )
 }
 
 /** [roundTop]/[roundBottom] — a cap only rounds when the segment's true end is confirmed on-screen;
  *  otherwise the track runs flush to the viewport edge, implying it continues off-screen.
  *
- *  Driven by `descriptor.isSegmentTop`/`isSegmentBottom`, computed fresh from `uiState.timeline` on
- *  every recomposition (`SessionTimeline.kt`'s `firstAnchorIndex`/`lastAnchorIndex`), so it never
- *  races with scrolling — scrolling doesn't change `uiState.timeline` at all. [topUnplaced]/
- *  [bottomUnplaced] (from `drawTrack`) additionally catch the case where a new anchor is prepended
- *  and its descriptor has registered `isSegmentTop`/`isSegmentBottom` but its position hasn't yet —
- *  without that, the track would flush to the screen edge under the alarm card for one frame. See
- *  docs/color-roles.md Round 35/36 for why a plain `anchors`-only fallback (`anchors.none {
- *  isSegmentTop }`) was rejected: it can't distinguish that transient case from the true top/bottom
- *  anchor being disposed by ordinary scrolling, which reintroduces the flicker a prior
- *  `visibleItemsInfo`-based attempt was reverted for. */
+ *  [topId]/[bottomId] are [TrackEndState]'s remembered anchor ids, not a same-frame
+ *  `descriptor.isSegmentTop`/`isSegmentBottom` read: a brand-new anchor's descriptor (written by its
+ *  own `SideEffect`, pre-layout) and its position (written by `onGloballyPositioned`, post-layout)
+ *  can BOTH still be missing for more than one frame after it's prepended — confirmed live (see
+ *  docs/color-roles.md Round 37) by logging the registry at the exact frame the track flushed to the
+ *  screen edge: neither the outgoing nor incoming anchor's descriptor claimed `isSegmentTop` yet, so
+ *  a same-frame registry lookup (Round 36's `anchors.none { isSegmentTop }` fallback) has nothing to
+ *  fall back to either. Persisting the last anchor that was *both* placed and descriptor-confirmed
+ *  sidesteps the exact inter-callback timing entirely: the outgoing anchor keeps its rounded cap
+ *  (it's still the topmost *placed* anchor, so `top.id == topId` still holds) until the incoming one
+ *  is fully confirmed, at which point `drawTrack` updates [TrackEndState] and the cap hands off
+ *  cleanly. A row genuinely disposed by ordinary scrolling clears the id naturally: once it's gone
+ *  from `placed`, `top.id == topId` stops matching (`topId` still names the disposed id, but nothing
+ *  in `anchors` does), so the track correctly resumes flushing to the edge instead of a stale claim.
+ *  See docs/color-roles.md Round 35/36 for why an `anchors`-only, same-frame fallback was tried
+ *  twice and rejected both times. */
 private fun DrawScope.drawSegment(
     anchors: List<PlacedAnchor>,
     trackCenterX: Float,
@@ -195,13 +209,13 @@ private fun DrawScope.drawSegment(
     awakeSpineColor: Color,
     asleepSpineColor: Color,
     scratch: android.graphics.Path,
-    topUnplaced: Boolean,
-    bottomUnplaced: Boolean,
+    topId: String?,
+    bottomId: String?,
 ) {
     val top = anchors.first()
     val bottom = anchors.last()
-    val roundTop = top.descriptor.isSegmentTop || topUnplaced
-    val roundBottom = bottom.descriptor.isSegmentBottom || bottomUnplaced
+    val roundTop = top.id == topId
+    val roundBottom = bottom.id == bottomId
     // Cap edge sits a full halfTrack beyond the terminal anchor's center (not at it) so the anchor nests concentrically inside the cap's rounded corner.
     val bgTop = if (roundTop) top.cy - halfTrack else 0f
     val bgBottom = if (roundBottom) bottom.cy + halfTrack else size.height

--- a/docs/color-roles.md
+++ b/docs/color-roles.md
@@ -1068,3 +1068,25 @@ tweaks, plus two follow-up refinements once the fixes were tested more broadly.
   the test clock past the settle gate an earlier round introduced — all of `TimelineNodeScreenshotTest`'s
   cases plus `PillPressMorphScreenshotTest`, confirmed by tracing every `captureRoboImage()` call site
   in the touched test files, not just the handful first noticed.
+
+Round 36 — addresses Round 35's "track flush-to-screen-edge flash on a new arrival," left open there.
+
+- **A first attempt — `roundTop = top.descriptor.isSegmentTop || anchors.none { it.descriptor
+  .isSegmentTop }` — was tried and rejected.** `registry.remove(id)` clears both `descriptors` and
+  `positions` together on disposal, including ordinary scroll-driven disposal (the same "row disposes
+  while still visually on-screen" behavior Round 35's ghost-caching attempt above already found). So
+  once the *true* top row is disposed by plain scrolling, no placed anchor has `isSegmentTop == true`
+  either — the exact same observable signal as "the new top row registered a descriptor but not yet a
+  position." An `anchors`-only check can't tell these apart, and rounds the current top cap on every
+  ordinary scroll past the original first row — reintroducing the same class of flicker the
+  `visibleItemsInfo` cross-check was reverted for in Round 35, just reached through registry state
+  instead of layout state.
+- **Fix: disambiguate using `registry.descriptors` directly**, which still distinguishes the two cases
+  — a descriptor claiming `isSegmentTop`/`isSegmentBottom` exists somewhere in the registry (new row,
+  descriptor written but position not yet registered) vs. no descriptor anywhere claims it (true top/
+  bottom genuinely disposed by scrolling, both maps cleared together). `drawTrack` now computes
+  `topUnplaced = registry.descriptors.values.any { it.isSegmentTop } && placed.none { it.descriptor
+  .isSegmentTop }` (and the bottom equivalent), passed into `drawSegment` as `roundTop = top.descriptor
+  .isSegmentTop || topUnplaced`. Still purely data-derived (registry descriptor state, not scroll/
+  layoutInfo) — self-corrects the next frame once the new anchor's position registers, and is `false`
+  in the ordinary-disposal case since no descriptor anywhere claims the flag anymore.

--- a/docs/color-roles.md
+++ b/docs/color-roles.md
@@ -1090,3 +1090,44 @@ Round 36 — addresses Round 35's "track flush-to-screen-edge flash on a new arr
   .isSegmentTop || topUnplaced`. Still purely data-derived (registry descriptor state, not scroll/
   layoutInfo) — self-corrects the next frame once the new anchor's position registers, and is `false`
   in the ordinary-disposal case since no descriptor anywhere claims the flag anymore.
+- **Not re-verified live as of this writing** (no device available this round) — build and the
+  existing screenshot suite pass, but per this file's own standing note, that's not a substitute for
+  a real new-arrival check on-device. See Round 37: a live pass found this fix insufficient.
+
+Round 37 — a live-device pass (screen-recorded at high frame rate, frame-by-frame inspection) found
+Round 36's fix did not actually stop the flush-to-screen-edge flash; this identifies why and corrects
+it.
+
+- **The flush was still fully reproducible**, captured as a light vertical stripe (the awake spine,
+  `AWAKE_SPINE_BLEND`-tinted and thus visible against the near-black background even though the wider
+  background fill itself — plain `surfaceContainerHigh` — blends in too closely to notice) running
+  from the true anchor position all the way up behind the status bar for one or two frames right at
+  the moment a new run's streaming placeholder is inserted (triggering at tap time, not at turn
+  completion — the streaming placeholder is itself the new `AiRun` row).
+- **Root cause: Round 36's assumption that the new anchor's descriptor (`SideEffect`, pre-layout)
+  always lands no later than its position (`onGloballyPositioned`, post-layout) — i.e. that they're
+  at most one frame apart — is false.** Temporary `Log.d` instrumentation in `drawTrack`/`drawSegment`,
+  read live off the device right at the flush, showed `registry.descriptors.values.any { isSegmentTop
+  }` was **also** false at the exact frame the track flushed — meaning neither the outgoing row's
+  descriptor (already flipped to `isSegmentTop = false`) nor the incoming row's (not yet written at
+  all) claimed the flag. Round 36's `topUnplaced` fallback reads `registry.descriptors` in the same
+  draw call as everything else, so when the incoming row's `SideEffect` genuinely hasn't fired yet —
+  not just its position — there's nothing in the registry for that fallback to find either.
+- **Fix: stop depending on same-frame inter-callback ordering entirely.** `TimelineTrackOverlay` now
+  holds a small `remember`-scoped `TrackEndState` (a plain draw-phase-mutated field, not snapshot
+  state — it only needs to survive across this composable's own draw calls) recording the last anchor
+  id that was genuinely confirmed (both placed **and** descriptor-claiming) as the segment's top and
+  bottom. `drawTrack` updates it only when a fresh claim exists this frame; `drawSegment`'s
+  `roundTop`/`roundBottom` become `top.id == topId`/`bottom.id == bottomId` against that remembered
+  id instead of any same-frame descriptor read. The outgoing row keeps the rounded cap — it's still
+  the topmost *placed* anchor, so the id still matches — for however many frames the incoming row's
+  descriptor and position take to land, however long that turns out to be; once the incoming row is
+  fully confirmed, `drawTrack` updates the remembered id and the cap hands off with no discontinuity.
+  A row disposed by ordinary scrolling still degrades correctly: once its id is no longer in `placed`,
+  the remembered id (still naming the disposed row) stops matching anything, so the track resumes
+  flushing to the edge exactly as before — same non-regression as Round 36's `registry`-based
+  disambiguation, without depending on how fast a new row's callbacks fire.
+- **Verified live**: re-recorded the same tap-triggered new-run-insertion transition at high frame
+  rate across three separate triggers after this fix, frame-by-frame inspected the entire transition
+  burst each time (the same window that showed the stripe unambiguously before the fix) — no
+  recurrence in any of them.


### PR DESCRIPTION
## Summary

Three independent Home/Plan Detail bugs, each root-caused by reading the relevant source directly:

- **Alarm card collapse gets permanently stuck** (expanded or collapsed), unrecoverable by scrolling. `HomeContent.kt`'s `collapseState` hardcoded `fraction = 1f` whenever the `"alarm-spacer"` item missed the `visibleItemsInfo` lookup — including on cold start and rare transient reads, not just genuine scroll-past. That discontinuity corrupted `AlarmCollapseEffects`' `scrollingDown` tracker, which could fire an unwanted `animateScrollToItem(0)` on release regardless of actual scroll direction. Fixed by cross-checking `listState.firstVisibleItemIndex` (independent of the key-search that can miss) before falling back to collapsed. **Status: not yet independently re-observed live — flagged in-app for continued watching.**

- **Timeline track flushes to the top of the screen for a frame** when a new run is added. `TimelineTrackRegistry` keeps `descriptors` (written via `SideEffect`, pre-layout) and `positions` (written via `onGloballyPositioned`, post-layout) as independently-timed maps; a newly-prepended row's descriptor claims `isSegmentTop` before its position registers, so for one frame no *placed* anchor claims it and the track flushes to the screen edge. This is a previously "fixed" bug (`docs/color-roles.md` Round 35) that resurfaced. A first fix attempt (Round 36, disambiguating via `registry.descriptors`) assumed the new row's descriptor lands no more than one frame after its position — **live testing on-device disproved this**: temporary logging showed neither the outgoing nor incoming row's descriptor claimed `isSegmentTop` at the exact flush frame. The shipped fix (Round 37) drops the same-frame assumption entirely: it persists the last anchor id genuinely confirmed as top/bottom across draw calls, updating only on a fresh confirmation, so the outgoing row keeps its cap for however long the incoming row's callbacks take. **Verified live across three separate re-plan triggers on a physical device (screen-recorded, frame-by-frame inspected) — no recurrence, versus the first fix attempt which still clearly reproduced the overflow on the same repro.**

- **Thinking-header block in Plan Detail expands instantly** (no animation) on tap, while collapse and drag both animate correctly. `onExpandedChange` set `pullState.expanded = true` synchronously before the reveal animation ran; `ExpandReveal` clips straight to the full measured height once `expanded` is true, bypassing the animating `Animatable` entirely. Fixed by mirroring the already-correct `onPreFling` ordering (animate first, then flip `expanded`). **Confirmed fixed by user testing.**

## Test plan

- [x] `./gradlew :app:assembleDebug` passes after each commit
- [x] `./gradlew :app:lintDebug` — no new issues in touched files
- [x] `./gradlew :app:testDebugUnitTest` — 299 tests, 0 failures
- [x] Existing Roborazzi suites re-recorded with no diffs (`HomeContentScreenshotTest`, `PlanDetailScreenScreenshotTest`, `SessionTimelineScreenshotTest`, `NextAlarmCardScreenshotTest`, `TimelineNodeScreenshotTest`, `PillPressMorphScreenshotTest`, `TimelineGalleryScreenshotTest`)
- [x] Timeline overflow fix verified live on a physical Pixel 7 (screen-recorded at high frame rate across 3 separate triggers, frame-by-frame inspected the transition window that clearly showed the bug before the fix)
- [x] Thinking-header fix confirmed by user
- [ ] Alarm-card collapse fix — awaiting further observation (intermittent, hard to force on demand)
- [ ] Follow-up: add scroll-simulation Roborazzi cases exercising the mid-transition frames these bugs live in (static captures don't reach them) — noted but not added here to keep this PR scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)