### PR TITLE
feat(dev-settings): show AI tool availability and why

### DIFF
--- a/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/AiToolAvailabilitySection.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/AiToolAvailabilitySection.kt
@@ -1,0 +1,48 @@
+package fr.bsodium.cron.ui.screens.settings.categories
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import fr.bsodium.cron.ai.tools.aiToolAvailability
+import fr.bsodium.cron.ui.theme.Spacing
+
+/**
+ * DEBUG-ONLY. Lists every AI tool `AiTurnWorker.buildToolRegistry` can register and whether it's
+ * currently available — e.g. the location tools (geocode/commute) are silently skipped rather than
+ * erroring when `GOOGLE_ROUTES_API_KEY` isn't configured, which otherwise reads as the model simply
+ * never calling them for no visible reason.
+ */
+@Composable
+internal fun AiToolAvailabilitySection() {
+    Column {
+        Text(
+            text = "AI tools",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Text(
+            text = "What the model can call this turn, and why not if it can't",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        for (status in aiToolAvailability()) {
+            Column(modifier = Modifier.padding(top = Spacing.sm)) {
+                Text(
+                    text = if (status.available) "${status.name} — available" else "${status.name} — unavailable",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (status.available) MaterialTheme.colorScheme.onBackground else MaterialTheme.colorScheme.error,
+                )
+                status.reason?.let { reason ->
+                    Text(
+                        text = reason,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
+++ b/app/src/debug/java/fr/bsodium/cron/ui/screens/settings/categories/DeveloperSettingsScreen.kt
@@ -99,6 +99,7 @@ fun DeveloperSettingsScreen(onBack: () -> Unit) {
         }
         FsmEventInjector(context, scope)
         WorkerInjector()
+        AiToolAvailabilitySection()
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/fr/bsodium/cron/ai/tools/AiToolAvailability.kt
+++ b/app/src/main/java/fr/bsodium/cron/ai/tools/AiToolAvailability.kt
@@ -1,0 +1,27 @@
+package fr.bsodium.cron.ai.tools
+
+import fr.bsodium.cron.BuildConfig
+
+/** One AI tool's registration status — read-only diagnostic info surfaced in Settings → Developer
+ *  to explain why the model can't call a given tool. Mirrors `AiTurnWorker.buildToolRegistry`'s
+ *  actual gating rather than re-deriving it independently; keep both in sync if a new conditional
+ *  tool is added there. */
+internal data class AiToolStatus(val name: String, val available: Boolean, val reason: String? = null)
+
+/** The only conditional gate today is the Google Routes API key, which suppresses the three
+ *  location tools as a group; every other tool is always registered. */
+internal fun aiToolAvailability(): List<AiToolStatus> {
+    val routesConfigured = BuildConfig.GOOGLE_ROUTES_API_KEY.isNotBlank()
+    val routesReason = "GOOGLE_ROUTES_API_KEY is blank in local.properties".takeIf { !routesConfigured }
+    return listOf(
+        AiToolStatus(ReadCalendarTool.NAME, available = true),
+        AiToolStatus(GeocodeTool.NAME, available = routesConfigured, reason = routesReason),
+        AiToolStatus(EstimateCommuteTool.NAME, available = routesConfigured, reason = routesReason),
+        AiToolStatus(EstimateCommuteMultiModeTool.NAME, available = routesConfigured, reason = routesReason),
+        AiToolStatus(SetAlarmTool.NAME, available = true),
+        AiToolStatus(DoNothingTool.NAME, available = true),
+        AiToolStatus(CancelAlarmTool.NAME, available = true),
+        AiToolStatus(SendBriefTool.NAME, available = true),
+        AiToolStatus(NotifyWarningTool.NAME, available = true),
+    )
+}


### PR DESCRIPTION
## Summary

- `AiTurnWorker.buildToolRegistry` silently skips `GeocodeTool`, `EstimateCommuteTool`, and `EstimateCommuteMultiModeTool` when `GOOGLE_ROUTES_API_KEY` is blank in `local.properties` — no error surfaces anywhere, the model just never has those tools available. This came up while debugging something else this session and had no way to diagnose short of reading `AiTurnWorker.kt` directly.
- Adds a debug-only "AI tools" section to Settings → Developer, listing every tool the registry can register and whether it's currently available (and why not, when it isn't).
- `aiToolAvailability()` (`app/src/main/java/fr/bsodium/cron/ai/tools/AiToolAvailability.kt`) mirrors `buildToolRegistry`'s one real conditional gate today (the Routes API key), sourcing each tool's display name from its own `NAME` companion constant rather than hand-typed strings, so it can't drift from the actual wire-format name sent to the API.
- `AiToolAvailabilitySection.kt` mirrors the existing `WorkerInjector.kt` section's exact style (header + subtitle + row list), wired into `DeveloperSettingsScreen.kt` alongside it.

## Test plan

- [x] `./gradlew :app:assembleDebug` passes
- [x] `./gradlew :app:lintDebug` — no new issues
- [x] `./gradlew :app:testDebugUnitTest` — 306 tests, 0 failures
- [x] Visual verification on-device — **not done this session**, the test device disconnected before I could check it renders correctly. No existing screenshot-test coverage exists for any Settings screen in this repo to fall back on either. The code closely mirrors `WorkerInjector`'s already-shipped Text/Column pattern, but that's not the same as confirming it on screen — please eyeball Settings → Developer → "AI tools" before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)